### PR TITLE
fix: remove unused variables and imports to resolve ESLint warnings

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import { Routes, Route, useNavigate, Navigate, useLocation } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
-import { UnifiedGameInterface, SimpleScorekeeper } from "./components/game";
-import { SimulationMode, ScorerMode, MonteCarloSimulation } from "./components/simulation";
+import { MonteCarloSimulation } from "./components/simulation";
 import FeedAnalyzer from "./components/simulation/FeedAnalyzer";
 import ShotRangeAnalyzer from "./components/ShotRangeAnalyzer";
 import ColdStartHandler from "./components/ColdStartHandler";

--- a/frontend/src/components/game/MobileScorecard.jsx
+++ b/frontend/src/components/game/MobileScorecard.jsx
@@ -30,7 +30,6 @@ const MobileScorecard = ({ gameState }) => {
 
   const standings = getCurrentStandings();
   const currentHole = gameState.current_hole || 1;
-  const holeHistory = getHoleHistory();
 
   // Render compact standings view (default for game manager)
   const renderStandingsView = () => (

--- a/frontend/src/components/simulation/ScorerMode.js
+++ b/frontend/src/components/simulation/ScorerMode.js
@@ -26,7 +26,6 @@ function ScorerMode() {
     addFeedback,
     clearFeedback,
     shotState,
-    setShotState,
     interactionNeeded,
     setInteractionNeeded,
     pendingDecision,
@@ -95,7 +94,7 @@ function ScorerMode() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount
 
-  const fetchPokerState = async () => {
+  const fetchPokerState = useCallback(async () => {
     if (!isGameActive) return;
 
     try {
@@ -115,7 +114,7 @@ function ScorerMode() {
     } catch (error) {
       console.error("Error fetching poker state:", error);
     }
-  };
+  }, [isGameActive]);
 
   useEffect(() => {
     if (isGameActive) {
@@ -125,7 +124,7 @@ function ScorerMode() {
       }, 3000);
       return () => clearInterval(interval);
     }
-  }, [isGameActive, gameState?.current_hole]);
+  }, [isGameActive, gameState?.current_hole, fetchPokerState]);
 
   const makeDecision = async (decision) => {
     setLoading(true);

--- a/frontend/src/components/simulation/visual/SimulationVisualInterface.jsx
+++ b/frontend/src/components/simulation/visual/SimulationVisualInterface.jsx
@@ -6,7 +6,6 @@ import {
   HoleVisualization,
   PlayersCard,
   BettingCard,
-  ShotContextCard,
   Scorecard
 } from './index';
 import SimulationDecisionPanel from '../SimulationDecisionPanel';

--- a/frontend/src/pages/GameScorerPage.js
+++ b/frontend/src/pages/GameScorerPage.js
@@ -13,12 +13,10 @@ const API_URL = process.env.REACT_APP_API_URL || "";
 const GameScorerPage = () => {
   const navigate = useNavigate();
   const theme = useTheme();
-  const [creating, setCreating] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     const createTestGame = async () => {
-      setCreating(true);
       setError(null);
 
       try {
@@ -43,7 +41,6 @@ const GameScorerPage = () => {
       } catch (err) {
         console.error('Error creating test game:', err);
         setError(err.message);
-        setCreating(false);
       }
     };
 


### PR DESCRIPTION
- Remove unused imports (UnifiedGameInterface, SimpleScorekeeper, SimulationMode, ScorerMode, ShotContextCard)
- Remove unused variables (holeHistory, creating, setShotState)
- Fix React Hook dependency warning by wrapping fetchPokerState with useCallback