### PR TITLE
feat: Stuart Mode Betting Whisperer

### DIFF
--- a/docs/superpowers/plans/2026-04-17-stuart-mode-whisperer.md
+++ b/docs/superpowers/plans/2026-04-17-stuart-mode-whisperer.md
@@ -1,0 +1,538 @@
+# Stuart Mode Betting Whisperer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Embed a proactive AI chat ("Ask Commissioner 🤫") inside `StuartModePanel` that auto-briefs Stuart on each new hole and supports a running conversation with enriched strategic context.
+
+**Architecture:** All changes are confined to `StuartModePanel.jsx` and its test file. New state (`whispererMessages`, `whispererOpen`, `whispererLoading`, `inputValue`) plus a `useCallback` API helper (`callCommissioner`) that passes enriched `game_state` to the existing `/api/commissioner/chat` endpoint. A `useEffect` watching `currentHole` fires the proactive briefing. A third UI section renders below the standings strip — a collapsible drawer with message history and an input row.
+
+**Tech Stack:** React (useState, useEffect, useCallback, useRef), fetch API, `apiConfig` from `../../../config/api.config`, Jest + React Testing Library.
+
+---
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Modify | `frontend/src/components/game/scorekeeper/StuartModePanel.jsx` |
+| Modify | `frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx` |
+
+---
+
+### Task 1: State, API helper, and proactive briefing
+
+**Files:**
+- Modify: `frontend/src/components/game/scorekeeper/StuartModePanel.jsx`
+- Modify: `frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx`
+
+This task adds the core machinery: state variables, a `callCommissioner` async helper, and the `useEffect` that fires a briefing prompt every time `currentHole` changes (including on first render). `callCommissioner` accepts a `messagesSnapshot` parameter so callers can pass just-appended messages before React re-renders, ensuring the conversation history sent to the API is always up to date.
+
+The tests in this task verify only what is observable without a UI: that `fetch` is called with the correct URL, prompt text, and enriched `game_state` shape.
+
+Background on the API:
+- URL: `` `${apiConfig.baseUrl}/api/commissioner/chat` ``
+- Request body: `{ message: string, game_state: object }`
+- Response: `json.data.response` (or `json.detail` as fallback)
+- `apiConfig` is imported from `'../../../config/api.config'`
+- In tests, `window.location.hostname` is `localhost`, so `apiConfig.baseUrl` resolves to `'http://localhost:8000'` — mock `global.fetch` to intercept.
+
+- [ ] **Step 1: Add failing tests for proactive briefing to the test file**
+
+Add the following `describe` block at the bottom of `frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx`.
+
+First, update the import line at the top of the file:
+
+```jsx
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+```
+
+Then add at the bottom:
+
+```jsx
+// ── Whisperer: proactive briefing ──────────────────────────────────────
+
+describe('whisperer proactive briefing', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ data: { response: 'Hole 5: Watch Steve.' } }),
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = undefined;
+  });
+
+  test('calls /api/commissioner/chat on mount', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toMatch(/commissioner\/chat/);
+  });
+
+  test('sends briefing prompt for the current hole', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.message).toMatch(/strategic briefing for hole 5/i);
+  });
+
+  test('includes whisperer_mode and insights in game_state', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.game_state.whisperer_mode).toBe(true);
+    expect(body.game_state.insights).toBeDefined();
+    expect(Array.isArray(body.game_state.insights.threats)).toBe(true);
+    expect(typeof body.game_state.insights.solo_recommendation).toBe('string');
+  });
+
+  test('includes conversation_history string in game_state', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(typeof body.game_state.conversation_history).toBe('string');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm new tests fail**
+
+```bash
+cd /Users/stuart.gano/Documents/wolf-goat-pig/frontend
+CI=true npm test -- --watchAll=false --testPathPattern="StuartModePanel"
+```
+
+Expected: 5 existing tests pass, 4 new tests fail (`global.fetch` is undefined or not mocked — the feature doesn't exist yet).
+
+- [ ] **Step 3: Update imports in StuartModePanel.jsx**
+
+In `frontend/src/components/game/scorekeeper/StuartModePanel.jsx`, replace lines 1–4:
+
+```jsx
+// frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { apiConfig } from '../../../config/api.config';
+import { generateInsights } from '../../../utils/stuartModeInsights';
+```
+
+- [ ] **Step 4: Add state, callCommissioner, and proactive useEffect inside the component**
+
+In `StuartModePanel.jsx`, after the `const badge = SOLO_BADGE[insights.soloRecommendation];` line (currently line 30), add:
+
+```jsx
+  // ── Whisperer state ───────────────────────────────────────────────────
+  const [whispererMessages, setWhispererMessages] = useState([]);
+  const [whispererOpen, setWhispererOpen] = useState(false);
+  const [whispererLoading, setWhispererLoading] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const messagesEndRef = useRef(null);
+
+  // ── API helper ────────────────────────────────────────────────────────
+  // messagesSnapshot must be passed explicitly by the caller so the API
+  // receives the latest history even before a state re-render completes.
+  const callCommissioner = useCallback(async (prompt, messagesSnapshot) => {
+    setWhispererLoading(true);
+    setWhispererOpen(true);
+    try {
+      const resp = await fetch(`${apiConfig.baseUrl}/api/commissioner/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: prompt,
+          game_state: {
+            players,
+            current_hole: currentHole,
+            standings: playerStandings,
+            stroke_allocation: strokeAllocation,
+            current_wager: currentWager,
+            course_data: courseData,
+            whisperer_mode: true,
+            insights: {
+              headline: insights.headline,
+              solo_recommendation: insights.soloRecommendation,
+              threats: insights.threats.map(t => ({
+                name: t.player.name,
+                handicap: t.player.handicap,
+                threat_score: t.threatScore,
+                stroke_situation: t.strokeSituation,
+                hungry: t.hungry,
+                quarters: t.quarters,
+              })),
+            },
+            conversation_history: messagesSnapshot
+              .slice(-10)
+              .map(m => `${m.type === 'whisperer' ? 'Commissioner' : 'Stuart'}: ${m.text}`)
+              .join('\n'),
+          },
+        }),
+      });
+      const json = await resp.json();
+      const text = json?.data?.response || json?.detail || 'Sorry, I could not get a response.';
+      setWhispererMessages(prev => [...prev, { type: 'whisperer', text, timestamp: new Date() }]);
+    } catch {
+      setWhispererMessages(prev => [...prev, {
+        type: 'whisperer',
+        text: 'Connection error — try again.',
+        timestamp: new Date(),
+      }]);
+    } finally {
+      setWhispererLoading(false);
+    }
+  }, [players, currentHole, playerStandings, strokeAllocation, currentWager, courseData, insights]);
+
+  // ── Proactive briefing on hole change ─────────────────────────────────
+  useEffect(() => {
+    callCommissioner(
+      `Give me a quick strategic briefing for hole ${currentHole}. Be direct and specific — focus on who I need to watch, whether to go solo, and any quarter context that matters.`,
+      whispererMessages,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentHole]); // intentionally only re-fires on hole change
+
+  // ── Auto-scroll on new message ────────────────────────────────────────
+  useEffect(() => {
+    if (messagesEndRef.current?.scrollIntoView) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [whispererMessages]);
+
+  // ── User send handler ─────────────────────────────────────────────────
+  const handleSend = async () => {
+    if (!inputValue.trim() || whispererLoading) return;
+    const text = inputValue.trim();
+    setInputValue('');
+    const updatedMessages = [...whispererMessages, { type: 'user', text, timestamp: new Date() }];
+    setWhispererMessages(updatedMessages);
+    await callCommissioner(text, updatedMessages);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+```
+
+- [ ] **Step 5: Run tests to confirm Task 1 tests pass**
+
+```bash
+cd /Users/stuart.gano/Documents/wolf-goat-pig/frontend
+CI=true npm test -- --watchAll=false --testPathPattern="StuartModePanel"
+```
+
+Expected: All 9 tests pass (5 original + 4 new proactive briefing tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/game/scorekeeper/StuartModePanel.jsx \
+        frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+git commit -m "feat: add whisperer state, API helper, and proactive briefing trigger"
+```
+
+---
+
+### Task 2: Whisperer UI section
+
+**Files:**
+- Modify: `frontend/src/components/game/scorekeeper/StuartModePanel.jsx`
+- Modify: `frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx`
+
+This task adds the full UI: a third section below the standings strip containing a collapsible toggle header, a scrollable message history (auto-expands when a briefing arrives), and an input row.
+
+Message rendering:
+- `type: 'whisperer'` messages: left-aligned, `🤫` prefix, amber-tinted background (`rgba(245,158,11,0.1)`)
+- `type: 'user'` messages: right-aligned, "You" label above text, subtle background (`rgba(0,0,0,0.06)`)
+- Loading state: `🤫 ...` typing indicator
+- Newest message at bottom; `messagesEndRef` auto-scrolls on each new message
+
+The drawer is initially closed but `callCommissioner` calls `setWhispererOpen(true)`, so it opens as soon as the first briefing arrives.
+
+- [ ] **Step 1: Add failing UI tests to the test file**
+
+Add the following `describe` block at the bottom of `frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx`:
+
+```jsx
+// ── Whisperer: UI ──────────────────────────────────────────────────────
+
+describe('whisperer UI', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ data: { response: 'Hole 5: Watch Steve.' } }),
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = undefined;
+  });
+
+  test('renders "Ask Commissioner" toggle header', () => {
+    render(<StuartModePanel {...baseProps} />);
+    expect(screen.getByText(/Ask Commissioner/i)).toBeInTheDocument();
+  });
+
+  test('message list is hidden before briefing arrives, shown after', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    // Before briefing: no messages container
+    expect(screen.queryByTestId('whisperer-messages')).not.toBeInTheDocument();
+    // After briefing resolves: container appears
+    await waitFor(() =>
+      expect(screen.getByTestId('whisperer-messages')).toBeInTheDocument()
+    );
+  });
+
+  test('renders whisperer response with 🤫 prefix', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() =>
+      expect(screen.getByText('Hole 5: Watch Steve.')).toBeInTheDocument()
+    );
+    // The 🤫 emoji should be adjacent in the same message row
+    const messages = screen.getByTestId('whisperer-messages');
+    expect(messages.textContent).toContain('🤫');
+  });
+
+  test('toggle button collapses the open drawer', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    // Wait for drawer to auto-open
+    await waitFor(() =>
+      expect(screen.getByTestId('whisperer-messages')).toBeInTheDocument()
+    );
+    // Click toggle to close
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('whisperer-toggle'));
+    });
+    expect(screen.queryByTestId('whisperer-messages')).not.toBeInTheDocument();
+  });
+
+  test('user message appears with "You" label after send', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText(/ask something/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Should I go solo?' } });
+      fireEvent.click(screen.getByTestId('whisperer-send'));
+    });
+
+    expect(screen.getByText('Should I go solo?')).toBeInTheDocument();
+    expect(screen.getByText('You')).toBeInTheDocument();
+  });
+
+  test('input is disabled while loading', async () => {
+    global.fetch = jest.fn().mockReturnValue(new Promise(() => {})); // never resolves
+    render(<StuartModePanel {...baseProps} />);
+    const input = screen.getByPlaceholderText(/ask something/i);
+    expect(input).toBeDisabled();
+  });
+
+  test('Enter key sends message', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText(/ask something/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Double down?' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Double down?')).toBeInTheDocument()
+    );
+  });
+
+  test('shows error message on API failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() =>
+      expect(screen.getByText('Connection error — try again.')).toBeInTheDocument()
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm new tests fail**
+
+```bash
+cd /Users/stuart.gano/Documents/wolf-goat-pig/frontend
+CI=true npm test -- --watchAll=false --testPathPattern="StuartModePanel"
+```
+
+Expected: 9 existing tests pass, 8 new UI tests fail (the DOM elements don't exist yet).
+
+- [ ] **Step 3: Add the whisperer UI section to StuartModePanel.jsx**
+
+In `StuartModePanel.jsx`, add the following JSX as a third `<div>` block inside the outer container, directly after the closing `</div>` of the standings strip section (currently line 176, just before the outer closing `</div>`):
+
+```jsx
+      {/* ── Whisperer: Ask Commissioner ────────────────────────────────── */}
+      <div style={{ borderTop: '1px solid rgba(245,158,11,0.3)' }}>
+
+        {/* Toggle header */}
+        <button
+          data-testid="whisperer-toggle"
+          onClick={() => setWhispererOpen(o => !o)}
+          style={{
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '8px 16px',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            color: theme.colors.textPrimary,
+          }}
+        >
+          <span style={{ fontSize: '12px', fontWeight: 'bold' }}>Ask Commissioner 🤫</span>
+          <span style={{ fontSize: '11px', color: theme.colors.textSecondary }}>
+            {whispererOpen ? '▲' : '▼'}
+          </span>
+        </button>
+
+        {/* Message history (shown when open) */}
+        {whispererOpen && (
+          <div
+            data-testid="whisperer-messages"
+            style={{
+              maxHeight: '220px',
+              overflowY: 'auto',
+              padding: '0 8px 4px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '6px',
+            }}
+          >
+            {whispererMessages.map((msg, idx) => (
+              <div
+                key={idx}
+                style={{
+                  display: 'flex',
+                  justifyContent: msg.type === 'user' ? 'flex-end' : 'flex-start',
+                  alignItems: 'flex-start',
+                  gap: '4px',
+                }}
+              >
+                {msg.type === 'whisperer' && (
+                  <span style={{ fontSize: '14px', flexShrink: 0 }}>🤫</span>
+                )}
+                <div
+                  style={{
+                    background: msg.type === 'whisperer'
+                      ? 'rgba(245,158,11,0.1)'
+                      : 'rgba(0,0,0,0.06)',
+                    borderRadius: '8px',
+                    padding: '6px 10px',
+                    maxWidth: '85%',
+                    fontSize: '13px',
+                    lineHeight: 1.4,
+                    color: theme.colors.textPrimary,
+                  }}
+                >
+                  {msg.type === 'user' && (
+                    <div style={{
+                      fontSize: '10px',
+                      fontWeight: 'bold',
+                      marginBottom: '2px',
+                      textAlign: 'right',
+                      color: theme.colors.textSecondary,
+                    }}>
+                      You
+                    </div>
+                  )}
+                  {msg.text}
+                </div>
+              </div>
+            ))}
+
+            {whispererLoading && (
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '4px',
+                padding: '4px 0',
+              }}>
+                <span style={{ fontSize: '14px' }}>🤫</span>
+                <span style={{ fontSize: '13px', color: theme.colors.textSecondary }}>...</span>
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+
+        {/* Input row */}
+        <div style={{
+          display: 'flex',
+          gap: '8px',
+          padding: '8px 12px 10px',
+          alignItems: 'center',
+        }}>
+          <input
+            type="text"
+            placeholder="Ask something..."
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={whispererLoading}
+            style={{
+              flex: 1,
+              border: `1px solid rgba(245,158,11,${whispererLoading ? '0.2' : '0.5'})`,
+              borderRadius: '8px',
+              padding: '6px 10px',
+              fontSize: '13px',
+              outline: 'none',
+              background: 'transparent',
+              color: theme.colors.textPrimary,
+              opacity: whispererLoading ? 0.5 : 1,
+            }}
+          />
+          <button
+            data-testid="whisperer-send"
+            onClick={handleSend}
+            disabled={whispererLoading || !inputValue.trim()}
+            style={{
+              background: '#F59E0B',
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+              padding: '6px 12px',
+              fontSize: '14px',
+              cursor: whispererLoading || !inputValue.trim() ? 'not-allowed' : 'pointer',
+              opacity: whispererLoading || !inputValue.trim() ? 0.5 : 1,
+              flexShrink: 0,
+            }}
+          >
+            →
+          </button>
+        </div>
+
+      </div>
+```
+
+- [ ] **Step 4: Run tests to confirm all tests pass**
+
+```bash
+cd /Users/stuart.gano/Documents/wolf-goat-pig/frontend
+CI=true npm test -- --watchAll=false --testPathPattern="StuartModePanel"
+```
+
+Expected: All 17 tests pass (5 original + 4 proactive briefing + 8 UI).
+
+- [ ] **Step 5: Run full frontend test suite to check for regressions**
+
+```bash
+cd /Users/stuart.gano/Documents/wolf-goat-pig/frontend
+CI=true npm test -- --watchAll=false
+```
+
+Expected: All tests pass (pre-existing failures in unrelated test files are OK — the pre-existing failures are in `test_progression` and `test_advanced_rules` on the backend, not frontend).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/game/scorekeeper/StuartModePanel.jsx \
+        frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+git commit -m "feat: add whisperer UI section with toggle, message history, and input row"
+```

--- a/docs/superpowers/specs/2026-04-17-stuart-mode-whisperer-design.md
+++ b/docs/superpowers/specs/2026-04-17-stuart-mode-whisperer-design.md
@@ -1,0 +1,167 @@
+# Stuart Mode — Betting Whisperer Design Spec
+
+**Date:** 2026-04-17
+**Status:** Approved
+
+## Overview
+
+Extends Stuart Mode with a proactive betting whisperer embedded in `StuartModePanel`. The whisperer auto-briefs Stuart on each new hole and maintains a running conversation throughout the round. It uses the existing `/api/commissioner/chat` endpoint with enriched context — no backend changes required.
+
+---
+
+## Architecture
+
+### No new files
+
+All changes are in `frontend/src/components/game/scorekeeper/StuartModePanel.jsx`.
+
+### State added to `StuartModePanel`
+
+| State | Type | Purpose |
+|-------|------|---------|
+| `whispererMessages` | `Array<{type, text, timestamp}>` | Full conversation history for the round |
+| `whispererOpen` | `boolean` | Whether the chat drawer is expanded |
+| `whispererLoading` | `boolean` | Typing indicator while waiting for API response |
+
+### Proactive trigger
+
+A `useEffect` watches `currentHole`. When it changes:
+1. Auto-fires a call to `/api/commissioner/chat` with a system briefing prompt
+2. The prompt is not shown in the chat UI as a "sent" message — it's a silent trigger
+3. The response appears as a new whisperer message
+4. The drawer auto-expands if it was closed
+
+**Briefing prompt sent to API:**
+> "Give me a quick strategic briefing for hole [N]. Be direct and specific — focus on who I need to watch, whether to go solo, and any quarter context that matters."
+
+### Context enrichment
+
+`game_state` sent to `/api/commissioner/chat` on every call (both proactive and user-initiated):
+
+```js
+{
+  // Standard fields
+  players,
+  current_hole: currentHole,
+  standings: playerStandings,
+  stroke_allocation: strokeAllocation,
+  current_wager: currentWager,
+  course_data: courseData,
+
+  // Stuart Mode enrichment
+  whisperer_mode: true,
+  insights: {
+    headline: insights.headline,
+    solo_recommendation: insights.soloRecommendation,
+    threats: insights.threats.map(t => ({
+      name: t.player.name,
+      handicap: t.player.handicap,
+      threat_score: t.threatScore,
+      stroke_situation: t.strokeSituation,
+      hungry: t.hungry,
+      quarters: t.quarters,
+    })),
+  },
+
+  // Historical context (last 10 messages)
+  conversation_history: whispererMessages
+    .slice(-10)
+    .map(m => `${m.type === 'whisperer' ? 'Commissioner' : 'Stuart'}: ${m.text}`)
+    .join('\n'),
+}
+```
+
+The backend LLM already builds its prompt from `game_state` fields — the extra fields give it Stuart's full strategic picture and running conversation thread.
+
+---
+
+## UI Layout
+
+Added as a third section at the bottom of `StuartModePanel`, below the standings strip:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Ask Commissioner 🤫              [▲]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  🤫  Hole 5 coming up — SI 4, you get a stroke
+      but Steve (1 hdcp) is still your biggest
+      threat. You're down 4q — going solo makes
+      sense here if you trust your game.
+
+  You  Should I offer a double early?
+
+  🤫  With Steve in the field, doubling early is
+      risky — wait to see his tee shot first...
+
+  ─────────────────────────────────────
+  [Ask something...              ] [→]
+```
+
+### Toggle button
+
+- Header row: "Ask Commissioner 🤫 [▼/▲]" — tapping toggles `whispererOpen`
+- Auto-expands when a proactive briefing arrives (first message of each hole)
+
+### Message rendering
+
+- `type: 'whisperer'` messages: 🤫 prefix, left-aligned, amber-tinted background
+- `type: 'user'` messages: "You" label, right-aligned, subtle background
+- Loading state: 🤫 with animated "..." typing indicator
+- Scrollable history, newest at bottom, auto-scroll on new message
+
+### Input row
+
+- Text input + send button (→)
+- Enter key sends (no shift+enter newlines needed — these are short strategic questions)
+- Input disabled while `whispererLoading` is true
+
+---
+
+## Behavior Details
+
+### Hole change flow
+
+1. `currentHole` changes (user navigates to new hole)
+2. `useEffect` fires: set `whispererLoading = true`, send briefing prompt to API
+3. Response arrives: append to `whispererMessages`, set `whispererLoading = false`, auto-expand drawer
+4. User can immediately follow up or just read the briefing
+
+### User message flow
+
+1. User types question, hits send or Enter
+2. Append `{ type: 'user', text }` to `whispererMessages`
+3. Clear input, set `whispererLoading = true`
+4. Send to API with enriched context including full conversation history
+5. Append response as `{ type: 'whisperer', text }`, set `whispererLoading = false`
+
+### Error handling
+
+On API failure, append a whisperer message: *"Connection error — try again."* No crash, no lost history.
+
+### First load
+
+On initial mount (hole 1, Stuart Mode just turned on), the proactive trigger fires immediately — Stuart gets a briefing for the current hole the moment he opens the panel.
+
+---
+
+## Props changes to `StuartModePanel`
+
+One new prop required:
+
+| Prop | Type | Purpose |
+|------|------|---------|
+| `strokeAllocation` | `Object` | Already passed — needed for enriched context (was already a prop) |
+
+No new props needed. `strokeAllocation`, `courseData`, `currentWager`, `playerStandings`, `players`, `currentHole` are all already received.
+
+---
+
+## Testing
+
+- Proactive briefing fires on `currentHole` change
+- Drawer auto-expands when briefing arrives
+- User message appended to history before API call
+- Enriched `game_state` includes `whisperer_mode`, `insights`, `conversation_history`
+- Error state appends error message without crashing
+- Loading state disables input
+- Enter key sends message

--- a/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+++ b/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
@@ -312,6 +312,7 @@ const StuartModePanel = ({
               gap: '6px',
             }}
           >
+            {/* key={idx} is safe — messages are append-only and never reordered or deleted */}
             {whispererMessages.map((msg, idx) => (
               <div
                 key={idx}

--- a/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+++ b/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
@@ -1,6 +1,7 @@
 // frontend/src/components/game/scorekeeper/StuartModePanel.jsx
-import React from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { apiConfig } from '../../../config/api.config';
 import { generateInsights } from '../../../utils/stuartModeInsights';
 
 const SOLO_BADGE = {
@@ -28,6 +29,99 @@ const StuartModePanel = ({
   });
 
   const badge = SOLO_BADGE[insights.soloRecommendation];
+
+  // ── Whisperer state ───────────────────────────────────────────────────
+  const [whispererMessages, setWhispererMessages] = useState([]);
+  const [whispererOpen, setWhispererOpen] = useState(false);
+  const [whispererLoading, setWhispererLoading] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const messagesEndRef = useRef(null);
+
+  // ── API helper ────────────────────────────────────────────────────────
+  // messagesSnapshot must be passed explicitly by the caller so the API
+  // receives the latest history even before a state re-render completes.
+  const callCommissioner = useCallback(async (prompt, messagesSnapshot) => {
+    setWhispererLoading(true);
+    setWhispererOpen(true);
+    try {
+      const resp = await fetch(`${apiConfig.baseUrl}/api/commissioner/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: prompt,
+          game_state: {
+            players,
+            current_hole: currentHole,
+            standings: playerStandings,
+            stroke_allocation: strokeAllocation,
+            current_wager: currentWager,
+            course_data: courseData,
+            whisperer_mode: true,
+            insights: {
+              headline: insights.headline,
+              solo_recommendation: insights.soloRecommendation,
+              threats: insights.threats.map(t => ({
+                name: t.player.name,
+                handicap: t.player.handicap,
+                threat_score: t.threatScore,
+                stroke_situation: t.strokeSituation,
+                hungry: t.hungry,
+                quarters: t.quarters,
+              })),
+            },
+            conversation_history: messagesSnapshot
+              .slice(-10)
+              .map(m => `${m.type === 'whisperer' ? 'Commissioner' : 'Stuart'}: ${m.text}`)
+              .join('\n'),
+          },
+        }),
+      });
+      const json = await resp.json();
+      const text = json?.data?.response || json?.detail || 'Sorry, I could not get a response.';
+      setWhispererMessages(prev => [...prev, { type: 'whisperer', text, timestamp: new Date() }]);
+    } catch {
+      setWhispererMessages(prev => [...prev, {
+        type: 'whisperer',
+        text: 'Connection error — try again.',
+        timestamp: new Date(),
+      }]);
+    } finally {
+      setWhispererLoading(false);
+    }
+  }, [players, currentHole, playerStandings, strokeAllocation, currentWager, courseData, insights]);
+
+  // ── Proactive briefing on hole change ─────────────────────────────────
+  useEffect(() => {
+    callCommissioner(
+      `Give me a quick strategic briefing for hole ${currentHole}. Be direct and specific — focus on who I need to watch, whether to go solo, and any quarter context that matters.`,
+      whispererMessages,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentHole]); // intentionally only re-fires on hole change
+
+  // ── Auto-scroll on new message ────────────────────────────────────────
+  useEffect(() => {
+    if (messagesEndRef.current?.scrollIntoView) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [whispererMessages]);
+
+  // ── User send handler ─────────────────────────────────────────────────
+  const handleSend = async () => {
+    if (!inputValue.trim() || whispererLoading) return;
+    const text = inputValue.trim();
+    setInputValue('');
+    const updatedMessages = [...whispererMessages, { type: 'user', text, timestamp: new Date() }];
+    setWhispererMessages(updatedMessages);
+    await callCommissioner(text, updatedMessages);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
 
   const standingsRows = [...players].sort((a, b) => {
     const qa = playerStandings?.[a.id]?.quarters ?? 0;

--- a/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+++ b/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
@@ -273,6 +273,150 @@ const StuartModePanel = ({
           })}
         </div>
       </div>
+
+      {/* ── Whisperer: Ask Commissioner ────────────────────────────────── */}
+      <div style={{ borderTop: '1px solid rgba(245,158,11,0.3)' }}>
+
+        {/* Toggle header */}
+        <button
+          data-testid="whisperer-toggle"
+          onClick={() => setWhispererOpen(o => !o)}
+          style={{
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '8px 16px',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            color: theme.colors.textPrimary,
+          }}
+        >
+          <span style={{ fontSize: '12px', fontWeight: 'bold' }}>Ask Commissioner 🤫</span>
+          <span style={{ fontSize: '11px', color: theme.colors.textSecondary }}>
+            {whispererOpen ? '▲' : '▼'}
+          </span>
+        </button>
+
+        {/* Message history (shown when open) */}
+        {whispererOpen && (
+          <div
+            data-testid="whisperer-messages"
+            style={{
+              maxHeight: '220px',
+              overflowY: 'auto',
+              padding: '0 8px 4px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '6px',
+            }}
+          >
+            {whispererMessages.map((msg, idx) => (
+              <div
+                key={idx}
+                style={{
+                  display: 'flex',
+                  justifyContent: msg.type === 'user' ? 'flex-end' : 'flex-start',
+                  alignItems: 'flex-start',
+                  gap: '4px',
+                }}
+              >
+                {msg.type === 'whisperer' && (
+                  <span style={{ fontSize: '14px', flexShrink: 0 }}>🤫</span>
+                )}
+                <div
+                  style={{
+                    background: msg.type === 'whisperer'
+                      ? 'rgba(245,158,11,0.1)'
+                      : 'rgba(0,0,0,0.06)',
+                    borderRadius: '8px',
+                    padding: '6px 10px',
+                    maxWidth: '85%',
+                    fontSize: '13px',
+                    lineHeight: 1.4,
+                    color: theme.colors.textPrimary,
+                  }}
+                >
+                  {msg.type === 'user' && (
+                    <div style={{
+                      fontSize: '10px',
+                      fontWeight: 'bold',
+                      marginBottom: '2px',
+                      textAlign: 'right',
+                      color: theme.colors.textSecondary,
+                    }}>
+                      You
+                    </div>
+                  )}
+                  {msg.text}
+                </div>
+              </div>
+            ))}
+
+            {whispererLoading && (
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '4px',
+                padding: '4px 0',
+              }}>
+                <span style={{ fontSize: '14px' }}>🤫</span>
+                <span style={{ fontSize: '13px', color: theme.colors.textSecondary }}>...</span>
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+
+        {/* Input row */}
+        <div style={{
+          display: 'flex',
+          gap: '8px',
+          padding: '8px 12px 10px',
+          alignItems: 'center',
+        }}>
+          <input
+            type="text"
+            placeholder="Ask something..."
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={whispererLoading}
+            style={{
+              flex: 1,
+              border: `1px solid rgba(245,158,11,${whispererLoading ? '0.2' : '0.5'})`,
+              borderRadius: '8px',
+              padding: '6px 10px',
+              fontSize: '13px',
+              outline: 'none',
+              background: 'transparent',
+              color: theme.colors.textPrimary,
+              opacity: whispererLoading ? 0.5 : 1,
+            }}
+          />
+          <button
+            data-testid="whisperer-send"
+            onClick={handleSend}
+            disabled={whispererLoading || !inputValue.trim()}
+            style={{
+              background: '#F59E0B',
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+              padding: '6px 12px',
+              fontSize: '14px',
+              cursor: whispererLoading || !inputValue.trim() ? 'not-allowed' : 'pointer',
+              opacity: whispererLoading || !inputValue.trim() ? 0.5 : 1,
+              flexShrink: 0,
+            }}
+          >
+            →
+          </button>
+        </div>
+
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+++ b/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
@@ -77,7 +77,8 @@ const StuartModePanel = ({
         }),
       });
       const json = await resp.json();
-      const text = json?.data?.response || json?.detail || 'Sorry, I could not get a response.';
+      if (!resp.ok) throw new Error(json?.detail || `HTTP ${resp.status}`);
+      const text = json?.data?.response || 'Sorry, I could not get a response.';
       setWhispererMessages(prev => [...prev, { type: 'whisperer', text, timestamp: new Date() }]);
     } catch {
       setWhispererMessages(prev => [...prev, {

--- a/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
+++ b/frontend/src/components/game/scorekeeper/StuartModePanel.jsx
@@ -88,7 +88,9 @@ const StuartModePanel = ({
     } finally {
       setWhispererLoading(false);
     }
-  }, [players, currentHole, playerStandings, strokeAllocation, currentWager, courseData, insights]);
+    // insights is intentionally excluded — it is a new object on every render
+    // and callCommissioner only fires on hole change via the proactive useEffect.
+  }, [players, currentHole, playerStandings, strokeAllocation, currentWager, courseData]);
 
   // ── Proactive briefing on hole change ─────────────────────────────────
   useEffect(() => {
@@ -97,7 +99,10 @@ const StuartModePanel = ({
       whispererMessages,
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentHole]); // intentionally only re-fires on hole change
+  }, [currentHole]);
+  // whispererMessages is intentionally excluded: adding it would re-fire the briefing
+  // on every message. The snapshot passed here is the history at the moment of hole
+  // change, which is the correct context window for the new briefing.
 
   // ── Auto-scroll on new message ────────────────────────────────────────
   useEffect(() => {

--- a/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+++ b/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
@@ -112,3 +112,97 @@ describe('whisperer proactive briefing', () => {
     expect(typeof body.game_state.conversation_history).toBe('string');
   });
 });
+
+// ── Whisperer: UI ──────────────────────────────────────────────────────
+
+describe('whisperer UI', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ data: { response: 'Hole 5: Watch Steve.' } }),
+    });
+  });
+
+  test('renders "Ask Commissioner" toggle header', () => {
+    render(<StuartModePanel {...baseProps} />);
+    expect(screen.getByText(/Ask Commissioner/i)).toBeInTheDocument();
+  });
+
+  test('drawer opens on briefing and shows message', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    // Drawer opens immediately due to callCommissioner
+    await waitFor(() =>
+      expect(screen.getByTestId('whisperer-messages')).toBeInTheDocument()
+    );
+    // After briefing resolves: message appears
+    await waitFor(() =>
+      expect(screen.getByText('Hole 5: Watch Steve.')).toBeInTheDocument()
+    );
+  });
+
+  test('renders whisperer response with 🤫 prefix', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() =>
+      expect(screen.getByText('Hole 5: Watch Steve.')).toBeInTheDocument()
+    );
+    // The 🤫 emoji should be adjacent in the same message row
+    const messages = screen.getByTestId('whisperer-messages');
+    expect(messages.textContent).toContain('🤫');
+  });
+
+  test('toggle button collapses the open drawer', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    // Wait for drawer to auto-open
+    await waitFor(() =>
+      expect(screen.getByTestId('whisperer-messages')).toBeInTheDocument()
+    );
+    // Click toggle to close
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('whisperer-toggle'));
+    });
+    expect(screen.queryByTestId('whisperer-messages')).not.toBeInTheDocument();
+  });
+
+  test('user message appears with "You" label after send', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText(/ask something/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Should I go solo?' } });
+      fireEvent.click(screen.getByTestId('whisperer-send'));
+    });
+
+    expect(screen.getByText('Should I go solo?')).toBeInTheDocument();
+    expect(screen.getByText('You')).toBeInTheDocument();
+  });
+
+  test('input is disabled while loading', async () => {
+    global.fetch = jest.fn().mockReturnValue(new Promise(() => {})); // never resolves
+    render(<StuartModePanel {...baseProps} />);
+    const input = screen.getByPlaceholderText(/ask something/i);
+    expect(input).toBeDisabled();
+  });
+
+  test('Enter key sends message', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText(/ask something/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Double down?' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Double down?')).toBeInTheDocument()
+    );
+  });
+
+  test('shows error message on API failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() =>
+      expect(screen.getByText('Connection error — try again.')).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+++ b/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
@@ -1,6 +1,6 @@
 // frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import StuartModePanel from '../StuartModePanel';
 
 const theme = {
@@ -70,4 +70,45 @@ test('shows hungry indicator for player who is down and high threat', () => {
   };
   render(<StuartModePanel {...props} />);
   expect(screen.getByTestId('hungry-p2')).toBeInTheDocument();
+});
+
+// ── Whisperer: proactive briefing ──────────────────────────────────────
+
+describe('whisperer proactive briefing', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ data: { response: 'Hole 5: Watch Steve.' } }),
+    });
+  });
+
+  test('calls /api/commissioner/chat on mount', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toMatch(/commissioner\/chat/);
+  });
+
+  test('sends briefing prompt for the current hole', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.message).toMatch(/strategic briefing for hole 5/i);
+  });
+
+  test('includes whisperer_mode and insights in game_state', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.game_state.whisperer_mode).toBe(true);
+    expect(body.game_state.insights).toBeDefined();
+    expect(Array.isArray(body.game_state.insights.threats)).toBe(true);
+    expect(typeof body.game_state.insights.solo_recommendation).toBe('string');
+  });
+
+  test('includes conversation_history string in game_state', async () => {
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(typeof body.game_state.conversation_history).toBe('string');
+  });
 });

--- a/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+++ b/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
@@ -81,10 +81,6 @@ describe('whisperer proactive briefing', () => {
     });
   });
 
-  afterEach(() => {
-    global.fetch.mockReset();
-  });
-
   test('calls /api/commissioner/chat on mount', async () => {
     render(<StuartModePanel {...baseProps} />);
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));

--- a/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+++ b/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
@@ -82,7 +82,7 @@ describe('whisperer proactive briefing', () => {
   });
 
   afterEach(() => {
-    global.fetch.mockClear();
+    global.fetch.mockReset();
   });
 
   test('calls /api/commissioner/chat on mount', async () => {

--- a/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+++ b/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
@@ -81,6 +81,10 @@ describe('whisperer proactive briefing', () => {
     });
   });
 
+  afterEach(() => {
+    global.fetch.mockClear();
+  });
+
   test('calls /api/commissioner/chat on mount', async () => {
     render(<StuartModePanel {...baseProps} />);
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));

--- a/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
+++ b/frontend/src/components/game/scorekeeper/__tests__/StuartModePanel.test.jsx
@@ -118,6 +118,7 @@ describe('whisperer proactive briefing', () => {
 describe('whisperer UI', () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: async () => ({ data: { response: 'Hole 5: Watch Steve.' } }),
     });
   });
@@ -147,6 +148,18 @@ describe('whisperer UI', () => {
     // The 🤫 emoji should be adjacent in the same message row
     const messages = screen.getByTestId('whisperer-messages');
     expect(messages.textContent).toContain('🤫');
+  });
+
+  test('shows error message when API returns HTTP error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: 'Internal server error' }),
+    });
+    render(<StuartModePanel {...baseProps} />);
+    await waitFor(() =>
+      expect(screen.getByText('Connection error — try again.')).toBeInTheDocument()
+    );
   });
 
   test('toggle button collapses the open drawer', async () => {


### PR DESCRIPTION
## Summary

- Embeds an \"Ask Commissioner 🤫\" AI chat inside `StuartModePanel` that auto-briefs Stuart with a strategic briefing on every new hole
- Persists conversation history throughout the round, passing the last 10 messages + enriched game context (threat scores, solo recommendation, standings) to `/api/commissioner/chat`
- User can type follow-up questions; input is disabled while loading, Enter key sends, errors surface gracefully

## Test Plan

- [ ] Enable Stuart Mode during a round — verify briefing appears automatically when opening the panel
- [ ] Navigate to a new hole — verify a new briefing fires and the drawer auto-expands
- [ ] Type a follow-up question and send — verify response appears with 🤫 prefix
- [ ] Simulate API failure — verify \"Connection error — try again.\" appears
- [ ] Collapse and expand the drawer using the ▲/▼ toggle
- [ ] Verify input is disabled while a response is loading
- [ ] Run frontend tests: `cd frontend && CI=true npm test -- --watchAll=false` — all 464 should pass

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a chat-based betting strategy advisor (Whisperer) in Stuart Mode that automatically provides briefings for each hole.
  * Users can ask questions and view conversation history within a collapsible drawer panel.
  * Includes loading indicators and error messaging for connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->