### PR TITLE
fix: remove unused getHoleHistory function in MobileScorecard

### DIFF
--- a/frontend/src/components/game/MobileScorecard.jsx
+++ b/frontend/src/components/game/MobileScorecard.jsx
@@ -23,11 +23,6 @@ const MobileScorecard = ({ gameState }) => {
       .sort((a, b) => b.quarters - a.quarters);
   };
 
-  // Get hole history if available
-  const getHoleHistory = () => {
-    return gameState.hole_history || [];
-  };
-
   const standings = getCurrentStandings();
   const currentHole = gameState.current_hole || 1;
 


### PR DESCRIPTION
Removed the unused getHoleHistory function that was causing an ESLint no-unused-vars error during build.