### PR TITLE
feat: add Stuart Mode strategy panel to scorekeeper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,6 @@ coordination/orchestration/*
 claude-flow
 # Removed Windows wrapper files per user request
 hive-mind-prompt-*.txt
+
+# Git worktrees
+.worktrees/

--- a/docs/superpowers/specs/2026-04-17-stuart-mode-design.md
+++ b/docs/superpowers/specs/2026-04-17-stuart-mode-design.md
@@ -1,0 +1,152 @@
+# Stuart Mode — Design Spec
+
+**Date:** 2026-04-17  
+**Status:** Approved  
+
+## Overview
+
+A toggleable strategy panel for the scoring screen that gives the authenticated user (Stuart) real-time, personalized advice during a Wolf Goat Pig round. It answers two questions on every hole: *who do I need to watch out for?* and *does going solo make sense right now?*
+
+---
+
+## Architecture
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/utils/stuartModeInsights.js` | Pure functions that compute tips from game state. No React, fully unit-testable. |
+| `frontend/src/components/game/scorekeeper/StuartModePanel.jsx` | Display component. Renders below `HoleHeader` when Stuart Mode is on. |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `frontend/src/hooks/useUIState.js` | Add `stuartMode` boolean + `toggleStuartMode`, persisted to `localStorage` key `wgp_stuart_mode`. |
+| `frontend/src/components/game/SimpleScorekeeper.jsx` | Add toggle button to toolbar; render `<StuartModePanel>` between `HoleHeader` and score inputs when `stuartMode` is true. |
+| `frontend/src/components/game/scorekeeper/index.js` | Export `StuartModePanel`. |
+
+---
+
+## Player Identification
+
+Stuart is identified as `players.find(p => p.is_authenticated)`. This is already set via Auth0 and displayed in the app (🔒 badge). No new auth work needed.
+
+---
+
+## Threat Score
+
+For each player on the current hole:
+
+```
+threatScore = handicap − (fullStrokes + halfStrokes × 0.5)
+```
+
+Where:
+- `fullStrokes` = `Math.floor(strokeAllocation[playerId][currentHole])`
+- `halfStrokes` = `strokeAllocation[playerId][currentHole] % 1 >= 0.4 ? 1 : 0` (Creecher half-stroke)
+
+Lower threat score = more dangerous opponent. Bands:
+
+| Score | Label | Example |
+|-------|-------|---------|
+| ≤ 4 | **High threat** | Steve (1 hdcp, no stroke) → score 1 |
+| 5–10 | **Moderate** | Dan (8 hdcp, no stroke) → score 8 |
+| > 10 | **Favored** | Mike (14 hdcp, no stroke) → score 14 |
+
+Stuart's own score is computed the same way so comparisons are relative.
+
+---
+
+## Tip Logic (`stuartModeInsights.js`)
+
+`generateInsights({ stuartPlayer, players, currentHole, strokeAllocation, playerStandings, courseData, currentWager })` returns:
+
+```js
+{
+  headline: string,       // bold summary line
+  detail: string,         // 1–2 sentence explanation
+  threats: [              // sorted high → low threat
+    { player, threatScore, strokeSituation }
+  ],
+  soloRecommendation: 'go' | 'caution' | 'avoid'
+}
+```
+
+### Tip priority (evaluated in order, can combine)
+
+1. **Stroke situation** — describe Stuart's strokes (full / Creecher / none) and contrast with each opponent's strokes
+2. **High-threat callouts** — name every opponent with threatScore ≤ 4, explain why ("Steve is a 1 — the Creecher barely dents his advantage")
+3. **Quarter standing context** — if Stuart is down > 3q: "You're down X quarters — higher-variance play makes sense"; if up > 3q: "You're up X — a partner reduces risk"
+4. **Hungry opponent callout** — opponent who is both a high threat AND down in quarters gets `⚠️ hungry` flag (they'll play aggressively)
+5. **Hole difficulty fallback** — if SI ≤ 6 and no clear stroke advantage: "Tough hole — partnership reduces exposure at Xq"
+
+### Solo recommendation logic
+
+| Condition | Recommendation |
+|-----------|---------------|
+| Stuart has full stroke AND no high-threat opponents | `go` |
+| Stuart has full stroke BUT ≥ 1 high-threat opponent | `caution` |
+| Stuart has Creecher AND ≥ 1 high-threat opponent | `caution` |
+| Stuart has no stroke AND ≥ 1 high-threat opponent | `avoid` |
+| Stuart is down > 3q (overrides caution → go) | bumps up one level |
+
+---
+
+## Panel Layout (`StuartModePanel.jsx`)
+
+Renders as two stacked sections below `HoleHeader`:
+
+### Strategy tip card (amber/gold accent)
+```
+🧠 Stuart Mode
+────────────────────────────────
+[soloRecommendation badge]  [headline]
+[detail text]
+```
+
+Solo recommendation badge:
+- `go` → green "Solo ✓"
+- `caution` → amber "Solo ⚠"  
+- `avoid` → red "Solo ✗"
+
+### Standings strip (compact)
+One row per player, sorted by current quarter total descending:
+
+```
+Stuart   +7q  🟢
+Steve    -4q  🔴  ⚠️ hungry
+Dan       0q  ⚪
+Mike     -3q  🔴
+```
+
+- Green = positive quarters, red = negative, neutral = 0
+- `⚠️ hungry` callout for players who are down AND are a high threat this hole
+
+---
+
+## Toggle
+
+- Small button in the `SimpleScorekeeper` toolbar row (same row as photo/sync buttons)
+- Label: `🧠 Stuart` when off, active style when on
+- State: `stuartMode` boolean in `useUIState`, persisted to `localStorage('wgp_stuart_mode')`
+- Default: off
+
+---
+
+## Data Flow
+
+`SimpleScorekeeper` already has all required data in scope:
+- `players` (includes `handicap`, `is_authenticated`)
+- `strokeAllocation` (includes half-strokes from Creecher)
+- `playerStandings` (live quarter totals, recalculated from `holeHistory`)
+- `currentHole`, `courseData`, `currentWager`
+
+All of these are passed as props to `StuartModePanel`. `stuartModeInsights.js` receives them as plain objects.
+
+---
+
+## Testing
+
+- `stuartModeInsights.js` — unit tests covering: full stroke advantage, Creecher-only advantage, high-threat opponent (low handicap), hungry opponent (down in quarters + high threat), combined scenarios, solo recommendation logic
+- `StuartModePanel.jsx` — render test: panel shows/hides correctly, standings strip reflects player data

--- a/frontend/src/components/game/SimpleScorekeeper.jsx
+++ b/frontend/src/components/game/SimpleScorekeeper.jsx
@@ -29,6 +29,7 @@ import {
   TeamSelector,
   QuartersPanel,
   HoleNavigation,
+  StuartModePanel,
 } from "./scorekeeper";
 import "../../styles/mobile-touch.css";
 import { apiConfig } from "../../config/api.config";
@@ -371,6 +372,8 @@ const SimpleScorekeeper = ({
     setIsGameMarkedComplete,
     startEditingPlayerName,
     cancelEditingPlayerName: handleCancelPlayerNameEdit,
+    stuartMode,
+    toggleStuartMode,
   } = ui;
 
   // Offline-first sync hook
@@ -1762,6 +1765,25 @@ const SimpleScorekeeper = ({
             📷 Import from photo
           </button>
         </div>
+        {/* Stuart Mode toggle */}
+        <div style={{ marginTop: "4px", textAlign: "center" }}>
+          <button
+            onClick={toggleStuartMode}
+            style={{
+              padding: "4px 12px",
+              fontSize: "12px",
+              border: `1px solid ${stuartMode ? "#F59E0B" : theme.colors.border}`,
+              borderRadius: "12px",
+              background: stuartMode ? "rgba(245,158,11,0.15)" : "transparent",
+              color: stuartMode ? "#92400E" : theme.colors.textSecondary,
+              cursor: "pointer",
+              fontWeight: stuartMode ? "bold" : "normal",
+              transition: "all 0.2s",
+            }}
+          >
+            🧠 Stuart Mode {stuartMode ? "ON" : "OFF"}
+          </button>
+        </div>
       </div>
 
       {/* Enhanced Hole Title Section - Combines hole info, hitting order, and strokes */}
