### PR TITLE
Ensure simulation feedback handles arrays safely

### DIFF
--- a/frontend/src/components/simulation/SimulationMode.js
+++ b/frontend/src/components/simulation/SimulationMode.js
@@ -40,12 +40,6 @@ function SimulationMode() {
     setHasNextShot,
   } = useGame();
 
-  // Helper functions for missing setters
-  const setFeedback = (message) => {
-    clearFeedback();
-    if (message) addFeedback(message);
-  };
-  
   // Timeline and Poker state
   const [timelineEvents, setTimelineEvents] = useState([]);
   const [pokerState, setPokerState] = useState({});
@@ -141,7 +135,7 @@ function SimulationMode() {
       // Reset all local state for new simulation
       setGameState(null);
       endGame();  // Use endGame directly instead of setIsGameActive
-      setFeedback([]);
+      clearFeedback();
       setShotProbabilities(null);
       setShotState(null);
       setHasNextShot(true);
@@ -174,10 +168,11 @@ function SimulationMode() {
         startGame(data.game_state);
         
         // Set initial feedback
+        clearFeedback();
         if (data.feedback && Array.isArray(data.feedback)) {
-          setFeedback(data.feedback);
+          data.feedback.forEach((msg) => addFeedback(msg));
         } else {
-          setFeedback([data.message || "Simulation started!"]);
+          addFeedback(data.message || "Simulation started!");
         }
         
         // Set next shot availability from the response
@@ -489,7 +484,7 @@ function SimulationMode() {
         errorMessage += error.message;
       }
       
-      setFeedback(prev => [...prev, `❌ ${errorMessage}`]);
+      addFeedback(`❌ ${errorMessage}`);
     } finally {
       setLoading(false);
     }
@@ -511,7 +506,7 @@ function SimulationMode() {
   const resetSimulation = () => {
     setGameState(null);
     endGame();  // Use endGame directly instead of setIsGameActive
-    setFeedback([]);
+    clearFeedback();
     setHoleDecisions({
       action: null,
       requested_partner: null,


### PR DESCRIPTION
## Summary
- remove the setFeedback helper that coerced arrays/updaters into a single message
- call clearFeedback directly when resetting simulation state and before loading new messages
- iterate backend feedback arrays and push individual entries via addFeedback for consistent rendering

## Testing
- not run (UI environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68e46351df808330a0bc8820d33ff459