### PR TITLE
fix: remove deprecated routes from vercel.json

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -18,34 +18,34 @@
       "REACT_APP_DEPLOY_PLATFORM": "vercel"
     }
   },
-  "routes": [
-    {
-      "src": "/static/(.*)",
-      "headers": {
-        "cache-control": "public, max-age=31536000, immutable"
-      },
-      "dest": "/static/$1"
-    },
-    {
-      "src": "/manifest.json",
-      "headers": {
-        "cache-control": "public, max-age=3600"
-      },
-      "dest": "/manifest.json"
-    },
-    {
-      "src": "/(.*\\.(?:ico|png|jpg|jpeg|svg|gif|css|js|json|woff|woff2|ttf|eot)$)",
-      "headers": {
-        "cache-control": "public, max-age=3600"
-      },
-      "dest": "/$1"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
-  ],
   "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    },
+    {
+      "source": "/(.*\\.(?:ico|png|jpg|jpeg|svg|gif|css|js|json|woff|woff2|ttf|eot)$)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    },
     {
       "source": "/(.*)",
       "headers": [


### PR DESCRIPTION
Convert deprecated 'routes' syntax to modern 'headers' and 'rewrites'.

Vercel no longer allows 'routes' when using 'rewrites', 'headers', etc. Converted all route-based cache headers to the headers array format.

This fixes the Vercel deployment error:
'If rewrites, redirects, headers, cleanUrls or trailingSlash are used, then routes cannot be present.'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces deprecated `routes` with `headers` and a catch-all `rewrites` entry, preserving caching and security headers.
> 
> - **Vercel config (`frontend/vercel.json`)**:
>   - Migrate deprecated `routes` cache rules to `headers` entries:
>     - `Cache-Control` for `static/*`, `manifest.json`, and common asset extensions.
>   - Add global security headers on `/(.*)`: `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`.
>   - Add SPA rewrite: `/(.*)` -> `/index.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66359693cb3c79ca71f76618ed7e38cbb719f78c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->