### PR TITLE
Ensure shot probability updates use merged payloads

### DIFF
--- a/frontend/src/components/simulation/SimulationMode.js
+++ b/frontend/src/components/simulation/SimulationMode.js
@@ -372,17 +372,23 @@ function SimulationMode() {
           setHasNextShot(data.next_shot_available);
         }
         
-        // Show probabilities if available
-        if (data.probabilities) {
-          setShotProbabilities(data.probabilities);
-        }
-        
-        // Show betting probabilities if available
-        if (data.betting_probabilities) {
-          setShotProbabilities(prev => ({
-            ...prev,
-            betting_analysis: data.betting_probabilities
-          }));
+        const baseProbabilities =
+          data.probabilities && typeof data.probabilities === "object" && !Array.isArray(data.probabilities)
+            ? data.probabilities
+            : null;
+
+        const bettingAnalysis =
+          data.betting_probabilities && typeof data.betting_probabilities === "object"
+            ? data.betting_probabilities
+            : null;
+
+        if (baseProbabilities || bettingAnalysis) {
+          const combinedProbabilities = {
+            ...(baseProbabilities || {}),
+            ...(bettingAnalysis ? { betting_analysis: bettingAnalysis } : {}),
+          };
+
+          setShotProbabilities(combinedProbabilities);
         }
         
         // Auto-continue if no interaction needed and shots available

--- a/frontend/src/components/simulation/__tests__/SimulationMode.probabilities.test.js
+++ b/frontend/src/components/simulation/__tests__/SimulationMode.probabilities.test.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockGameContext = {
+  gameState: null,
+  setGameState: jest.fn(),
+  isGameActive: true,
+  startGame: jest.fn(),
+  endGame: jest.fn(),
+  loading: false,
+  setLoading: jest.fn(),
+  feedback: [],
+  addFeedback: jest.fn(),
+  clearFeedback: jest.fn(),
+  shotState: null,
+  setShotState: jest.fn(),
+  interactionNeeded: null,
+  setInteractionNeeded: jest.fn(),
+  pendingDecision: {},
+  setPendingDecision: jest.fn(),
+  shotProbabilities: null,
+  setShotProbabilities: jest.fn(),
+  hasNextShot: true,
+  setHasNextShot: jest.fn(),
+};
+
+jest.mock('../../../context', () => ({
+  useGame: () => mockGameContext,
+}));
+
+jest.mock('../GameSetup', () => {
+  return function MockGameSetup({ onStartGame }) {
+    return (
+      <div data-testid="game-setup">
+        <button onClick={onStartGame} data-testid="start-game-btn">
+          Start Simulation
+        </button>
+      </div>
+    );
+  };
+});
+
+jest.mock('../GamePlay', () => ({ onMakeDecision }) => (
+  <div data-testid="game-play">
+    <button onClick={() => onMakeDecision({ action: 'test' })} data-testid="make-decision-btn">
+      Make Decision
+    </button>
+  </div>
+));
+
+jest.mock('../EnhancedSimulationLayout', () => ({ onDecision }) => (
+  <div data-testid="enhanced-layout">
+    <button onClick={() => onDecision({ action: 'test' })} data-testid="make-decision-btn">
+      Make Decision
+    </button>
+  </div>
+));
+
+// Import after mocks are defined
+import SimulationMode from '../SimulationMode';
+
+global.fetch = jest.fn();
+
+describe('SimulationMode probabilities merging', () => {
+  beforeEach(() => {
+    fetch.mockReset();
+    Object.values(mockGameContext).forEach((value) => {
+      if (typeof value === 'function') {
+        value.mockClear();
+      }
+    });
+    mockGameContext.isGameActive = true;
+    mockGameContext.gameState = { status: 'active' };
+    mockGameContext.interactionNeeded = null;
+    mockGameContext.pendingDecision = {};
+    mockGameContext.shotProbabilities = null;
+    mockGameContext.hasNextShot = true;
+  });
+
+  it('combines shot and betting probabilities into a single payload', async () => {
+    const decisionResponse = {
+      status: 'ok',
+      game_state: { status: 'active', updated: true },
+      probabilities: { shot: { success: 0.65 } },
+      betting_probabilities: { offer_double: 0.4 },
+      next_shot_available: false,
+    };
+
+    fetch.mockImplementation((url) => {
+      if (url.includes('/simulation/available-personalities')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ personalities: [] }) });
+      }
+      if (url.includes('/simulation/suggested-opponents')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ opponents: [] }) });
+      }
+      if (url.endsWith('/courses')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      if (url.includes('/simulation/play-hole')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(decisionResponse) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    render(<SimulationMode />);
+
+    fireEvent.click(await screen.findByTestId('make-decision-btn'));
+
+    await waitFor(() => {
+      expect(mockGameContext.setShotProbabilities).toHaveBeenCalledWith({
+        shot: { success: 0.65 },
+        betting_analysis: { offer_double: 0.4 },
+      });
+    });
+    expect(mockGameContext.setShotProbabilities).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/context/GameProvider.js
+++ b/frontend/src/context/GameProvider.js
@@ -347,7 +347,33 @@ export const GameProvider = ({ children }) => {
     setPendingDecision: (decision) => dispatch({ type: GameActions.SET_PENDING_DECISION, payload: decision }),
     
     // Shot analysis
-    setShotProbabilities: (probabilities) => dispatch({ type: GameActions.SET_SHOT_PROBABILITIES, payload: probabilities }),
+    setShotProbabilities: (probabilities) => {
+      const previousProbabilities =
+        state.shotProbabilities && typeof state.shotProbabilities === 'object'
+          ? { ...state.shotProbabilities }
+          : null;
+
+      const resolvedProbabilities =
+        typeof probabilities === 'function'
+          ? probabilities(previousProbabilities)
+          : probabilities;
+
+      if (
+        resolvedProbabilities !== null &&
+        (typeof resolvedProbabilities !== 'object' || Array.isArray(resolvedProbabilities))
+      ) {
+        console.warn('setShotProbabilities expected a plain object or null. Received:', resolvedProbabilities);
+        dispatch({ type: GameActions.SET_SHOT_PROBABILITIES, payload: null });
+        return;
+      }
+
+      const normalizedProbabilities =
+        resolvedProbabilities && typeof resolvedProbabilities === 'object'
+          ? { ...resolvedProbabilities }
+          : null;
+
+      dispatch({ type: GameActions.SET_SHOT_PROBABILITIES, payload: normalizedProbabilities });
+    },
     setHasNextShot: (hasNext) => dispatch({ type: GameActions.SET_HAS_NEXT_SHOT, payload: hasNext }),
     
     // API actions

--- a/frontend/src/context/__tests__/GameProvider.shotProbabilities.test.js
+++ b/frontend/src/context/__tests__/GameProvider.shotProbabilities.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+
+import { GameProvider, useGame } from '../GameProvider';
+
+const ContextConsumer = ({ onReady }) => {
+  const context = useGame();
+
+  React.useEffect(() => {
+    if (onReady) {
+      onReady(context);
+    }
+  }, [context, onReady]);
+
+  return null;
+};
+
+describe('GameProvider shot probabilities', () => {
+  it('resolves updater functions to plain objects', () => {
+    let contextValue;
+
+    render(
+      <GameProvider>
+        <ContextConsumer onReady={(ctx) => { contextValue = ctx; }} />
+      </GameProvider>
+    );
+
+    const initialProbabilities = { shot: { success: 0.45 } };
+    const bettingProbabilities = { offer_double: 0.3 };
+
+    act(() => {
+      contextValue.setShotProbabilities(initialProbabilities);
+    });
+
+    expect(contextValue.shotProbabilities).toEqual(initialProbabilities);
+    expect(typeof contextValue.shotProbabilities).toBe('object');
+
+    act(() => {
+      contextValue.setShotProbabilities((prev) => ({
+        ...prev,
+        betting_analysis: bettingProbabilities,
+      }));
+    });
+
+    expect(contextValue.shotProbabilities).toEqual({
+      ...initialProbabilities,
+      betting_analysis: bettingProbabilities,
+    });
+    expect(typeof contextValue.shotProbabilities).toBe('object');
+  });
+});


### PR DESCRIPTION
## Summary
- merge shot and betting probability payloads before updating the simulation shot probabilities state
- normalize GameProvider.setShotProbabilities to resolve updater functions and guard against non-object payloads
- add focused regression tests covering probability merging and GameProvider shot probability updates

## Testing
- CI=true npm test -- src/components/simulation/__tests__/SimulationMode.probabilities.test.js src/context/__tests__/GameProvider.shotProbabilities.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4635293c4833080d444eabfa9463a