### PR TITLE
fix: correct player field reference to prevent transaction abort during game start

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2369,17 +2369,17 @@ async def start_game_from_lobby(game_id: str, db: Session = Depends(database.get
         # Send game start notifications to all players using NotificationService
         notification_service = get_notification_service()
         for player in players:
-            if player.player_id:  # Only send to registered players
+            if player.player_profile_id:  # Only send to registered players
                 try:
                     notification_service.send_notification(
-                        player_id=player.player_id,
+                        player_id=player.player_profile_id,
                         notification_type="game_start",
                         message=f"Game {game_id[:8]} has started with {len(players)} players!",
                         db=db,
                         data={"game_id": game_id, "player_count": len(players)}
                     )
                 except Exception as notif_error:
-                    logger.warning(f"Failed to send game start notification to player {player.player_id}: {notif_error}")
+                    logger.warning(f"Failed to send game start notification to player {player.player_profile_id}: {notif_error}")
 
         return {
             "status": "started",


### PR DESCRIPTION
- Changed player.player_id to player.player_profile_id in notification code
- The GamePlayer model uses player_profile_id, not player_id
- This was causing AttributeError which aborted PostgreSQL transactions
- Subsequent queries would fail with 'current transaction is aborted' error
- Fixes hold data persistence issue on Render deployment