### PR TITLE
fix: remove deprecated routes from vercel.json

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -18,34 +18,34 @@
       "REACT_APP_DEPLOY_PLATFORM": "vercel"
     }
   },
-  "routes": [
-    {
-      "src": "/static/(.*)",
-      "headers": {
-        "cache-control": "public, max-age=31536000, immutable"
-      },
-      "dest": "/static/$1"
-    },
-    {
-      "src": "/manifest.json",
-      "headers": {
-        "cache-control": "public, max-age=3600"
-      },
-      "dest": "/manifest.json"
-    },
-    {
-      "src": "/(.*\\.(?:ico|png|jpg|jpeg|svg|gif|css|js|json|woff|woff2|ttf|eot)$)",
-      "headers": {
-        "cache-control": "public, max-age=3600"
-      },
-      "dest": "/$1"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
-  ],
   "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    },
+    {
+      "source": "/(.*\\.(?:ico|png|jpg|jpeg|svg|gif|css|js|json|woff|woff2|ttf|eot)$)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    },
     {
       "source": "/(.*)",
       "headers": [


### PR DESCRIPTION
Convert deprecated 'routes' syntax to modern 'headers' and 'rewrites'.

Vercel no longer allows 'routes' when using 'rewrites', 'headers', etc. Converted all route-based cache headers to the headers array format.

This fixes the Vercel deployment error:
'If rewrites, redirects, headers, cleanUrls or trailingSlash are used, then routes cannot be present.'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace deprecated routes in `frontend/vercel.json` with modern `headers` and `rewrites`, preserving cache rules and adding global security headers.
> 
> - **Config (frontend/vercel.json)**:
>   - Replace deprecated `routes` with top-level `headers` and `rewrites`.
>   - Preserve cache-control for `static/*`, `manifest.json`, and asset file types via `headers`.
>   - Add global security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`) for `/(.*)`.
>   - Add `rewrites` to route all paths to `index.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65170f67351e2853c01a5766d47ab6e374dc7fe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->