### PR TITLE
test: integration tests for external services (contract + live)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -61,7 +61,9 @@ jobs:
     - name: Run Ruff linting and format check
       run: |
         cd backend
-        pip install ruff
+        # Pin ruff so the format gate is deterministic — a floating `pip install
+        # ruff` lets any new release reformat code and break unrelated PRs.
+        pip install -r requirements-testing.txt
         ruff check app/ tests/
         ruff format --check app/ tests/
     

--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -1,0 +1,43 @@
+name: Live External Integration Tests
+
+# Manual only (Phase 1). Scheduled runs + alerting are Phase 2.
+on:
+  workflow_dispatch:
+
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-testing.txt
+      - name: Run live external suite (skips any service without secrets)
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GROQ_MODEL: ${{ secrets.GROQ_MODEL }}
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          AUTH0_API_AUDIENCE: ${{ secrets.AUTH0_API_AUDIENCE }}
+          GROUPME_ACCESS_TOKEN: ${{ secrets.GROUPME_ACCESS_TOKEN }}
+          GROUPME_GROUP_ID: ${{ secrets.GROUPME_GROUP_ID }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          GHIN_API_USER: ${{ secrets.GHIN_API_USER }}
+          GHIN_API_PASS: ${{ secrets.GHIN_API_PASS }}
+          GHIN_API_STATIC_TOKEN: ${{ secrets.GHIN_API_STATIC_TOKEN }}
+          ENABLE_GHIN_INTEGRATION: ${{ secrets.ENABLE_GHIN_INTEGRATION }}
+          LIVE_TEST_GHIN_ID: ${{ secrets.LIVE_TEST_GHIN_ID }}
+          FORETEES_ENABLED: ${{ secrets.FORETEES_ENABLED }}
+          FORETEES_USERNAME: ${{ secrets.FORETEES_USERNAME }}
+          FORETEES_PASSWORD: ${{ secrets.FORETEES_PASSWORD }}
+          GOOGLE_OAUTH_CREDENTIALS: ${{ secrets.GOOGLE_OAUTH_CREDENTIALS }}
+          LIVE_TEST_SHEET_ID: ${{ secrets.LIVE_TEST_SHEET_ID }}
+          LIVE_TEST_TEE_SHEET: ${{ secrets.LIVE_TEST_TEE_SHEET }}
+        run: |
+          python -m pytest tests/live -v -m live

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -117,5 +117,6 @@ norecursedirs = ["_diagnostic", "manual", "integration"]
 pythonpath = ["../.ctk"]
 markers = [
     "integration: tests that require external services or long-running setup",
+    "live: hits real external APIs; requires credentials; run on-demand only",
 ]
-addopts = "-ra -m \"not integration\""
+addopts = "-ra -m \"not integration and not live\""

--- a/backend/requirements-testing.txt
+++ b/backend/requirements-testing.txt
@@ -9,7 +9,7 @@ playwright
 pytest-playwright
 mypy>=1.8.0
 types-requests>=2.31.0
-ruff>=0.11.0
+ruff==0.14.8
 types-python-dateutil>=2.8.0
 respx>=0.21.1
 responses>=0.25.0

--- a/backend/requirements-testing.txt
+++ b/backend/requirements-testing.txt
@@ -11,3 +11,5 @@ mypy>=1.8.0
 types-requests>=2.31.0
 ruff>=0.11.0
 types-python-dateutil>=2.8.0
+respx>=0.21.1
+responses>=0.25.0

--- a/backend/tests/contract/conftest.py
+++ b/backend/tests/contract/conftest.py
@@ -1,0 +1,14 @@
+"""Shared fixtures for contract tests.
+
+Contract tests mock every external HTTP boundary; nothing here should make a
+real network call. Each test module uses `respx` (httpx) or `responses`
+(requests) to intercept its service's endpoint.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    # pytest-asyncio uses this; keep async contract tests on asyncio.
+    return "asyncio"

--- a/backend/tests/contract/conftest.py
+++ b/backend/tests/contract/conftest.py
@@ -7,6 +7,27 @@ real network call. Each test module uses `respx` (httpx) or `responses`
 
 import pytest
 
+# Proxy env vars that httpx honors when constructing a client. Contract tests
+# mock all I/O, so a real proxy must never be involved; on machines behind a
+# SOCKS proxy (e.g. the local sandbox) an unset `socksio` dep otherwise makes
+# httpx raise at client construction — the same failure mode as the documented
+# local-only startup_test. CI has no proxy, so this is a no-op there.
+_PROXY_ENV_VARS = (
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_proxy_for_contract_tests(monkeypatch):
+    """Ensure httpx clients in contract tests never pick up a real proxy."""
+    for var in _PROXY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/contract/test_auth0_contract.py
+++ b/backend/tests/contract/test_auth0_contract.py
@@ -1,0 +1,108 @@
+"""Contract tests for the Auth0 integration (JWT verification).
+
+Mocks the tenant's JWKS endpoint at the httpx boundary and verifies
+`AuthService.verify_token` fetches+uses the JWKS, rejects bad tokens, and
+surfaces JWKS-fetch failures.
+
+`verify_token(credentials)` is a FastAPI dependency taking
+`HTTPAuthorizationCredentials`; the JWKS path only runs when
+`ENVIRONMENT == "production"`. It does a *sync* `httpx.get` to the JWKS URL,
+calls `raise_for_status()`, `resp.json()`, then `jwt.decode(...)`.
+
+Behavior pinned to what the code actually does (read auth_service.py):
+- bogus token (no matching key) -> jose raises JWTError, caught -> HTTPException 401
+- missing config in production  -> HTTPException 500 (raised directly)
+- JWKS 500 -> `raise_for_status()` -> httpx.HTTPStatusError (NOT caught -> propagates)
+- JWKS timeout -> httpx.ConnectTimeout (propagates)
+- malformed JWKS body -> `resp.json()` -> json.JSONDecodeError (propagates)
+
+The `except` in verify_token only catches JWTError, so JWKS fetch/parse
+failures propagate as their raw httpx/json types — mirroring how the Groq
+reference pins httpx.ConnectTimeout / json.JSONDecodeError rather than a
+wrapped type.
+
+`ENVIRONMENT` is read live via os.getenv inside the function (setenv works),
+but `AUTH0_DOMAIN`/`AUTH0_API_AUDIENCE` are module-level constants captured at
+import — they must be patched via monkeypatch.setattr on the module, not setenv.
+"""
+
+import json
+
+import httpx
+import pytest
+import respx
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.services import auth_service as auth_service_module
+
+DOMAIN = "test.example.com"
+AUDIENCE = "https://api.test/"
+JWKS_URL = f"https://{DOMAIN}/.well-known/jwks.json"
+
+# Success-shape JWKS: a single RSA signing key. A bogus token can't be validated
+# against this (no matching kid / signature), which is the correct rejection.
+_JWKS_BODY = {"keys": [{"kid": "test", "kty": "RSA", "use": "sig", "n": "abc", "e": "AQAB"}]}
+
+# Syntactically-bogus bearer token (not a real JWT).
+BOGUS_TOKEN = "not.a.realtoken"
+
+
+def _creds(token: str = BOGUS_TOKEN) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+@pytest.fixture
+def _production_auth0(monkeypatch):
+    """Put verify_token on the production JWKS path with valid-looking config."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(auth_service_module, "AUTH0_DOMAIN", DOMAIN)
+    monkeypatch.setattr(auth_service_module, "AUTH0_API_AUDIENCE", AUDIENCE)
+
+
+@respx.mock
+def test_success_shape_jwks_bogus_token_raises_401(_production_auth0):
+    # JWKS fetch succeeds; the bogus token can't be validated -> jose JWTError
+    # -> caught -> HTTPException 401. Proves we fetch+use the JWKS and reject.
+    respx.get(JWKS_URL).mock(return_value=httpx.Response(200, json=_JWKS_BODY))
+    with pytest.raises(HTTPException) as exc:
+        auth_service_module.AuthService.verify_token(_creds())
+    assert exc.value.status_code == 401
+
+
+@respx.mock
+def test_jwks_endpoint_500_raises(_production_auth0):
+    # resp.raise_for_status() fires before decode; only JWTError is caught, so
+    # this propagates as a raw httpx.HTTPStatusError (would be an unhandled 500).
+    respx.get(JWKS_URL).mock(return_value=httpx.Response(500))
+    with pytest.raises(httpx.HTTPStatusError):
+        auth_service_module.AuthService.verify_token(_creds())
+
+
+@respx.mock
+def test_jwks_timeout_raises(_production_auth0):
+    # Pin the injected type: a bare Exception would green-wash a client-build
+    # failure (e.g. local SOCKS proxy) instead of asserting the timeout path.
+    respx.get(JWKS_URL).mock(side_effect=httpx.ConnectTimeout("x"))
+    with pytest.raises(httpx.ConnectTimeout):
+        auth_service_module.AuthService.verify_token(_creds())
+
+
+@respx.mock
+def test_malformed_jwks_body_raises(_production_auth0):
+    # resp.json() on a non-JSON 200 body raises JSONDecodeError before decode.
+    respx.get(JWKS_URL).mock(return_value=httpx.Response(200, text="not json"))
+    with pytest.raises(json.JSONDecodeError):
+        auth_service_module.AuthService.verify_token(_creds())
+
+
+def test_missing_config_raises_500(monkeypatch):
+    # Production branch with no domain configured -> the guard raises directly.
+    # AUTH0_DOMAIN is a module constant captured at import, so clear it via
+    # setattr (delenv on the env var can't touch the already-captured value).
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(auth_service_module, "AUTH0_DOMAIN", "")
+    monkeypatch.setattr(auth_service_module, "AUTH0_API_AUDIENCE", "")
+    with pytest.raises(HTTPException) as exc:
+        auth_service_module.AuthService.verify_token(_creds())
+    assert exc.value.status_code == 500

--- a/backend/tests/contract/test_foretees_contract.py
+++ b/backend/tests/contract/test_foretees_contract.py
@@ -1,0 +1,143 @@
+"""Contract tests for the ForeTees integration (Wing Point tee-time auth).
+
+Mocks the multi-step login handshake at the httpx boundary and verifies
+`ForeteesService._ensure_session()` drives its real success/failure branches.
+
+The login flow (foretees_service._ensure_session) makes FOUR HTTP calls:
+1. GET  https://www.wingpointgolf.com/public/member-login-465.html  (login page)
+2. POST https://www.wingpointgolf.com/public/member-login-465.html  (credentials)
+3. GET  https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html
+        (tee page — must embed `ftSSOKey = '...'` and `ftSSOIV = '...'`)
+4. GET  {base_url}/Member_select?sso_uid=...&sso_iv=...  (SSO → JSESSIONID)
+
+Success requires both SSO markers in the tee page (single-quoted — the regex
+is `ftSSOKey\\s*=\\s*'([^']+)'`); the JSESSIONID cookie check is best-effort and
+returns True regardless. Every error branch (HTTPStatusError, RequestError,
+bare Exception) is swallowed and returns `False` — never raises. Because we
+cannot pin a raised exception type, we assert `route.called` to prove the
+False came from the real error branch (not a client-construction failure that
+never exercised the handler), mirroring the "specific type" guard the other
+contract modules use.
+"""
+
+import httpx
+import pytest
+import respx
+
+from app.services.foretees_service import (
+    FORETEES_APP_BASE,
+    ForeteesConfig,
+    ForeteesService,
+)
+
+LOGIN_URL = "https://www.wingpointgolf.com/public/member-login-465.html"
+TEE_PAGE_URL = "https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html"
+SSO_URL_PREFIX = f"{FORETEES_APP_BASE}/Member_select"
+
+# Tee page with both SSO markers — single quotes, both keys present, so the
+# `if not sso_key_match or not sso_iv_match` guard passes and login succeeds.
+TEE_PAGE_OK_HTML = (
+    "<html><body><script>var ftSSOKey = 'sso-key-abc123'; var ftSSOIV = 'sso-iv-def456';</script></body></html>"
+)
+
+# Tee page WITHOUT the SSO markers — drives the bad-credentials failure branch
+# ("Could not find ftSSOKey/ftSSOIV") which returns False.
+TEE_PAGE_BAD_HTML = "<html><body><p>Invalid username or password.</p></body></html>"
+
+
+def _config(enabled: bool = True) -> ForeteesConfig:
+    return ForeteesConfig(
+        enabled=enabled,
+        username="u",
+        password="p",
+        base_url=FORETEES_APP_BASE,
+        timeout_seconds=15.0,
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_successful_login_establishes_session():
+    respx.get(LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>login</html>"))
+    respx.post(LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>ok</html>"))
+    respx.get(TEE_PAGE_URL).mock(return_value=httpx.Response(200, text=TEE_PAGE_OK_HTML))
+    respx.get(url__startswith=SSO_URL_PREFIX).mock(return_value=httpx.Response(200, text="<html>sso</html>"))
+
+    service = ForeteesService(_config())
+    try:
+        ok = await service._ensure_session()
+        assert ok is True
+        assert service._session_valid() is True
+    finally:
+        await service.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_failed_login_bad_credentials_returns_false():
+    # Login page + POST succeed, but the tee page lacks the SSO markers, so the
+    # handshake can't complete. No crash, returns False, session not valid.
+    respx.get(LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>login</html>"))
+    respx.post(LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>ok</html>"))
+    tee_route = respx.get(TEE_PAGE_URL).mock(return_value=httpx.Response(200, text=TEE_PAGE_BAD_HTML))
+
+    service = ForeteesService(_config())
+    try:
+        ok = await service._ensure_session()
+        assert ok is False
+        assert service._session_valid() is False
+        # The boundary was hit — the False came from the missing-marker branch,
+        # not from a client-construction failure that never ran the handler.
+        assert tee_route.called is True
+    finally:
+        await service.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_non_200_from_login_returns_false():
+    # raise_for_status() on the login GET → HTTPStatusError → swallowed → False.
+    login_route = respx.get(LOGIN_URL).mock(return_value=httpx.Response(500, text="boom"))
+
+    service = ForeteesService(_config())
+    try:
+        ok = await service._ensure_session()
+        assert ok is False
+        assert service._session_valid() is False
+        assert login_route.called is True
+    finally:
+        await service.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_timeout_during_login_returns_false():
+    # ConnectTimeout is an httpx.RequestError → swallowed → False.
+    login_route = respx.get(LOGIN_URL).mock(side_effect=httpx.ConnectTimeout("timed out"))
+
+    service = ForeteesService(_config())
+    try:
+        ok = await service._ensure_session()
+        assert ok is False
+        assert service._session_valid() is False
+        assert login_route.called is True
+    finally:
+        await service.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_disabled_config_short_circuits_without_http():
+    # enabled=False: the guard at the top of _ensure_session returns False
+    # before any HTTP call is made.
+    login_route = respx.get(LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>login</html>"))
+
+    service = ForeteesService(_config(enabled=False))
+    try:
+        ok = await service._ensure_session()
+        assert ok is False
+        assert service._session_valid() is False
+        # No HTTP boundary touched — the short-circuit fired first.
+        assert login_route.called is False
+    finally:
+        await service.close()

--- a/backend/tests/contract/test_ghin_contract.py
+++ b/backend/tests/contract/test_ghin_contract.py
@@ -1,0 +1,140 @@
+"""Contract tests for the GHIN integration (handicap sync).
+
+Mocks api2.ghin.com at the httpx boundary and verifies GHINService.initialize()
+handles success, bad-creds (401), server error (500), connection timeout, and
+missing credentials.
+
+Unlike the Groq reference, GHINService NEVER raises on failure: every error
+path is swallowed by a broad `except` / status-code guard and returns ``False``
+with ``self.initialized = False``. So all error cases assert the *same* shape
+(``is False``) and must additionally pin *which* code path fired (did the HTTP
+request actually happen?) — otherwise a client-construction failure or the
+missing-creds short-circuit would green-wash a test that proves nothing.
+
+IMPORTANT: credentials are read in ``__init__`` (``os.getenv``), not in
+``initialize()``. So env must be set/unset BEFORE constructing the service.
+"""
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.services.ghin_service import GHINService
+
+GHIN_LOGIN_URL = "https://api2.ghin.com/api/v1/golfer_login.json"
+FAKE_TOKEN = "fake-golfer-user-token-abc123"
+
+TEST_DATABASE_URL = "sqlite:///./test_ghin_contract.db"
+engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db():
+    """Minimal sqlite Session so GHINService(db) can be constructed."""
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def _login_ok_body(token: str = FAKE_TOKEN) -> dict:
+    # Real-shaped GHIN login body: token at golfer_user.golfer_user_token.
+    return {
+        "golfer_user": {
+            "golfer_user_token": token,
+            "id": 12345,
+            "email": "golfer@example.com",
+        }
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_success_login_authenticates(monkeypatch, db):
+    monkeypatch.setenv("GHIN_API_USER", "golfer@example.com")
+    monkeypatch.setenv("GHIN_API_PASS", "secret")
+    route = respx.post(GHIN_LOGIN_URL).mock(return_value=httpx.Response(200, json=_login_ok_body()))
+
+    service = GHINService(db)  # reads creds from env in __init__
+    ok = await service.initialize()
+
+    assert ok is True
+    assert route.called  # the login request actually fired
+    assert service.initialized is True
+    # Prove the golfer_user.golfer_user_token extraction ran.
+    assert service.jwt_token == FAKE_TOKEN
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bad_creds_401_disables_gracefully(monkeypatch, db):
+    monkeypatch.setenv("GHIN_API_USER", "golfer@example.com")
+    monkeypatch.setenv("GHIN_API_PASS", "wrong")
+    route = respx.post(GHIN_LOGIN_URL).mock(return_value=httpx.Response(401, json={"error": "invalid"}))
+
+    service = GHINService(db)
+    ok = await service.initialize()
+
+    # Real behavior: status != 200 → log + return False, no raise.
+    assert ok is False
+    assert route.called  # not the missing-creds short-circuit
+    assert service.initialized is False
+    assert service.jwt_token is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_error_500_disables_gracefully(monkeypatch, db):
+    monkeypatch.setenv("GHIN_API_USER", "golfer@example.com")
+    monkeypatch.setenv("GHIN_API_PASS", "secret")
+    route = respx.post(GHIN_LOGIN_URL).mock(return_value=httpx.Response(500, json={"error": "boom"}))
+
+    service = GHINService(db)
+    ok = await service.initialize()
+
+    assert ok is False
+    assert route.called
+    assert service.initialized is False
+    assert service.jwt_token is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_connect_timeout_disables_gracefully(monkeypatch, db):
+    monkeypatch.setenv("GHIN_API_USER", "golfer@example.com")
+    monkeypatch.setenv("GHIN_API_PASS", "secret")
+    route = respx.post(GHIN_LOGIN_URL).mock(side_effect=httpx.ConnectTimeout("timed out"))
+
+    service = GHINService(db)
+    ok = await service.initialize()
+
+    # Broad `except Exception` swallows the timeout → False (no raise).
+    assert ok is False
+    assert route.called  # the request was attempted before timing out
+    assert service.initialized is False
+    assert service.jwt_token is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_missing_creds_disables_without_http_call(monkeypatch, db):
+    monkeypatch.delenv("GHIN_API_USER", raising=False)
+    monkeypatch.delenv("GHIN_API_PASS", raising=False)
+    # Register the route but expect it to be untouched: the guard must
+    # short-circuit before any httpx call.
+    route = respx.post(GHIN_LOGIN_URL).mock(return_value=httpx.Response(200, json=_login_ok_body()))
+
+    service = GHINService(db)  # __init__ sees no creds
+    ok = await service.initialize()
+
+    assert ok is False
+    assert route.call_count == 0  # no network attempt at all
+    assert service.initialized is False
+    assert service.jwt_token is None

--- a/backend/tests/contract/test_google_contract.py
+++ b/backend/tests/contract/test_google_contract.py
@@ -1,0 +1,220 @@
+"""Contract tests for the Google Sheets integration (leaderboard / round sync).
+
+The Google read client lives in ``app/services/spreadsheet_sync_service.py``.
+Unlike the other six reference services, it talks to Google over the stdlib
+``urllib.request`` — NOT httpx or requests. So respx/responses are useless here;
+the correct seam is ``monkeypatch.setattr("urllib.request.urlopen", fake)``,
+which the module reaches via ``import urllib.request``.
+
+urllib specifics that drive the mocking strategy:
+- ``urlopen`` RAISES ``HTTPError`` on 4xx/5xx (it does not return a status), so
+  the 401/403/500 cases must *raise*, not return a fake response. Only success
+  and malformed-body return a fake.
+- The success read hits ``urlopen`` TWICE: token exchange at
+  ``oauth2.googleapis.com/token`` (because ``GOOGLE_OAUTH_CREDENTIALS`` is set),
+  then the values read at ``sheets.googleapis.com``. One fake branches on URL.
+- ``urlopen`` is used as a context manager whose ``.read()`` returns bytes.
+
+Real behavior being pinned: EVERY read failure (401, 403, 500, timeout,
+malformed body) is swallowed by the broad ``except Exception`` in
+``_sheets_api_get`` → returns ``None`` → ``get_all_rounds`` returns ``[]``. There
+is NO refresh-retry on 401 — an expired token is observationally identical to
+an empty sheet. We pin that as-is (and flag it as a real silent-masking concern)
+and additionally assert the sheets request actually fired, so the no-token
+short-circuit can't green-wash a test that proves nothing.
+"""
+
+import json
+import urllib.error
+
+import pytest
+
+from app.services.spreadsheet_sync_service import SpreadsheetSyncService
+
+OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+SHEETS_HOST = "https://sheets.googleapis.com/"
+FAKE_ACCESS_TOKEN = "fake-access-token-xyz"
+
+# Real-shaped Google credentials blob; presence routes _get_access_token through
+# the patched urlopen (token exchange) rather than the gcloud CLI fallback.
+FAKE_OAUTH_CREDS = json.dumps(
+    {
+        "refresh_token": "fake-refresh-token",
+        "client_id": "fake-client-id.apps.googleusercontent.com",
+        "client_secret": "fake-client-secret",
+    }
+)
+
+
+class _FakeResponse:
+    """Context-manager stand-in for an http.client.HTTPResponse."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url=SHEETS_HOST, code=code, msg="error", hdrs={}, fp=None)
+
+
+class _UrlopenRecorder:
+    """A fake urlopen that branches on the request URL.
+
+    Records every URL it sees so tests can assert which boundary fired (token
+    exchange vs. sheets read) and detect the no-token short-circuit.
+    """
+
+    def __init__(self, *, sheets_result):
+        # sheets_result: either bytes to return, or an Exception to raise.
+        self.sheets_result = sheets_result
+        self.urls: list[str] = []
+
+    def __call__(self, req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        self.urls.append(url)
+
+        if url.startswith(OAUTH_TOKEN_URL):
+            return _FakeResponse(json.dumps({"access_token": FAKE_ACCESS_TOKEN}).encode())
+
+        if url.startswith(SHEETS_HOST):
+            if isinstance(self.sheets_result, Exception):
+                raise self.sheets_result
+            return _FakeResponse(self.sheets_result)
+
+        raise AssertionError(f"unexpected URL hit real network: {url}")
+
+    @property
+    def token_called(self) -> bool:
+        return any(u.startswith(OAUTH_TOKEN_URL) for u in self.urls)
+
+    @property
+    def sheets_called(self) -> bool:
+        return any(u.startswith(SHEETS_HOST) for u in self.urls)
+
+
+@pytest.fixture
+def with_creds(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CREDENTIALS", FAKE_OAUTH_CREDS)
+
+
+def test_success_returns_parsed_rounds(monkeypatch, with_creds):
+    # Real-shaped Sheets values response for the Details!A2:F range.
+    body = json.dumps(
+        {
+            "range": "Details!A2:F5000",
+            "majorDimension": "ROWS",
+            "values": [
+                ["21-Jul", "A", "Stu", "153", "Wing Point", "3:55:00"],
+                ["21-Jul", "A", "Tony", "-153", "Wing Point", "3:55:00"],
+            ],
+        }
+    ).encode()
+    fake = _UrlopenRecorder(sheets_result=body)
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    # Both boundaries fired: token exchange then values read.
+    assert fake.token_called
+    assert fake.sheets_called
+    # Parsed into RoundResult objects with correct field extraction.
+    assert len(rounds) == 2
+    assert rounds[0].date == "21-Jul"
+    assert rounds[0].member == "Stu"
+    assert rounds[0].score == 153
+    assert rounds[0].location == "Wing Point"
+    assert rounds[0].duration == "3:55:00"
+    assert rounds[1].member == "Tony"
+    assert rounds[1].score == -153
+
+
+def test_expired_token_401_swallowed_no_retry(monkeypatch, with_creds):
+    # urllib raises HTTPError(401); the broad except swallows it. There is NO
+    # refresh-retry — a single sheets request fires, then [] is returned.
+    fake = _UrlopenRecorder(sheets_result=_http_error(401))
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    assert rounds == []
+    assert fake.sheets_called  # the read was attempted, not short-circuited
+    # No retry: exactly one sheets call (plus the one token exchange).
+    assert sum(u.startswith(SHEETS_HOST) for u in fake.urls) == 1
+
+
+def test_forbidden_403_swallowed(monkeypatch, with_creds):
+    fake = _UrlopenRecorder(sheets_result=_http_error(403))
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    assert rounds == []
+    assert fake.sheets_called
+
+
+def test_server_error_500_swallowed(monkeypatch, with_creds):
+    fake = _UrlopenRecorder(sheets_result=_http_error(500))
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    assert rounds == []
+    assert fake.sheets_called
+
+
+def test_timeout_swallowed(monkeypatch, with_creds):
+    fake = _UrlopenRecorder(sheets_result=TimeoutError("read timed out"))
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    assert rounds == []
+    assert fake.sheets_called  # request attempted before timing out
+
+
+def test_malformed_body_swallowed(monkeypatch, with_creds):
+    # 200 OK but body is not valid JSON → json.loads raises → swallowed → [].
+    fake = _UrlopenRecorder(sheets_result=b"<html>not json</html>")
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    assert rounds == []
+    assert fake.sheets_called
+
+
+def test_valid_json_without_values_key_returns_empty(monkeypatch, with_creds):
+    # 200 OK, valid JSON, but no "values" key (empty sheet shape).
+    fake = _UrlopenRecorder(sheets_result=json.dumps({"range": "Details!A2:F5000"}).encode())
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    assert rounds == []
+    assert fake.sheets_called
+
+
+def test_no_token_short_circuits_without_sheets_call(monkeypatch):
+    # No GOOGLE_OAUTH_CREDENTIALS and gcloud fallback neutralized → no token →
+    # _sheets_api_get returns None before any sheets request → [].
+    monkeypatch.delenv("GOOGLE_OAUTH_CREDENTIALS", raising=False)
+    monkeypatch.setattr(
+        "app.services.spreadsheet_sync_service._get_access_token",
+        lambda: None,
+    )
+    fake = _UrlopenRecorder(sheets_result=b'{"values": [["x"]]}')
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+    rounds = SpreadsheetSyncService("sheet-id").get_all_rounds()
+
+    assert rounds == []
+    assert fake.sheets_called is False  # short-circuited; no network at all

--- a/backend/tests/contract/test_groq_contract.py
+++ b/backend/tests/contract/test_groq_contract.py
@@ -1,0 +1,93 @@
+"""Contract tests for the Groq integration (Commissioner chat).
+
+Mocks api.groq.com at the httpx boundary and verifies _llm_generate handles
+success, auth failure, rate limit, server error, timeout, and malformed JSON.
+
+`_llm_generate(prompt, system_instruction)` takes two strings (NOT a messages
+list) and returns the assistant message *content string*. Error paths raise:
+ValueError for the missing-key/429/non-200 branches; httpx/JSON exceptions
+propagate for timeout/malformed-JSON.
+"""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from app.routers import commissioner
+
+GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
+PROMPT = "hi"
+SYSTEM = "be brief"
+
+
+def _ok_body(content: str = "Hello from Groq") -> dict:
+    # OpenAI-compatible shape Groq returns.
+    return {
+        "id": "chatcmpl-test",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": content}}],
+        "usage": {"total_tokens": 3},
+    }
+
+
+def _err_body(message: str) -> dict:
+    # Groq's real error envelope: nested error.message.
+    return {"error": {"message": message, "type": "invalid_request_error"}}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_success_returns_usable_content(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    respx.post(GROQ_URL).mock(return_value=httpx.Response(200, json=_ok_body("pong")))
+    result = await commissioner._llm_generate(PROMPT, SYSTEM)
+    assert "pong" in (result if isinstance(result, str) else str(result))
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        await commissioner._llm_generate(PROMPT, SYSTEM)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_rate_limit_429_raises(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    respx.post(GROQ_URL).mock(return_value=httpx.Response(429, json=_err_body("rate")))
+    with pytest.raises(ValueError):
+        await commissioner._llm_generate(PROMPT, SYSTEM)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_error_500_raises(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    respx.post(GROQ_URL).mock(return_value=httpx.Response(500, json=_err_body("boom")))
+    with pytest.raises(ValueError):
+        await commissioner._llm_generate(PROMPT, SYSTEM)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_timeout_raises(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    respx.post(GROQ_URL).mock(side_effect=httpx.ConnectTimeout("timed out"))
+    # Specific type: a bare `Exception` here would silently green-wash an
+    # ImportError if the httpx client failed to build (e.g. local SOCKS proxy),
+    # asserting nothing about the timeout path. Pin to the injected type.
+    with pytest.raises(httpx.ConnectTimeout):
+        await commissioner._llm_generate(PROMPT, SYSTEM)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_malformed_json_raises(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    respx.post(GROQ_URL).mock(return_value=httpx.Response(200, text="not json"))
+    # Specific type: assert the JSON-decode path actually fired (resp.json() on
+    # the 200 body), not just "some exception".
+    with pytest.raises(json.JSONDecodeError):
+        await commissioner._llm_generate(PROMPT, SYSTEM)

--- a/backend/tests/contract/test_groupme_contract.py
+++ b/backend/tests/contract/test_groupme_contract.py
@@ -1,0 +1,150 @@
+"""Contract tests for the GroupMe integration (league chat bridge, read side).
+
+`groupme_service._api_get` performs its GET with the **stdlib**
+`urllib.request.urlopen` (NOT httpx, NOT requests), so neither respx nor the
+`responses` library intercepts it. We mock at that seam: patch
+`urllib.request.urlopen` to return a fake response object (`.read()` ->
+bytes, context-manager protocol) or to raise the real exception type.
+
+GroupMe wraps payloads as ``{"response": <payload>, "meta": {"code": <int>}}``;
+`_api_get` returns ``parsed.get("response")``. `list_groups()` maps each group
+to ``{"id", "name", "members": <count>}`` and returns ``[]`` when the payload
+is falsy.
+
+Behaviors pinned here (verified against the real code):
+- success            -> list of mapped groups
+- missing `response` -> `_api_get` returns None -> `list_groups()` -> []
+- 401 / 500          -> urlopen raises urllib.error.HTTPError; `list_groups`
+                        does NOT catch it, so it propagates
+- timeout            -> urlopen raises TimeoutError (socket timeout); propagates
+- malformed (non-JSON) body -> json.loads raises json.JSONDecodeError; propagates
+- missing token      -> `_token()` is None -> `_api_get` raises RuntimeError
+"""
+
+import io
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from app.services import groupme_service
+
+GROUPS_OK = {
+    "response": [{"id": "123", "name": "LivSOW 2026", "members": [{"id": "m1"}]}],
+    "meta": {"code": 200},
+}
+
+
+class _FakeResp:
+    """Minimal stand-in for the urlopen() context-manager response."""
+
+    def __init__(self, body: str):
+        self._body = body.encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+def _patch_urlopen(monkeypatch, *, body: str | None = None, exc: BaseException | None = None):
+    """Intercept the stdlib HTTP fetch that _api_get uses."""
+
+    def fake_urlopen(req, timeout=None):
+        if exc is not None:
+            raise exc
+        return _FakeResp(body if body is not None else "")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+
+def test_success_returns_visible_group(monkeypatch):
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "test-token")
+    _patch_urlopen(monkeypatch, body=json.dumps(GROUPS_OK))
+
+    groups = groupme_service.list_groups()
+
+    assert isinstance(groups, list)
+    assert {"id": groups[0]["id"], "name": groups[0]["name"]} == {
+        "id": "123",
+        "name": "LivSOW 2026",
+    }
+    # list_groups maps the members array to a count.
+    assert groups[0]["members"] == 1
+
+
+def test_missing_response_key_returns_empty(monkeypatch):
+    # GroupMe envelope without a `response` payload -> _api_get returns None
+    # -> list_groups() coalesces to []. Pin this graceful-empty behavior.
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "test-token")
+    _patch_urlopen(monkeypatch, body=json.dumps({"meta": {"code": 200}}))
+
+    assert groupme_service.list_groups() == []
+
+
+def test_unauthorized_401_propagates(monkeypatch):
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "test-token")
+    err = urllib.error.HTTPError(
+        url="https://api.groupme.com/v3/groups",
+        code=401,
+        msg="Unauthorized",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(b'{"meta": {"code": 401, "errors": ["unauthorized"]}}'),
+    )
+    _patch_urlopen(monkeypatch, exc=err)
+
+    # list_groups() does not catch HTTPError (only get_messages does), so the
+    # 401 surfaces to the caller. Assert the specific type + code.
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        groupme_service.list_groups()
+    assert excinfo.value.code == 401
+
+
+def test_server_error_500_propagates(monkeypatch):
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "test-token")
+    err = urllib.error.HTTPError(
+        url="https://api.groupme.com/v3/groups",
+        code=500,
+        msg="Internal Server Error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(b"server error"),
+    )
+    _patch_urlopen(monkeypatch, exc=err)
+
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        groupme_service.list_groups()
+    assert excinfo.value.code == 500
+
+
+def test_timeout_propagates(monkeypatch):
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "test-token")
+    # urlopen(timeout=15) raises a socket timeout (TimeoutError subclass) on
+    # timeout. Specific type: a bare Exception would green-wash an unrelated
+    # construction error.
+    _patch_urlopen(monkeypatch, exc=TimeoutError("timed out"))
+
+    with pytest.raises(TimeoutError):
+        groupme_service.list_groups()
+
+
+def test_malformed_body_raises_json_error(monkeypatch):
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "test-token")
+    # Non-JSON 200 body -> json.loads(...) in _api_get raises. Assert the
+    # decode path actually fired, not just "some exception".
+    _patch_urlopen(monkeypatch, body="not json at all")
+
+    with pytest.raises(json.JSONDecodeError):
+        groupme_service.list_groups()
+
+
+def test_missing_token_raises_runtime_error(monkeypatch):
+    monkeypatch.delenv("GROUPME_ACCESS_TOKEN", raising=False)
+    # No HTTP should happen: _token() is None so _api_get raises before any
+    # urlopen call.
+    with pytest.raises(RuntimeError, match="GROUPME_ACCESS_TOKEN not configured"):
+        groupme_service.list_groups()

--- a/backend/tests/contract/test_resend_contract.py
+++ b/backend/tests/contract/test_resend_contract.py
@@ -1,0 +1,71 @@
+"""Contract tests for the Resend email integration.
+
+Resend sends via the `resend` Python SDK (`resend.Emails.send(params)`), so we
+mock at that SDK seam rather than the HTTP boundary. Tests exercise the
+provider directly (`ResendEmailProvider.send_email`), the analog of testing the
+Groq provider seam.
+
+Key interface facts (read from resend_provider.py):
+- `send_email(...)` returns a plain `bool` — it discards the SDK return value,
+  so success is `True` (NOT the email id) and any exception is swallowed
+  (`except Exception: return False`).
+- `is_configured()` checks the module global `resend.api_key` (set in
+  `__init__`) AND `self.from_email` — it does NOT read the `RESEND_API_KEY`
+  env var. The env var only gates the factory `create_resend_provider()`.
+"""
+
+import resend
+
+from app.services.providers.resend_provider import (
+    ResendEmailProvider,
+    create_resend_provider,
+)
+
+
+def test_success_returns_true(monkeypatch):
+    # Constructor sets resend.api_key, so is_configured() passes without env.
+    provider = ResendEmailProvider(api_key="test-key", from_email="t@example.com", from_name="T")
+    monkeypatch.setattr(resend.Emails, "send", lambda params: {"id": "email_123"})
+
+    # Pin to True, not the id: the provider returns a bool, discarding the SDK result.
+    assert provider.send_email("to@example.com", "Subj", "<p>hi</p>") is True
+
+
+def test_provider_error_swallowed_returns_false(monkeypatch):
+    provider = ResendEmailProvider(api_key="test-key", from_email="t@example.com", from_name="T")
+
+    def _boom(params):
+        raise Exception("resend: invalid API key")
+
+    monkeypatch.setattr(resend.Emails, "send", _boom)
+
+    # Broad except Exception -> return False is the intended design for email:
+    # a failed send must not crash the calling request.
+    assert provider.send_email("to@example.com", "Subj", "<p>hi</p>") is False
+
+
+def test_not_configured_provider_is_noop(monkeypatch):
+    # resend.api_key is a module global that leaks across tests; null it so a
+    # prior test's key cannot mask the falsy path.
+    monkeypatch.setattr(resend, "api_key", None)
+    provider = ResendEmailProvider(api_key="", from_email="", from_name="T")
+
+    sent = {"called": False}
+
+    def _spy(params):
+        sent["called"] = True
+        return {"id": "should_not_happen"}
+
+    monkeypatch.setattr(resend.Emails, "send", _spy)
+
+    assert provider.is_configured() is False
+    assert provider.send_email("to@example.com", "Subj", "<p>hi</p>") is False
+    # Prove the no-op: send must never be attempted when unconfigured.
+    assert sent["called"] is False
+
+
+def test_factory_returns_none_without_api_key(monkeypatch):
+    # The env var is the real gate at the factory layer (not at is_configured).
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setenv("FROM_EMAIL", "t@example.com")
+    assert create_resend_provider() is None

--- a/backend/tests/contract/test_tee_sheet_contract.py
+++ b/backend/tests/contract/test_tee_sheet_contract.py
@@ -1,0 +1,89 @@
+"""Contract tests for the thousand-cranes.com WGP tee-sheet integration.
+
+Mocks the thousand-cranes.com CGI endpoint at the httpx boundary and verifies
+`tee_sheet.get_tee_sheet` parses the real page shape and maps failures to the
+contract our callers rely on.
+
+`get_tee_sheet(date)` is async, GETs wgp_tee_sheet.cgi, runs the HTML through
+`_parse_slots`, and returns a dict:
+    {"date", "slots", "signed_up_count", "signed_up"}.
+On httpx.HTTPStatusError (raise_for_status) or any connection error it raises
+HTTPException(status_code=502). The success HTML below mirrors what the parser
+expects: each occupied slot is a `<tr><td align="center">N</td>...` row whose
+name lives in a `color:#001bbf` span and notes in a `color:#800000` span.
+"""
+
+import httpx
+import pytest
+import respx
+from fastapi import HTTPException
+
+from app.routers import tee_sheet
+
+DATE = "2026-06-15"
+
+# Realistic fragment: slot 1 occupied (name + notes), slot 2 empty. The
+# `<tr><td align="center">` must be literally adjacent — the row regex has no
+# wildcard there even under DOTALL, so a stray newline would kill the match.
+SLOTS_HTML = (
+    "<html><body><table>"
+    '<tr><td align="center">1</td>'
+    '<td><span style="color:#001bbf;font-weight:bold">John Doe</span></td>'
+    '<td><span style="color:#800000">Guest</span></td></tr>'
+    '<tr><td align="center">2</td><td>&nbsp;</td><td>&nbsp;</td></tr>'
+    "</table></body></html>"
+)
+
+# Valid page, no sign-up rows the parser recognizes.
+EMPTY_HTML = "<html><body><table><tr><th>No signups yet</th></tr></table></body></html>"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_success_parses_slots():
+    respx.get(url__startswith="https://thousand-cranes.com").mock(return_value=httpx.Response(200, text=SLOTS_HTML))
+    result = await tee_sheet.get_tee_sheet(date=DATE)
+
+    assert result["date"] == DATE
+    # Both slots parsed (one occupied, one empty placeholder).
+    occupied = [s for s in result["slots"] if s["name"]]
+    assert len(occupied) == 1
+    slot = occupied[0]
+    assert slot["slot"] == 1
+    assert slot["name"] == "John Doe"
+    assert slot["notes"] == "Guest"
+    # Derived fields stay consistent with the parsed slots.
+    assert result["signed_up_count"] == 1
+    assert result["signed_up"] == occupied
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_empty_but_valid_page_returns_no_signups():
+    respx.get(url__startswith="https://thousand-cranes.com").mock(return_value=httpx.Response(200, text=EMPTY_HTML))
+    result = await tee_sheet.get_tee_sheet(date=DATE)
+
+    assert result["slots"] == []
+    assert result["signed_up"] == []
+    assert result["signed_up_count"] == 0
+
+
+@pytest.mark.asyncio
+@respx.mock
+@pytest.mark.parametrize("status", [502, 500])
+async def test_upstream_http_error_maps_to_502(status):
+    respx.get(url__startswith="https://thousand-cranes.com").mock(return_value=httpx.Response(status))
+    with pytest.raises(HTTPException) as exc_info:
+        await tee_sheet.get_tee_sheet(date=DATE)
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_connection_error_maps_to_502():
+    respx.get(url__startswith="https://thousand-cranes.com").mock(side_effect=httpx.ConnectError("no route to host"))
+    # Pin to HTTPException(502), not a bare Exception: a bare assert would
+    # green-wash a client-construction failure that never exercised the handler.
+    with pytest.raises(HTTPException) as exc_info:
+        await tee_sheet.get_tee_sheet(date=DATE)
+    assert exc_info.value.status_code == 502

--- a/backend/tests/live/_helpers.py
+++ b/backend/tests/live/_helpers.py
@@ -1,0 +1,18 @@
+"""Helpers for the live external-service suite."""
+
+import os
+
+import pytest
+
+
+def require_env(*names: str) -> dict[str, str]:
+    """Return the requested env vars, or skip the test if any is missing/empty.
+
+    Usage:
+        env = require_env("GROQ_API_KEY")
+        key = env["GROQ_API_KEY"]
+    """
+    missing = [n for n in names if not os.environ.get(n)]
+    if missing:
+        pytest.skip(f"live: not configured (missing {', '.join(missing)})")
+    return {n: os.environ[n] for n in names}

--- a/backend/tests/live/conftest.py
+++ b/backend/tests/live/conftest.py
@@ -1,0 +1,15 @@
+"""Fixtures for the live external-service suite.
+
+Every test here is marked `live` and hits a REAL external API, read-only.
+Tests skip (never fail) when their service's credentials/targets are absent
+(see _helpers.require_env), so a partial or empty credential set runs cleanly.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mark_all_live(request):
+    # Defense in depth: ensure everything in tests/live is treated as live
+    # even if a module forgets the module-level marker.
+    request.node.add_marker(pytest.mark.live)

--- a/backend/tests/live/test_auth0_live.py
+++ b/backend/tests/live/test_auth0_live.py
@@ -1,0 +1,20 @@
+"""Live probe for Auth0: the tenant's JWKS endpoint is reachable and serves
+signing keys. Skips unless AUTH0_DOMAIN is set. Read-only."""
+
+import httpx
+import pytest
+from ctk import expect
+
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+
+def test_auth0_jwks_reachable():
+    env = require_env("AUTH0_DOMAIN")
+    url = f"https://{env['AUTH0_DOMAIN']}/.well-known/jwks.json"
+    resp = httpx.get(url, timeout=10.0)
+    assert resp.status_code == 200, f"Auth0 JWKS returned {resp.status_code}: {resp.text[:200]}"
+    data = resp.json()
+    expect(data).has_keys("keys").verify()
+    assert len(data["keys"]) > 0, "Auth0 JWKS returned no signing keys"

--- a/backend/tests/live/test_foretees_live.py
+++ b/backend/tests/live/test_foretees_live.py
@@ -1,0 +1,35 @@
+"""Live probe for ForeTees: real credentials complete the login handshake.
+Skips unless FORETEES_USERNAME + FORETEES_PASSWORD are set. Read-only — auth
+only, never books a tee time."""
+
+import pytest
+from ctk import claim_vs_reality
+
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+
+@pytest.mark.asyncio
+async def test_foretees_login_handshake(monkeypatch):
+    require_env("FORETEES_USERNAME", "FORETEES_PASSWORD")
+    from app.services.foretees_service import ForeteesConfig, ForeteesService
+
+    # from_env() reads FORETEES_ENABLED (a config flag, not a secret); without
+    # it a configured run short-circuits to False before attempting login.
+    monkeypatch.setenv("FORETEES_ENABLED", "true")
+
+    config = ForeteesConfig.from_env()
+    service = ForeteesService(config)
+    try:
+        ok = await service._ensure_session()
+
+        claim_vs_reality(
+            claimed_success=bool(ok),
+            verifier=lambda: None
+            if service._session_valid()
+            else (_ for _ in ()).throw(AssertionError("ForeTees session not valid after login")),
+            claim_label="foretees login handshake",
+        )
+    finally:
+        await service.close()

--- a/backend/tests/live/test_ghin_live.py
+++ b/backend/tests/live/test_ghin_live.py
@@ -1,0 +1,67 @@
+"""Live probe for GHIN: real credentials authenticate. Skips unless
+GHIN_API_USER + GHIN_API_PASS are set. Read-only (login + optional lookup).
+
+GHINService.initialize() returns True / sets self.initialized on success; on
+any failure it returns False (never raises). We pin the real success signal.
+
+If LIVE_TEST_GHIN_ID is set, additionally fetch that golfer's handicap. The
+by-id lookup (_fetch_handicap_from_ghin) is gated behind ENABLE_GHIN_INTEGRATION
+== "true", so we set that env inside the guarded block. The lookup is skipped
+(not failed) when LIVE_TEST_GHIN_ID is absent.
+"""
+
+import os
+
+import pytest
+from ctk import claim_vs_reality, expect
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+# The live dir has no DB fixture; GHINService(db) needs a real Session, so set
+# up a minimal sqlite session locally (read-only as far as GHIN auth goes).
+_TEST_DATABASE_URL = "sqlite:///./test_ghin_live.db"
+_engine = create_engine(_TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+_TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+
+@pytest.fixture
+def db():
+    from app.models import Base
+
+    Base.metadata.create_all(bind=_engine)
+    session = _TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=_engine)
+
+
+@pytest.mark.asyncio
+async def test_ghin_authenticates(db, monkeypatch):
+    require_env("GHIN_API_USER", "GHIN_API_PASS")
+    from app.services.ghin_service import GHINService
+
+    service = GHINService(db)
+    ok = await service.initialize()  # True on success; sets self.initialized + jwt_token
+
+    claim_vs_reality(
+        claimed_success=bool(ok),
+        verifier=lambda: (_ for _ in ()).throw(AssertionError("GHIN auth failed"))
+        if not (service.initialized and service.jwt_token)
+        else None,
+        claim_label="ghin initialize",
+    )
+
+    # Optional read-only by-id lookup, guarded on LIVE_TEST_GHIN_ID.
+    ghin_id = os.environ.get("LIVE_TEST_GHIN_ID")
+    if ghin_id:
+        # The by-id fetch is gated behind this flag; enable it for the probe.
+        monkeypatch.setenv("ENABLE_GHIN_INTEGRATION", "true")
+        handicap_data = await service._fetch_handicap_from_ghin(ghin_id)
+        expect(handicap_data, label="ghin handicap lookup").nonempty().verify()
+        expect(handicap_data.get("handicap_index"), label="handicap_index").nonempty().verify()

--- a/backend/tests/live/test_google_live.py
+++ b/backend/tests/live/test_google_live.py
@@ -1,0 +1,35 @@
+"""Live probe for Google Sheets: read a designated test sheet with real creds.
+
+Skips unless GOOGLE_OAUTH_CREDENTIALS + LIVE_TEST_SHEET_ID are set. Read-only —
+calls SpreadsheetSyncService.get_all_rounds(), which only GETs the Details range
+and never writes.
+
+The read path is synchronous (plain ``def``), so this is a plain test, not async.
+
+NOTE: the configured LIVE_TEST_SHEET_ID must point at a sheet with the WGP
+``Details`` tab shape (columns Date/Group/Member/Score/Location/Duration).
+get_all_rounds() returns [] for any read failure AND for an empty/wrong-shaped
+sheet, so a non-empty result is the only unambiguous "live read works" signal.
+"""
+
+import pytest
+from ctk import expect
+
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+
+def test_google_sheet_readable():
+    env = require_env("GOOGLE_OAUTH_CREDENTIALS", "LIVE_TEST_SHEET_ID")
+
+    from app.services.spreadsheet_sync_service import SpreadsheetSyncService
+
+    service = SpreadsheetSyncService(env["LIVE_TEST_SHEET_ID"])
+    rounds = service.get_all_rounds()
+
+    # Non-empty list of RoundResult proves token exchange + values read worked.
+    expect(rounds, label="google sheet rounds").nonempty().verify()
+    first = rounds[0]
+    expect(first.member, label="round member").nonempty().verify()
+    expect(first.date, label="round date").nonempty().verify()

--- a/backend/tests/live/test_groq_live.py
+++ b/backend/tests/live/test_groq_live.py
@@ -1,0 +1,32 @@
+"""Live probe for Groq: a real 1-token completion proves reachability + auth
++ a usable response. Skips unless GROQ_API_KEY is set. Read-only (no state)."""
+
+import os
+
+import httpx
+import pytest
+from ctk import expect
+
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
+
+
+def test_groq_reachable_and_returns_content():
+    env = require_env("GROQ_API_KEY")
+    model = os.environ.get("GROQ_MODEL", "llama-3.3-70b-versatile")
+    resp = httpx.post(
+        GROQ_URL,
+        headers={"Authorization": f"Bearer {env['GROQ_API_KEY']}"},
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "reply with the word pong"}],
+            "max_tokens": 5,
+        },
+        timeout=30.0,
+    )
+    assert resp.status_code == 200, f"Groq returned {resp.status_code}: {resp.text[:300]}"
+    content = resp.json()["choices"][0]["message"]["content"]
+    expect(content).nonempty().verify()

--- a/backend/tests/live/test_groupme_live.py
+++ b/backend/tests/live/test_groupme_live.py
@@ -1,0 +1,26 @@
+"""Live probe for GroupMe: the access token is valid and the configured group
+is visible. Skips unless GROUPME_ACCESS_TOKEN + GROUPME_GROUP_ID are set.
+Read-only — never posts a message."""
+
+import pytest
+from ctk import claim_vs_reality
+
+from app.services import groupme_service
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+
+def test_groupme_token_valid_and_group_visible():
+    env = require_env("GROUPME_ACCESS_TOKEN", "GROUPME_GROUP_ID")
+    groups = groupme_service.list_groups()  # real read-only call
+
+    def group_is_visible():
+        ids = {str(g.get("id")) for g in groups}
+        assert env["GROUPME_GROUP_ID"] in ids, f"configured group {env['GROUPME_GROUP_ID']} not in visible groups {ids}"
+
+    claim_vs_reality(
+        claimed_success=bool(groups),
+        verifier=group_is_visible,
+        claim_label="groupme list_groups",
+    )

--- a/backend/tests/live/test_resend_live.py
+++ b/backend/tests/live/test_resend_live.py
@@ -1,0 +1,22 @@
+"""Live probe for Resend: the API key is valid (lists domains). Skips unless
+RESEND_API_KEY is set. READ-ONLY — never sends an email."""
+
+import httpx
+import pytest
+from ctk import expect
+
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+
+def test_resend_api_key_valid():
+    env = require_env("RESEND_API_KEY")
+    resp = httpx.get(
+        "https://api.resend.com/domains",
+        headers={"Authorization": f"Bearer {env['RESEND_API_KEY']}"},
+        timeout=15.0,
+    )
+    assert resp.status_code == 200, f"Resend returned {resp.status_code}: {resp.text[:200]}"
+    # A valid key returns a parseable JSON body (a 401 would mean a dead key).
+    expect(resp.text).is_json().verify()

--- a/backend/tests/live/test_tee_sheet_live.py
+++ b/backend/tests/live/test_tee_sheet_live.py
@@ -1,0 +1,26 @@
+"""Live probe for the thousand-cranes WGP tee sheet: the page is reachable and
+parses into slots. Read-only. Opt-in via LIVE_TEST_TEE_SHEET=1 (no creds needed,
+but we don't hammer the real site unless explicitly enabled)."""
+
+from datetime import date as date_type
+
+import pytest
+from ctk import expect
+
+from tests.live._helpers import require_env
+
+pytestmark = pytest.mark.live
+
+
+@pytest.mark.asyncio
+async def test_tee_sheet_reachable_and_parses():
+    require_env("LIVE_TEST_TEE_SHEET")  # opt-in flag; skips unless set
+    from app.routers import tee_sheet
+
+    # Real GET against today's date. Reaching past this line means the request
+    # succeeded — a non-2xx or connection failure raises HTTPException(502).
+    result = await tee_sheet.get_tee_sheet(date=date_type.today().isoformat())
+
+    # Real return shape is a dict with the parsed slot list under "slots".
+    expect(result).has_keys("date", "slots", "signed_up", "signed_up_count").verify()
+    expect(result["slots"]).satisfies(lambda s: isinstance(s, list), "slots is a list").verify()


### PR DESCRIPTION
## Summary

Phase 1 of external-service reliability: two test layers for all **8 external API integrations** (Auth0, Groq, Google Sheets, GHIN, GroupMe, ForeTees, Resend, thousand-cranes tee-sheet).

- **Contract tests** (`backend/tests/contract/`, **in CI**, no creds): mock each service's HTTP boundary and verify our code handles success + the failure matrix (auth-fail, 5xx, timeout, malformed/empty). **45 tests.** Each service is mocked at its *real* client seam — httpx (`respx`), the `resend` SDK, and stdlib `urllib.request` (GroupMe + Google use urllib, so respx can't intercept them).
- **Live suite** (`backend/tests/live/`, marked `live`, **excluded from the gate**): one read-only probe per service — reachability + auth + a safe read. **Skip-until-configured** — runs green-with-skips with zero credentials; wire up each service's secrets incrementally. Anchored on the vendored `ctk` kit for claim-vs-reality assertions. **8 probes.**
- **Manual-dispatch workflow** `.github/workflows/live-integration.yml` (`workflow_dispatch`) runs the live suite with secrets; all-skips with none set. No schedule (that's Phase 2).

Spec: `docs/superpowers/specs/2026-06-14-external-integration-tests-design.md`.

## ⚠️ The payoff — 3 more silent-failure patterns surfaced

Writing the contract tests against the *real* error handling exposed three integrations that swallow external failures into "no data"/"false," so an outage is **invisible** (pinned by tests, not fixed here — Phase 2 alerting targets):

1. **Google Sheets** — `_sheets_api_get` swallows 401/403/5xx/timeout → `[]`, no refresh on 401. **An expired OAuth token looks identical to an empty leaderboard.**
2. **GHIN** — `initialize()` returns `False` for outage *and* missing-config alike; callers can't tell "down" from "not set up."
3. **ForeTees** — bad-creds vs network-error both `False` (milder; intentional best-effort, and it logs).

Plus a hardening note: **Auth0** `verify_token` lets JWKS fetch errors propagate as raw exceptions → unhandled 500 (fails *closed*, so safe, just noisy).

## Test plan
- [x] Default gate green incl. `tests/contract` (45 pass), no real network, live excluded (8 deselected). Only failure is the documented local-only SOCKS `startup_test` (passes in CI).
- [x] `tests/live` with no creds → 8 skipped, 0 failed
- [x] `live-integration.yml` parses; dispatches manually; all-skips with no secrets
- [x] `ruff check`/`format` clean

Phase 2 (per-endpoint alerting + scheduled live runs that notify on the failures above) is a separate spec.

This pull request and its description were written by Isaac.