### PR TITLE
fix: Correct PlayerProfile field name from created_date to created_at

### DIFF
--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -50,7 +50,7 @@ class PlayerService:
                 name=profile_data.name,
                 handicap=profile_data.handicap,
                 avatar_url=profile_data.avatar_url,
-                created_date=datetime.now().isoformat(),
+                created_at=datetime.now().isoformat(),
                 preferences=profile_data.preferences or {
                     "ai_difficulty": "medium",
                     "preferred_game_modes": ["wolf_goat_pig"],


### PR DESCRIPTION
Fixed field name mismatch causing player profile creation errors. PlayerProfile model expects 'created_at' field, not 'created_date'.

Resolves #49

Generated with [Claude Code](https://claude.ai/code)