### PR TITLE
feat: Add random team formation for >4 players

### DIFF
--- a/backend/app/services/team_formation_service.py
+++ b/backend/app/services/team_formation_service.py
@@ -1,0 +1,271 @@
+"""
+Random team formation service for creating balanced 4-player groups from daily signups.
+Handles scenarios where more than 4 players are signed up for a given day.
+"""
+
+from typing import List, Dict, Optional, Tuple
+import random
+import logging
+from datetime import datetime
+from itertools import combinations
+
+logger = logging.getLogger(__name__)
+
+class TeamFormationService:
+    """Service for creating random team formations from daily signups."""
+    
+    @staticmethod
+    def generate_random_teams(
+        players: List[Dict], 
+        seed: Optional[int] = None,
+        max_teams: Optional[int] = None
+    ) -> List[Dict]:
+        """
+        Generate random 4-player teams from a list of signed-up players.
+        
+        Args:
+            players: List of player dictionaries with player info
+            seed: Optional random seed for reproducible results
+            max_teams: Maximum number of teams to create (default: all possible)
+            
+        Returns:
+            List of team dictionaries with 4 players each
+        """
+        if len(players) < 4:
+            logger.warning(f"Not enough players for team formation: {len(players)} < 4")
+            return []
+        
+        # Set random seed if provided for reproducible results
+        if seed is not None:
+            random.seed(seed)
+        
+        # Create a copy to avoid modifying original list
+        available_players = players.copy()
+        random.shuffle(available_players)
+        
+        teams = []
+        team_number = 1
+        
+        # Create teams of 4 players
+        while len(available_players) >= 4:
+            team_players = available_players[:4]
+            available_players = available_players[4:]
+            
+            team = {
+                "team_id": team_number,
+                "players": team_players,
+                "created_at": datetime.now().isoformat(),
+                "formation_method": "random"
+            }
+            teams.append(team)
+            team_number += 1
+            
+            # Check if we've reached max teams limit
+            if max_teams and len(teams) >= max_teams:
+                break
+        
+        # Log remaining players who couldn't form a complete team
+        if available_players:
+            logger.info(f"Remaining players not assigned to teams: {len(available_players)}")
+        
+        return teams
+    
+    @staticmethod
+    def create_team_pairings_with_rotations(
+        players: List[Dict],
+        num_rotations: int = 3,
+        seed: Optional[int] = None
+    ) -> List[Dict]:
+        """
+        Create multiple team pairing rotations for variety throughout the day.
+        
+        Args:
+            players: List of player dictionaries
+            num_rotations: Number of different team rotations to create
+            seed: Optional random seed for reproducible results
+            
+        Returns:
+            List of rotation dictionaries, each containing teams for that rotation
+        """
+        if len(players) < 4:
+            return []
+        
+        rotations = []
+        
+        for rotation in range(num_rotations):
+            # Use different seed for each rotation to ensure variety
+            rotation_seed = (seed + rotation) if seed is not None else None
+            
+            teams = TeamFormationService.generate_random_teams(
+                players, 
+                seed=rotation_seed,
+                max_teams=None
+            )
+            
+            if teams:
+                rotations.append({
+                    "rotation_number": rotation + 1,
+                    "teams": teams,
+                    "created_at": datetime.now().isoformat(),
+                    "total_teams": len(teams),
+                    "total_players_assigned": len(teams) * 4
+                })
+        
+        return rotations
+    
+    @staticmethod
+    def generate_balanced_teams(
+        players: List[Dict],
+        skill_key: str = "handicap",
+        seed: Optional[int] = None
+    ) -> List[Dict]:
+        """
+        Generate teams with balanced skill levels using handicap or skill ratings.
+        
+        Args:
+            players: List of player dictionaries
+            skill_key: Key to use for skill-based balancing (e.g., 'handicap')
+            seed: Optional random seed
+            
+        Returns:
+            List of balanced team dictionaries
+        """
+        if len(players) < 4:
+            return []
+        
+        # Set random seed if provided
+        if seed is not None:
+            random.seed(seed)
+        
+        # Sort players by skill level (lower handicap = better player)
+        players_with_skill = []
+        players_without_skill = []
+        
+        for player in players:
+            if skill_key in player and player[skill_key] is not None:
+                players_with_skill.append(player)
+            else:
+                # Assign default handicap for balancing
+                player_copy = player.copy()
+                player_copy[skill_key] = 18.0  # Default handicap
+                players_without_skill.append(player_copy)
+        
+        # Combine lists and sort by skill
+        all_players = players_with_skill + players_without_skill
+        all_players.sort(key=lambda p: p.get(skill_key, 18.0))
+        
+        teams = []
+        team_number = 1
+        
+        # Snake draft approach for balanced teams
+        while len(all_players) >= 4:
+            # Take players from different skill levels
+            if len(all_players) >= 8:
+                # Take best, worst, middle-low, middle-high
+                team_players = [
+                    all_players.pop(0),      # Best player
+                    all_players.pop(-1),     # Worst player  
+                    all_players.pop(len(all_players)//2),  # Middle player
+                    all_players.pop(len(all_players)//2)   # Another middle player
+                ]
+            else:
+                # Just take first 4 remaining players
+                team_players = all_players[:4]
+                all_players = all_players[4:]
+            
+            # Calculate team average handicap
+            team_avg_handicap = sum(p.get(skill_key, 18.0) for p in team_players) / 4
+            
+            team = {
+                "team_id": team_number,
+                "players": team_players,
+                "average_handicap": round(team_avg_handicap, 1),
+                "created_at": datetime.now().isoformat(),
+                "formation_method": "balanced"
+            }
+            teams.append(team)
+            team_number += 1
+        
+        return teams
+    
+    @staticmethod
+    def create_team_summary(teams: List[Dict]) -> Dict:
+        """
+        Create a summary of the team formation results.
+        
+        Args:
+            teams: List of team dictionaries
+            
+        Returns:
+            Summary dictionary with statistics
+        """
+        if not teams:
+            return {
+                "total_teams": 0,
+                "total_players_assigned": 0,
+                "formation_method": None,
+                "created_at": datetime.now().isoformat()
+            }
+        
+        total_players = sum(len(team["players"]) for team in teams)
+        formation_method = teams[0].get("formation_method", "unknown")
+        
+        summary = {
+            "total_teams": len(teams),
+            "total_players_assigned": total_players,
+            "formation_method": formation_method,
+            "created_at": datetime.now().isoformat(),
+            "teams": teams
+        }
+        
+        # Add average handicap info if available
+        if formation_method == "balanced":
+            handicaps = [team.get("average_handicap") for team in teams if team.get("average_handicap")]
+            if handicaps:
+                summary["average_team_handicap"] = round(sum(handicaps) / len(handicaps), 1)
+                summary["handicap_range"] = {
+                    "min": min(handicaps),
+                    "max": max(handicaps)
+                }
+        
+        return summary
+    
+    @staticmethod
+    def validate_team_formation(teams: List[Dict]) -> Dict:
+        """
+        Validate that team formation results are correct.
+        
+        Args:
+            teams: List of team dictionaries
+            
+        Returns:
+            Validation result dictionary
+        """
+        validation = {
+            "is_valid": True,
+            "errors": [],
+            "warnings": []
+        }
+        
+        # Check each team has exactly 4 players
+        for i, team in enumerate(teams):
+            if len(team["players"]) != 4:
+                validation["is_valid"] = False
+                validation["errors"].append(f"Team {i+1} has {len(team['players'])} players, expected 4")
+        
+        # Check for duplicate players across teams
+        all_player_ids = []
+        for team in teams:
+            for player in team["players"]:
+                player_id = player.get("id") or player.get("player_profile_id")
+                if player_id in all_player_ids:
+                    validation["is_valid"] = False
+                    validation["errors"].append(f"Player ID {player_id} appears in multiple teams")
+                all_player_ids.append(player_id)
+        
+        # Check team formation timestamp consistency
+        creation_times = [team.get("created_at") for team in teams if team.get("created_at")]
+        if len(set(creation_times)) > 1:
+            validation["warnings"].append("Teams have different creation timestamps")
+        
+        return validation

--- a/frontend/src/components/signup/DailySignupView.js
+++ b/frontend/src/components/signup/DailySignupView.js
@@ -14,6 +14,9 @@ const DailySignupView = ({ selectedDate, onBack }) => {
   const [error, setError] = useState(null);
   const [newMessage, setNewMessage] = useState('');
   const [teeTimesText, setTeeTimesText] = useState('');
+  const [teams, setTeams] = useState([]);
+  const [teamFormationLoading, setTeamFormationLoading] = useState(false);
+  const [showTeamFormation, setShowTeamFormation] = useState(false);
 
   // Format date for display
   const formatDateDisplay = (dateStr) => {
@@ -144,6 +147,72 @@ const DailySignupView = ({ selectedDate, onBack }) => {
     } catch (err) {
       console.error('Message error:', err);
       setError('Failed to post message');
+    }
+  };
+
+  // Handle generating random teams
+  const handleGenerateRandomTeams = async () => {
+    if (signupData.players.length < 4) {
+      setError('Need at least 4 players to generate teams');
+      return;
+    }
+
+    try {
+      setTeamFormationLoading(true);
+      const response = await fetch(`${API_URL}/signups/${selectedDate}/team-formation/random`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        setTeams(result.teams);
+        setShowTeamFormation(true);
+        setError(null);
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || 'Failed to generate teams');
+      }
+    } catch (err) {
+      console.error('Team formation error:', err);
+      setError(`Failed to generate teams: ${err.message}`);
+    } finally {
+      setTeamFormationLoading(false);
+    }
+  };
+
+  // Handle generating balanced teams
+  const handleGenerateBalancedTeams = async () => {
+    if (signupData.players.length < 4) {
+      setError('Need at least 4 players to generate teams');
+      return;
+    }
+
+    try {
+      setTeamFormationLoading(true);
+      const response = await fetch(`${API_URL}/signups/${selectedDate}/team-formation/balanced`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        setTeams(result.teams);
+        setShowTeamFormation(true);
+        setError(null);
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || 'Failed to generate balanced teams');
+      }
+    } catch (err) {
+      console.error('Balanced team formation error:', err);
+      setError(`Failed to generate balanced teams: ${err.message}`);
+    } finally {
+      setTeamFormationLoading(false);
     }
   };
 
@@ -607,6 +676,195 @@ const DailySignupView = ({ selectedDate, onBack }) => {
           </div>
         </div>
       </div>
+
+      {/* Team Formation Section */}
+      {signupData.players.length >= 4 && (
+        <div style={{
+          background: '#fff',
+          borderRadius: '8px',
+          marginTop: '20px',
+          border: '2px solid #dee2e6',
+          overflow: 'hidden'
+        }}>
+          <div style={{
+            background: '#007bff',
+            color: 'white',
+            padding: '15px',
+            textAlign: 'center',
+            fontWeight: 'bold',
+            fontSize: '18px'
+          }}>
+            ⚡ Team Formation Available ({signupData.players.length} players)
+          </div>
+          
+          <div style={{ padding: '20px' }}>
+            <div style={{
+              marginBottom: '15px',
+              textAlign: 'center',
+              color: '#495057'
+            }}>
+              With {signupData.players.length} players signed up, you can form {Math.floor(signupData.players.length / 4)} complete team(s) of 4 players each.
+              {signupData.players.length % 4 > 0 && (
+                <span style={{ color: '#856404' }}>
+                  {' '}({signupData.players.length % 4} player{signupData.players.length % 4 > 1 ? 's' : ''} will be alternates)
+                </span>
+              )}
+            </div>
+            
+            <div style={{
+              display: 'flex',
+              gap: '15px',
+              justifyContent: 'center',
+              marginBottom: '20px',
+              flexWrap: 'wrap'
+            }}>
+              <button
+                onClick={handleGenerateRandomTeams}
+                disabled={teamFormationLoading}
+                style={{
+                  padding: '10px 20px',
+                  background: teamFormationLoading ? '#6c757d' : '#28a745',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  fontSize: '14px',
+                  fontWeight: 'bold',
+                  cursor: teamFormationLoading ? 'not-allowed' : 'pointer',
+                  minWidth: '150px'
+                }}
+              >
+                {teamFormationLoading ? 'Generating...' : '🎲 Random Teams'}
+              </button>
+              
+              <button
+                onClick={handleGenerateBalancedTeams}
+                disabled={teamFormationLoading}
+                style={{
+                  padding: '10px 20px',
+                  background: teamFormationLoading ? '#6c757d' : '#ffc107',
+                  color: teamFormationLoading ? 'white' : '#000',
+                  border: 'none',
+                  borderRadius: '6px',
+                  fontSize: '14px',
+                  fontWeight: 'bold',
+                  cursor: teamFormationLoading ? 'not-allowed' : 'pointer',
+                  minWidth: '150px'
+                }}
+              >
+                {teamFormationLoading ? 'Generating...' : '⚖️ Balanced Teams'}
+              </button>
+              
+              {showTeamFormation && teams.length > 0 && (
+                <button
+                  onClick={() => setShowTeamFormation(false)}
+                  style={{
+                    padding: '10px 20px',
+                    background: '#dc3545',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '6px',
+                    fontSize: '14px',
+                    fontWeight: 'bold',
+                    cursor: 'pointer',
+                    minWidth: '150px'
+                  }}
+                >
+                  ❌ Hide Teams
+                </button>
+              )}
+            </div>
+            
+            {showTeamFormation && teams.length > 0 && (
+              <div style={{
+                background: '#f8f9fa',
+                borderRadius: '6px',
+                padding: '15px',
+                border: '1px solid #dee2e6'
+              }}>
+                <h4 style={{
+                  margin: '0 0 15px 0',
+                  color: '#495057',
+                  textAlign: 'center'
+                }}>
+                  Generated Teams ({teams.length} team{teams.length > 1 ? 's' : ''})
+                </h4>
+                
+                <div style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+                  gap: '15px'
+                }}>
+                  {teams.map((team, teamIndex) => (
+                    <div key={team.team_id || teamIndex} style={{
+                      background: '#fff',
+                      borderRadius: '6px',
+                      padding: '15px',
+                      border: '2px solid #007bff',
+                      boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+                    }}>
+                      <div style={{
+                        background: '#007bff',
+                        color: 'white',
+                        padding: '8px',
+                        borderRadius: '4px',
+                        textAlign: 'center',
+                        fontWeight: 'bold',
+                        marginBottom: '10px'
+                      }}>
+                        Team {team.team_id || teamIndex + 1}
+                        {team.average_handicap && (
+                          <span style={{ fontSize: '12px', opacity: 0.9 }}>
+                            {' '}(Avg. Handicap: {team.average_handicap})
+                          </span>
+                        )}
+                      </div>
+                      
+                      {team.players.map((player, playerIndex) => (
+                        <div key={playerIndex} style={{
+                          padding: '6px 10px',
+                          background: '#f8f9fa',
+                          marginBottom: '5px',
+                          borderRadius: '4px',
+                          fontSize: '14px',
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center'
+                        }}>
+                          <span>{player.player_name}</span>
+                          {player.handicap && (
+                            <span style={{
+                              fontSize: '12px',
+                              color: '#6c757d',
+                              background: '#e9ecef',
+                              padding: '2px 6px',
+                              borderRadius: '3px'
+                            }}>
+                              HCP: {player.handicap}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+                
+                <div style={{
+                  marginTop: '15px',
+                  padding: '10px',
+                  background: '#d1ecf1',
+                  borderRadius: '4px',
+                  textAlign: 'center',
+                  fontSize: '14px',
+                  color: '#0c5460'
+                }}>
+                  💡 <strong>Tip:</strong> Teams are automatically balanced based on skill level when using "Balanced Teams". 
+                  Use "Random Teams" for completely random pairings.
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Not Authenticated Message */}
       {!isAuthenticated && (


### PR DESCRIPTION
Add comprehensive random team formation feature that:

- Creates random or skill-balanced 4-player teams
- Handles scenarios with more than 4 players signed up
- Provides multiple rotation options for variety
- Includes full validation and error handling
- Features intuitive UI in the daily signup view

Implements backend TeamFormationService and frontend team formation UI.

Closes #58

Generated with [Claude Code](https://claude.ai/code)