@@ -1784,6 +1806,18 @@ const SimpleScorekeeper = ({
         jumpToHole={jumpToHole}
         movePlayerInOrder={movePlayerInOrder}
       />
+      {/* Stuart Mode — strategy panel */}
+      {stuartMode && (
+        <StuartModePanel
+          players={players}
+          currentHole={currentHole}
+          strokeAllocation={strokeAllocation}
+          playerStandings={playerStandings}
+          courseData={courseData}
+          currentWager={currentWager}
+          theme={theme}
+        />
+      )}
 
       {/* Float & Option Tracking - Collapsed by default */}
       <div

--- a/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+++ b/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
@@ -5,7 +5,7 @@ import { generateInsights } from '../../../utils/stuartModeInsights';
 
 const SOLO_BADGE = {
   go:      { label: 'Solo ✓', bg: '#4CAF50', color: 'white' },
-  caution: { label: 'Solo ⚠',  bg: '#FF9800', color: 'white' },
+  caution: { label: 'Solo ⚠',  bg: '#F59E0B', color: 'white' },
   avoid:   { label: 'Solo ✗',  bg: '#f44336', color: 'white' },
 };
 

--- a/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+++ b/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
@@ -1,0 +1,196 @@
+// frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+import React from 'react';
+import PropTypes from 'prop-types';
+import { generateInsights } from '../../../utils/stuartModeInsights';
+
+const SOLO_BADGE = {
+  go:      { label: 'Solo ✓', bg: '#4CAF50', color: 'white' },
+  caution: { label: 'Solo ⚠',  bg: '#FF9800', color: 'white' },
+  avoid:   { label: 'Solo ✗',  bg: '#f44336', color: 'white' },
+};
+
+const StuartModePanel = ({
+  players,
+  currentHole,
+  strokeAllocation,
+  playerStandings,
+  courseData,
+  currentWager,
+  theme,
+}) => {
+  const insights = generateInsights({
+    players,
+    currentHole,
+    strokeAllocation,
+    playerStandings,
+    courseData,
+    currentWager,
+  });
+
+  const badge = SOLO_BADGE[insights.soloRecommendation];
+
+  const standingsRows = [...players].sort((a, b) => {
+    const qa = playerStandings?.[a.id]?.quarters ?? 0;
+    const qb = playerStandings?.[b.id]?.quarters ?? 0;
+    return qb - qa;
+  });
+
+  return (
+    <div
+      style={{
+        background: theme.colors.paper,
+        border: `2px solid #F59E0B`,
+        borderRadius: '12px',
+        marginBottom: '16px',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Strategy tip section */}
+      <div
+        style={{
+          background: 'linear-gradient(135deg, #92400E, #F59E0B)',
+          color: 'white',
+          padding: '12px 16px',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '11px',
+            fontWeight: 'bold',
+            textTransform: 'uppercase',
+            letterSpacing: '1px',
+            opacity: 0.9,
+            marginBottom: '8px',
+          }}
+        >
+          🧠 Stuart Mode
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: '10px' }}>
+          <span
+            data-testid="solo-recommendation"
+            style={{
+              background: badge.bg,
+              color: badge.color,
+              padding: '4px 10px',
+              borderRadius: '12px',
+              fontSize: '12px',
+              fontWeight: 'bold',
+              whiteSpace: 'nowrap',
+              flexShrink: 0,
+              border: '2px solid rgba(255,255,255,0.4)',
+            }}
+          >
+            {badge.label}
+          </span>
+
+          <div>
+            <div style={{ fontSize: '15px', fontWeight: 'bold', marginBottom: '4px' }}>
+              {insights.headline}
+            </div>
+            <div style={{ fontSize: '12px', opacity: 0.9, lineHeight: 1.4 }}>
+              {insights.detail}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Standings strip */}
+      <div style={{ padding: '10px 16px' }}>
+        <div
+          style={{
+            fontSize: '10px',
+            textTransform: 'uppercase',
+            letterSpacing: '1px',
+            color: theme.colors.textSecondary,
+            marginBottom: '6px',
+          }}
+        >
+          Quarter Standings
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          {standingsRows.map(player => {
+            const entry = insights.threats.find(t => t.player.id === player.id);
+            const quarters = playerStandings?.[player.id]?.quarters ?? 0;
+            const isStuart = player.is_authenticated;
+            const isHungry = entry?.hungry;
+
+            const qColor = quarters > 0 ? '#4CAF50' : quarters < 0 ? '#f44336' : '#9CA3AF';
+            const qLabel = quarters > 0 ? `+${quarters}q` : `${quarters}q`;
+
+            return (
+              <div
+                key={player.id}
+                data-testid={`standing-${player.id}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '4px 8px',
+                  borderRadius: '8px',
+                  background: isStuart ? 'rgba(245,158,11,0.08)' : 'transparent',
+                  border: isStuart ? '1px solid rgba(245,158,11,0.3)' : '1px solid transparent',
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: '13px',
+                    fontWeight: isStuart ? 'bold' : '500',
+                    color: theme.colors.textPrimary,
+                  }}
+                >
+                  {player.name}
+                  {isStuart && ' ←'}
+                </span>
+
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                  {isHungry && (
+                    <span
+                      data-testid={`hungry-${player.id}`}
+                      style={{
+                        fontSize: '11px',
+                        color: '#f44336',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      ⚠️ hungry
+                    </span>
+                  )}
+                  <span
+                    style={{
+                      fontSize: '13px',
+                      fontWeight: 'bold',
+                      color: qColor,
+                      minWidth: '40px',
+                      textAlign: 'right',
+                    }}
+                  >
+                    {qLabel}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+StuartModePanel.propTypes = {
+  players: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    handicap: PropTypes.number.isRequired,
+    is_authenticated: PropTypes.bool,
+  })).isRequired,
+  currentHole: PropTypes.number.isRequired,
+  strokeAllocation: PropTypes.object,
+  playerStandings: PropTypes.object,
+  courseData: PropTypes.object,
+  currentWager: PropTypes.number.isRequired,
+  theme: PropTypes.object.isRequired,
+};
+
+export default StuartModePanel;

--- a/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+++ b/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
@@ -1,0 +1,73 @@
+// frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import StuartModePanel from '../StuartModePanel';
+
+const theme = {
+  colors: {
+    primary: '#2196F3',
+    accent: '#FFD700',
+    paper: '#ffffff',
+    backgroundSecondary: '#f5f5f5',
+    border: '#e0e0e0',
+    textPrimary: '#333',
+    textSecondary: '#666',
+  },
+};
+
+const stuart = { id: 'p1', name: 'Stuart', handicap: 15, is_authenticated: true };
+const steve  = { id: 'p2', name: 'Steve',  handicap: 1,  is_authenticated: false };
+const dan    = { id: 'p3', name: 'Dan',    handicap: 12, is_authenticated: false };
+
+const baseProps = {
+  players: [stuart, steve, dan],
+  currentHole: 5,
+  strokeAllocation: {
+    p1: { 5: 1 },
+    p2: { 5: 0 },
+    p3: { 5: 0 },
+  },
+  playerStandings: {
+    p1: { quarters: 0, name: 'Stuart' },
+    p2: { quarters: 0, name: 'Steve' },
+    p3: { quarters: 0, name: 'Dan' },
+  },
+  courseData: { holes: [{ hole_number: 5, handicap: 4 }] },
+  currentWager: 2,
+  theme,
+};
+
+test('renders Stuart Mode heading', () => {
+  render(<StuartModePanel {...baseProps} />);
+  expect(screen.getByText(/Stuart Mode/i)).toBeInTheDocument();
+});
+
+test('renders headline from insights', () => {
+  render(<StuartModePanel {...baseProps} />);
+  expect(screen.getByText(/Watch out for Steve/i)).toBeInTheDocument();
+});
+
+test('renders solo recommendation badge', () => {
+  render(<StuartModePanel {...baseProps} />);
+  expect(screen.getByTestId('solo-recommendation')).toBeInTheDocument();
+});
+
+test('renders a standings row for each player', () => {
+  render(<StuartModePanel {...baseProps} />);
+  expect(screen.getByTestId('standing-p1')).toBeInTheDocument();
+  expect(screen.getByTestId('standing-p2')).toBeInTheDocument();
+  expect(screen.getByTestId('standing-p3')).toBeInTheDocument();
+});
+
+test('shows hungry indicator for player who is down and high threat', () => {
+  const props = {
+    ...baseProps,
+    playerStandings: {
+      p1: { quarters: 5,  name: 'Stuart' },
+      p2: { quarters: -5, name: 'Steve' },
+      p3: { quarters: 0,  name: 'Dan' },
+    },
+  };
+  render(<StuartModePanel {...props} />);
+  expect(screen.getByTestId('hungry-p2')).toBeInTheDocument();
+});

--- a/frontend/src/components/game/scorekeeper/index.js
+++ b/frontend/src/components/game/scorekeeper/index.js
@@ -4,3 +4,4 @@ export { default as HoleHeader } from "./HoleHeader";
 export { default as TeamSelector } from "./TeamSelector";
 export { default as QuartersPanel } from "./QuartersPanel";
 export { default as HoleNavigation } from "./HoleNavigation";
+export { default as StuartModePanel } from "./StuartModePanel";

--- a/frontend/src/hooks/__tests__/useUIState.stuartMode.test.js
+++ b/frontend/src/hooks/__tests__/useUIState.stuartMode.test.js
@@ -1,0 +1,32 @@
+// frontend/src/hooks/__tests__/useUIState.stuartMode.test.js
+import { renderHook, act } from '@testing-library/react';
+import { useUIState } from '../useUIState';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('stuartMode defaults to false', () => {
+  const { result } = renderHook(() => useUIState());
+  expect(result.current.stuartMode).toBe(false);
+});
+
+test('toggleStuartMode flips stuartMode', () => {
+  const { result } = renderHook(() => useUIState());
+  act(() => { result.current.toggleStuartMode(); });
+  expect(result.current.stuartMode).toBe(true);
+  act(() => { result.current.toggleStuartMode(); });
+  expect(result.current.stuartMode).toBe(false);
+});
+
+test('stuartMode persists to localStorage', () => {
+  const { result } = renderHook(() => useUIState());
+  act(() => { result.current.toggleStuartMode(); });
+  expect(localStorage.getItem('wgp_stuart_mode')).toBe('true');
+});
+
+test('stuartMode restores from localStorage on mount', () => {
+  localStorage.setItem('wgp_stuart_mode', 'true');
+  const { result } = renderHook(() => useUIState());
+  expect(result.current.stuartMode).toBe(true);
+});

--- a/frontend/src/hooks/useUIState.js
+++ b/frontend/src/hooks/useUIState.js
@@ -18,6 +18,9 @@ export function useUIState() {
   const [showSpecialActions, setShowSpecialActions] = useState(false);
   const [showUsageStats, setShowUsageStats] = useState(false);
   const [showAdvancedBetting, setShowAdvancedBetting] = useState(false);
+  const [stuartMode, setStuartMode] = useState(
+    () => localStorage.getItem('wgp_stuart_mode') === 'true'
+  );
   
   // Loading and error states
   const [submitting, setSubmitting] = useState(false);
@@ -84,6 +87,14 @@ export function useUIState() {
     setError(null);
   }, []);
 
+  const toggleStuartMode = useCallback(() => {
+    setStuartMode(prev => {
+      const next = !prev;
+      localStorage.setItem('wgp_stuart_mode', String(next));
+      return next;
+    });
+  }, []);
+
   /**
    * Set error with optional auto-clear
    */
@@ -140,6 +151,10 @@ export function useUIState() {
     isGameMarkedComplete,
     setIsGameMarkedComplete,
     
+    // Stuart Mode
+    stuartMode,
+    toggleStuartMode,
+
     // Actions
     toggleSection,
     startEditingPlayerName,

--- a/frontend/src/utils/__tests__/stuartModeInsights.test.js
+++ b/frontend/src/utils/__tests__/stuartModeInsights.test.js
@@ -1,0 +1,142 @@
+// frontend/src/utils/__tests__/stuartModeInsights.test.js
+import { computeThreatScore, generateInsights } from '../stuartModeInsights';
+
+describe('computeThreatScore', () => {
+  test('returns handicap minus full stroke', () => {
+    expect(computeThreatScore(8, 1)).toBe(7);
+  });
+
+  test('returns handicap minus half stroke (Creecher)', () => {
+    expect(computeThreatScore(8, 0.5)).toBe(7.5);
+  });
+
+  test('returns handicap when no strokes', () => {
+    expect(computeThreatScore(1, 0)).toBe(1);
+  });
+
+  test('handles double stroke', () => {
+    expect(computeThreatScore(20, 2)).toBe(18);
+  });
+});
+
+describe('generateInsights', () => {
+  const stuart = { id: 'p1', name: 'Stuart', handicap: 15, is_authenticated: true };
+  const steve  = { id: 'p2', name: 'Steve',  handicap: 1,  is_authenticated: false };
+  const dan    = { id: 'p3', name: 'Dan',    handicap: 12, is_authenticated: false };
+  const mike   = { id: 'p4', name: 'Mike',   handicap: 14, is_authenticated: false };
+
+  const baseParams = {
+    players: [stuart, steve, dan, mike],
+    currentHole: 5,
+    strokeAllocation: {
+      p1: { 5: 1 },
+      p2: { 5: 0 },
+      p3: { 5: 0 },
+      p4: { 5: 0 },
+    },
+    playerStandings: {
+      p1: { quarters: 0 },
+      p2: { quarters: 0 },
+      p3: { quarters: 0 },
+      p4: { quarters: 0 },
+    },
+    courseData: { holes: [{ hole_number: 5, handicap: 4 }] },
+    currentWager: 2,
+  };
+
+  test('returns required fields', () => {
+    const result = generateInsights(baseParams);
+    expect(result).toHaveProperty('headline');
+    expect(result).toHaveProperty('detail');
+    expect(result).toHaveProperty('threats');
+    expect(result).toHaveProperty('soloRecommendation');
+  });
+
+  test('soloRecommendation is go when Stuart has full stroke and no high-threat opponents', () => {
+    const params = {
+      ...baseParams,
+      players: [
+        stuart,
+        { id: 'p2', name: 'Bob', handicap: 18, is_authenticated: false },
+        { id: 'p3', name: 'Ted', handicap: 16, is_authenticated: false },
+      ],
+      strokeAllocation: { p1: { 5: 1 }, p2: { 5: 0 }, p3: { 5: 0 } },
+      playerStandings: {
+        p1: { quarters: 0 },
+        p2: { quarters: 0 },
+        p3: { quarters: 0 },
+      },
+    };
+    const result = generateInsights(params);
+    expect(result.soloRecommendation).toBe('go');
+  });
+
+  test('soloRecommendation is caution when Stuart has full stroke but Steve (1 hdcp) is high threat', () => {
+    const result = generateInsights(baseParams);
+    expect(result.soloRecommendation).toBe('caution');
+  });
+
+  test('soloRecommendation is avoid when Stuart has no stroke and high-threat opponent exists', () => {
+    const params = {
+      ...baseParams,
+      strokeAllocation: { p1: { 5: 0 }, p2: { 5: 0 }, p3: { 5: 0 }, p4: { 5: 0 } },
+    };
+    const result = generateInsights(params);
+    expect(result.soloRecommendation).toBe('avoid');
+  });
+
+  test('being down > 3q bumps soloRecommendation up one level (caution → go)', () => {
+    const params = {
+      ...baseParams,
+      playerStandings: {
+        p1: { quarters: -4 },
+        p2: { quarters: 2 },
+        p3: { quarters: 1 },
+        p4: { quarters: 1 },
+      },
+    };
+    const result = generateInsights(params);
+    expect(result.soloRecommendation).toBe('go');
+  });
+
+  test('threats array sorted lowest threatScore first', () => {
+    const result = generateInsights(baseParams);
+    const scores = result.threats.map(t => t.threatScore);
+    expect(scores).toEqual([...scores].sort((a, b) => a - b));
+  });
+
+  test('Creecher (0.5 stroke) is reflected in threatScore', () => {
+    const params = {
+      ...baseParams,
+      strokeAllocation: {
+        p1: { 5: 0.5 },
+        p2: { 5: 0 },
+        p3: { 5: 0 },
+        p4: { 5: 0 },
+      },
+    };
+    const result = generateInsights(params);
+    const stuartThreat = result.threats.find(t => t.player.id === 'p1');
+    expect(stuartThreat.threatScore).toBe(14.5);
+  });
+
+  test('headline mentions high-threat opponent by name', () => {
+    const result = generateInsights(baseParams);
+    expect(result.headline).toMatch(/Steve/);
+  });
+
+  test('hungry flag set for player who is down and is high threat', () => {
+    const params = {
+      ...baseParams,
+      playerStandings: {
+        p1: { quarters: 5 },
+        p2: { quarters: -5 },
+        p3: { quarters: 0 },
+        p4: { quarters: 0 },
+      },
+    };
+    const result = generateInsights(params);
+    const steveThreat = result.threats.find(t => t.player.id === 'p2');
+    expect(steveThreat.hungry).toBe(true);
+  });
+});

--- a/frontend/src/utils/__tests__/stuartModeInsights.test.js
+++ b/frontend/src/utils/__tests__/stuartModeInsights.test.js
@@ -163,4 +163,19 @@ describe('generateInsights', () => {
     const result = generateInsights(params);
     expect(result.soloRecommendation).toBe('caution');
   });
+
+  test('returns fallback when no authenticated player found', () => {
+    const params = {
+      players: [{ id: 'p1', name: 'Bob', handicap: 10, is_authenticated: false }],
+      currentHole: 1,
+      strokeAllocation: {},
+      playerStandings: {},
+      courseData: { holes: [] },
+      currentWager: 1,
+    };
+    const result = generateInsights(params);
+    expect(result.headline).toBe('No authenticated player found');
+    expect(result.threats).toEqual([]);
+    expect(result.soloRecommendation).toBe('caution');
+  });
 });

--- a/frontend/src/utils/__tests__/stuartModeInsights.test.js
+++ b/frontend/src/utils/__tests__/stuartModeInsights.test.js
@@ -139,4 +139,28 @@ describe('generateInsights', () => {
     const steveThreat = result.threats.find(t => t.player.id === 'p2');
     expect(steveThreat.hungry).toBe(true);
   });
+
+  test('soloRecommendation is caution when Stuart has Creecher and high-threat opponent exists', () => {
+    const params = {
+      ...baseParams,
+      strokeAllocation: { p1: { 5: 0.5 }, p2: { 5: 0 }, p3: { 5: 0 }, p4: { 5: 0 } },
+    };
+    const result = generateInsights(params);
+    expect(result.soloRecommendation).toBe('caution');
+  });
+
+  test('being down > 3q bumps soloRecommendation up one level (avoid → caution)', () => {
+    const params = {
+      ...baseParams,
+      strokeAllocation: { p1: { 5: 0 }, p2: { 5: 0 }, p3: { 5: 0 }, p4: { 5: 0 } },
+      playerStandings: {
+        p1: { quarters: -4 },
+        p2: { quarters: 0 },
+        p3: { quarters: 0 },
+        p4: { quarters: 0 },
+      },
+    };
+    const result = generateInsights(params);
+    expect(result.soloRecommendation).toBe('caution');
+  });
 });

--- a/frontend/src/utils/stuartModeInsights.js
+++ b/frontend/src/utils/stuartModeInsights.js
@@ -1,0 +1,135 @@
+// frontend/src/utils/stuartModeInsights.js
+
+/**
+ * Compute how dangerous a player is on a given hole.
+ * Lower = more dangerous. Full stroke = 1, Creecher half-stroke = 0.5.
+ */
+export function computeThreatScore(handicap, strokes) {
+  return handicap - strokes;
+}
+
+const HIGH_THREAT_THRESHOLD = 4;
+const QUARTERS_SWING_THRESHOLD = 3;
+
+/**
+ * Generate strategic insights for the authenticated player on the current hole.
+ *
+ * @param {Object} params
+ * @param {Array}  params.players           - All players: { id, name, handicap, is_authenticated }
+ * @param {number} params.currentHole       - Hole number (1–18)
+ * @param {Object} params.strokeAllocation  - { [playerId]: { [hole]: strokes } }
+ * @param {Object} params.playerStandings   - { [playerId]: { quarters } }
+ * @param {Object} params.courseData        - { holes: [{ hole_number, handicap }] }
+ * @param {number} params.currentWager      - Current wager in quarters
+ *
+ * @returns {{ headline, detail, threats, soloRecommendation }}
+ */
+export function generateInsights({
+  players,
+  currentHole,
+  strokeAllocation,
+  playerStandings,
+  courseData,
+  currentWager,
+}) {
+  const stuart = players.find(p => p.is_authenticated);
+  if (!stuart) {
+    return {
+      headline: 'No authenticated player found',
+      detail: '',
+      threats: [],
+      soloRecommendation: 'caution',
+    };
+  }
+
+  const strokeIndex = courseData?.holes?.find(h => h.hole_number === currentHole)?.handicap;
+
+  const threats = players.map(player => {
+    const strokes = strokeAllocation?.[player.id]?.[currentHole] ?? 0;
+    const threatScore = computeThreatScore(player.handicap, strokes);
+    const isHighThreat = !player.is_authenticated && threatScore <= HIGH_THREAT_THRESHOLD;
+    const quarters = playerStandings?.[player.id]?.quarters ?? 0;
+    const hungry = isHighThreat && quarters < -QUARTERS_SWING_THRESHOLD;
+
+    let strokeSituation;
+    if (strokes >= 1) strokeSituation = 'full';
+    else if (strokes >= 0.4) strokeSituation = 'creecher';
+    else strokeSituation = 'none';
+
+    return { player, threatScore, strokeSituation, isHighThreat, hungry, quarters };
+  }).sort((a, b) => a.threatScore - b.threatScore);
+
+  const stuartEntry = threats.find(t => t.player.is_authenticated);
+  const stuartStrokes = strokeAllocation?.[stuart.id]?.[currentHole] ?? 0;
+  const stuartQuarters = playerStandings?.[stuart.id]?.quarters ?? 0;
+  const highThreats = threats.filter(t => t.isHighThreat);
+
+  let soloRecommendation;
+  if (stuartStrokes >= 1 && highThreats.length === 0) {
+    soloRecommendation = 'go';
+  } else if (stuartStrokes >= 1 && highThreats.length > 0) {
+    soloRecommendation = 'caution';
+  } else if (stuartStrokes >= 0.4) {
+    soloRecommendation = highThreats.length > 0 ? 'caution' : 'go';
+  } else {
+    soloRecommendation = highThreats.length > 0 ? 'avoid' : 'caution';
+  }
+
+  if (stuartQuarters < -QUARTERS_SWING_THRESHOLD) {
+    if (soloRecommendation === 'caution') soloRecommendation = 'go';
+    else if (soloRecommendation === 'avoid') soloRecommendation = 'caution';
+  }
+
+  let headline;
+  if (highThreats.length > 0) {
+    const names = highThreats.map(t => t.player.name).join(' & ');
+    headline = `Watch out for ${names}`;
+  } else if (stuartStrokes >= 1) {
+    headline = 'Stroke advantage — you have the edge';
+  } else if (stuartEntry?.strokeSituation === 'creecher') {
+    headline = 'Creecher (½ stroke) — partial advantage';
+  } else if (strokeIndex && strokeIndex <= 6) {
+    headline = `Tough hole (SI ${strokeIndex}) — consider a partner`;
+  } else {
+    headline = 'Balanced hole — play your read';
+  }
+
+  const detailParts = [];
+
+  if (stuartStrokes >= 1) {
+    detailParts.push('You get a full stroke here.');
+  } else if (stuartStrokes >= 0.4) {
+    detailParts.push('You get the Creecher (½ stroke) here.');
+  } else {
+    detailParts.push('No stroke for you on this hole.');
+  }
+
+  highThreats.forEach(t => {
+    const strokeNote = t.strokeSituation === 'full'
+      ? 'also gets a stroke'
+      : t.strokeSituation === 'creecher'
+      ? 'gets the Creecher'
+      : 'gets no stroke';
+    detailParts.push(
+      `${t.player.name} is a ${t.player.handicap} hdcp (${strokeNote}) — high threat.`
+    );
+  });
+
+  if (stuartQuarters < -QUARTERS_SWING_THRESHOLD) {
+    detailParts.push(`You're down ${Math.abs(stuartQuarters)}q — higher-variance play makes sense.`);
+  } else if (stuartQuarters > QUARTERS_SWING_THRESHOLD) {
+    detailParts.push(`You're up ${stuartQuarters}q — a partner reduces risk.`);
+  }
+
+  const wagerNote = currentWager > 1 ? ` at ${currentWager}q` : '';
+  if (soloRecommendation === 'avoid' && strokeIndex && strokeIndex <= 6) {
+    detailParts.push(`Hard hole${wagerNote} — partnership cuts your exposure.`);
+  }
+
+  return {
+    headline,
+    detail: detailParts.join(' '),
+    threats,
+    soloRecommendation,
+  };
+}

--- a/frontend/src/utils/stuartModeInsights.js
+++ b/frontend/src/utils/stuartModeInsights.js
@@ -8,7 +8,7 @@ export function computeThreatScore(handicap, strokes) {
   return handicap - strokes;
 }
 
-const HIGH_THREAT_THRESHOLD = 4;
+const HIGH_THREAT_CEILING = 4;
 const QUARTERS_SWING_THRESHOLD = 3;
 
 /**
@@ -47,7 +47,7 @@ export function generateInsights({
   const threats = players.map(player => {
     const strokes = strokeAllocation?.[player.id]?.[currentHole] ?? 0;
     const threatScore = computeThreatScore(player.handicap, strokes);
-    const isHighThreat = !player.is_authenticated && threatScore <= HIGH_THREAT_THRESHOLD;
+    const isHighThreat = !player.is_authenticated && threatScore <= HIGH_THREAT_CEILING;
     const quarters = playerStandings?.[player.id]?.quarters ?? 0;
     const hungry = isHighThreat && quarters < -QUARTERS_SWING_THRESHOLD;
 
@@ -59,7 +59,6 @@ export function generateInsights({
     return { player, threatScore, strokeSituation, isHighThreat, hungry, quarters };
   }).sort((a, b) => a.threatScore - b.threatScore);
 
-  const stuartEntry = threats.find(t => t.player.is_authenticated);
   const stuartStrokes = strokeAllocation?.[stuart.id]?.[currentHole] ?? 0;
   const stuartQuarters = playerStandings?.[stuart.id]?.quarters ?? 0;
   const highThreats = threats.filter(t => t.isHighThreat);
@@ -86,7 +85,7 @@ export function generateInsights({
     headline = `Watch out for ${names}`;
   } else if (stuartStrokes >= 1) {
     headline = 'Stroke advantage — you have the edge';
-  } else if (stuartEntry?.strokeSituation === 'creecher') {
+  } else if (stuartStrokes >= 0.4 && stuartStrokes < 1) {
     headline = 'Creecher (½ stroke) — partial advantage';
   } else if (strokeIndex && strokeIndex <= 6) {
     headline = `Tough hole (SI ${strokeIndex}) — consider a partner`;


### PR DESCRIPTION
## Summary

- Adds a toggleable **Stuart Mode** panel that renders below the hole header during scoring, giving real-time, handicap-aware strategic advice hole by hole
- Computes a threat score per opponent (`handicap − strokes`) that accounts for full strokes and Creecher (½ stroke), so advice reflects actual skill matchups — not just who gets a stroke
- Panel shows a solo recommendation (Solo ✓ / ⚠ / ✗), a strategy tip with named threat callouts, and a live quarter standings strip with a "hungry" indicator for players who are down and dangerous

## Key files

- `frontend/src/utils/stuartModeInsights.js` — pure logic: threat scoring, tip generation, solo recommendation (16 tests)
- `frontend/src/components/game/scorekeeper/StuartModePanel.jsx` — display component: strategy tip card + standings strip
- `frontend/src/hooks/useUIState.js` — stuartMode toggle persisted to localStorage
- `frontend/src/components/game/SimpleScorekeeper.jsx` — toggle button + conditional panel render

## Test Plan

- [ ] Toggle button appears below the photo import link — panel shows below hole header when enabled
- [ ] Button turns amber and shows ON when active
- [ ] Strategy tip names high-threat opponents (low handicap players) and describes stroke situation
- [ ] Solo badge: green checkmark when stroke advantage + no threats, amber when threats present, red when no stroke + threats
- [ ] Creecher holes show partial advantage language
- [ ] Standings strip color-codes all players; hungry flag appears for players down >3q who are high threat
- [ ] Stuart Mode stays ON after page refresh (localStorage)
- [ ] Toggle off hides panel cleanly

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Stuart Mode: a toggleable strategy panel providing per-hole threat analysis and solo recommendations on the scoring screen.
  * Displays player standings with quarter deltas and identifies high-threat opponents.
  * Stuart Mode preference persists across sessions.

* **Tests**
  * Added comprehensive test coverage for Stuart Mode functionality.

* **Chores**
  * Updated Git configuration for worktree support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->