### PR TITLE
fix: two silent-failure bugs surfaced by the test consolidation

### DIFF
--- a/backend/app/schemas/courses.py
+++ b/backend/app/schemas/courses.py
@@ -92,21 +92,22 @@ class CourseUpdate(BaseModel):
     @field_validator("holes")
     @classmethod
     def validate_holes_update(cls, v):
+        # An update may be a PARTIAL subset of holes (the router merges them and
+        # preserves the rest), so we validate only what a partial payload can see:
+        # at least one hole, no more than 18, with in-range, unique hole numbers.
+        # The full-course invariants (exactly 18 holes, all handicaps unique 1-18,
+        # total par 70-74) belong to CourseCreate, which sees the whole course.
         if v is not None:
-            if len(v) != 18:
-                raise ValueError("Course must have exactly 18 holes")
-
-            handicaps = [hole.handicap for hole in v]
-            if len(set(handicaps)) != 18:
-                raise ValueError("All handicaps must be unique (1-18)")
+            if not v:
+                raise ValueError("holes update must include at least one hole")
+            if len(v) > 18:
+                raise ValueError("Course cannot have more than 18 holes")
 
             hole_numbers = [hole.hole_number for hole in v]
-            if sorted(hole_numbers) != list(range(1, 19)):
-                raise ValueError("Hole numbers must be 1-18 and unique")
-
-            total_par = sum(hole.par for hole in v)
-            if not 70 <= total_par <= 74:
-                raise ValueError("Total par must be between 70 and 74")
+            if not all(1 <= n <= 18 for n in hole_numbers):
+                raise ValueError("Hole numbers must be between 1 and 18")
+            if len(set(hole_numbers)) != len(hole_numbers):
+                raise ValueError("Hole numbers must be unique")
 
         return v
 

--- a/backend/app/services/sheet_integration_service.py
+++ b/backend/app/services/sheet_integration_service.py
@@ -295,7 +295,7 @@ class SheetIntegrationService:
                         player = PlayerProfile(
                             name=player_name,
                             handicap=data.get("handicap", 18.0),
-                            created_date=utc_now().isoformat(),
+                            created_at=utc_now().isoformat(),
                             is_active=1,
                         )
                         self.db.add(player)

--- a/backend/tests/unit/routers/test_courses_router.py
+++ b/backend/tests/unit/routers/test_courses_router.py
@@ -1,6 +1,5 @@
 """Unit tests for courses router — list, get, create, delete."""
 
-import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -78,14 +77,6 @@ class TestUpdateCoursePreservesHoles:
         assert course is not None, "course was not created"
         return {h.hole_number: h for h in db.query(models.Hole).filter(models.Hole.course_id == course.id).all()}
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="CourseUpdate.validate_holes_update (app/schemas/courses.py:96) "
-        "rejects a partial <18-hole PUT with 422, blocking the router's partial-merge "
-        "preservation logic (app/routers/courses.py:364-402). The schema validator "
-        "regressed the intended behavior the router still implements. Remove this "
-        "marker once the validator permits a partial (1-17) hole subset.",
-    )
     def test_partial_update_preserves_other_holes(self):
         # Clean slate in case a previous run left this course behind.
         client.delete(f"/courses/{self._NAME}")

--- a/backend/tests/unit/services/test_sheet_integration_service.py
+++ b/backend/tests/unit/services/test_sheet_integration_service.py
@@ -28,16 +28,6 @@ def db():
         Base.metadata.drop_all(bind=engine)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Blocked by a production bug: SheetIntegrationService line ~298 passes "
-        "created_date= to PlayerProfile, which only has created_at -> TypeError on "
-        "every player creation (swallowed by the per-row savepoint). No valid player "
-        "can persist until created_date->created_at is fixed. This xfail flips to "
-        "XPASS (forcing its own removal) the moment that one-line fix lands."
-    ),
-)
 def test_one_bad_row_does_not_abort_the_sync(db):
     sheet_data = [
         {


### PR DESCRIPTION
## Summary

Fixes the two production bugs that #254 surfaced (each was guarded there by a strict-xfail). This PR turns both xfails into **live green guards** — no test was weakened.

**Stacked on #254** (base = `chore/test-infra-consolidation`) because the guard tests live there. Retarget to `main` once #254 merges.

## Fix 1 — sheet sync silently created zero players
`SheetIntegrationService` constructed `PlayerProfile(created_date=...)`, but the model only has `created_at` → `TypeError` on every creation, swallowed by the per-row savepoint. One-line rename `created_date` → `created_at`. The salvaged regression (`test_one_bad_row_does_not_abort_the_sync`) now passes as a live guard of per-row savepoint isolation.

## Fix 2 — partial course updates returned 422
`CourseUpdate.validate_holes_update` required exactly 18 holes, so any partial `PUT /courses/{name}` was rejected and the router's partial-merge preservation logic was dead code. Relaxed the validator to validate only what a partial payload can see (≥1, ≤18, in-range unique hole numbers); the full-course invariants (exactly 18, all handicaps unique, total par 70–74) remain on `CourseCreate`. `CourseUpdate` is consumed only by this one endpoint. `test_partial_update_preserves_other_holes` now passes as a live guard.

## Test plan
- [x] Both guard tests pass for real (no longer xfail)
- [x] Full backend gate: `ruff check`/`format` clean, `pytest` → **1299 passed, 0 xfailed** (was 1297 + 2 xfailed); 1 local failure is the known SOCKS `startup_test`, green in CI
- [x] All course + sheet tests pass (27); validator relaxation broke nothing
- [x] `CourseCreate` full-18 rules unchanged

⚠️ Merges to `main` auto-deploy (Render + Vercel). Fix 2 changes API validation semantics for `PUT /courses/{name}` (now accepts partial hole lists).

This pull request and its description were written by Isaac.