### PR TITLE
fix: remove routes property to resolve Vercel deployment conflict

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -67,31 +67,5 @@
         }
       ]
     }
-  ],
-  "routes": [
-    {
-      "src": "/static/(.*)",
-      "dest": "/static/$1"
-    },
-    {
-      "src": "/manifest.json",
-      "dest": "/manifest.json"
-    },
-    {
-      "src": "/favicon.ico",
-      "dest": "/favicon.ico"
-    },
-    {
-      "src": "/robots.txt",
-      "dest": "/robots.txt"
-    },
-    {
-      "src": "/(.*\\.(ico|png|jpg|jpeg|svg|gif|css|js|json|woff|woff2|ttf|eot|webp))",
-      "dest": "/$1"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
   ]
 }


### PR DESCRIPTION
The 'routes' property cannot be used when 'headers', 'redirects', 'rewrites',
'cleanUrls', or 'trailingSlash' are defined in vercel.json. Removed the legacy
'routes' configuration as Vercel automatically handles static file serving and
SPA routing for Create React App deployments.