### PR TITLE
feat(observability): synthetic external-health monitoring (Phase 2b)

### DIFF
--- a/backend/app/observability/external_checks.py
+++ b/backend/app/observability/external_checks.py
@@ -1,0 +1,220 @@
+"""Read-only health probes for the external services WGP depends on.
+
+Each checker reaches its service with a minimal read-only request and returns a
+ServiceStatus. A service with no credentials configured returns "not_configured"
+(NOT a failure — must never alert). Used by GET /health/external.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+import httpx
+
+Status = Literal["ok", "down", "not_configured"]
+_TIMEOUT = 8.0
+
+
+@dataclass
+class ServiceStatus:
+    name: str
+    status: Status
+    latency_ms: int | None = None
+    detail: str = ""
+
+
+def _missing(*names: str) -> bool:
+    return any(not os.environ.get(n) for n in names)
+
+
+async def _timed(name: str, coro) -> ServiceStatus:
+    """Run a probe coroutine, mapping success/exception to ServiceStatus."""
+    start = time.monotonic()
+    try:
+        detail = await coro
+        return ServiceStatus(name, "ok", int((time.monotonic() - start) * 1000), detail or "ok")
+    except Exception as e:  # any failure (HTTP error, timeout, parse) means the dep is down
+        return ServiceStatus(name, "down", int((time.monotonic() - start) * 1000), f"{type(e).__name__}: {e}")
+
+
+async def check_groq() -> ServiceStatus:
+    if _missing("GROQ_API_KEY"):
+        return ServiceStatus("groq", "not_configured")
+
+    async def probe() -> str:
+        model = os.environ.get("GROQ_MODEL", "llama-3.3-70b-versatile")
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                "https://api.groq.com/openai/v1/chat/completions",
+                headers={"Authorization": f"Bearer {os.environ['GROQ_API_KEY']}"},
+                json={"model": model, "messages": [{"role": "user", "content": "ping"}], "max_tokens": 1},
+            )
+            resp.raise_for_status()
+            return f"HTTP {resp.status_code}"
+
+    return await _timed("groq", probe())
+
+
+async def check_auth0() -> ServiceStatus:
+    if _missing("AUTH0_DOMAIN"):
+        return ServiceStatus("auth0", "not_configured")
+
+    async def probe() -> str:
+        url = f"https://{os.environ['AUTH0_DOMAIN']}/.well-known/jwks.json"
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            keys = resp.json().get("keys") or []
+            if not keys:
+                raise ValueError("JWKS returned no signing keys")
+            return f"{len(keys)} signing key(s)"
+
+    return await _timed("auth0", probe())
+
+
+async def check_resend() -> ServiceStatus:
+    if _missing("RESEND_API_KEY"):
+        return ServiceStatus("resend", "not_configured")
+
+    async def probe() -> str:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(
+                "https://api.resend.com/domains",
+                headers={"Authorization": f"Bearer {os.environ['RESEND_API_KEY']}"},
+            )
+            resp.raise_for_status()
+            return f"HTTP {resp.status_code}"
+
+    return await _timed("resend", probe())
+
+
+async def check_tee_sheet() -> ServiceStatus:
+    # Public page, no creds required — always "configured".
+    async def probe() -> str:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get("https://thousand-cranes.com/WolfGoatPig")
+            resp.raise_for_status()
+            return f"HTTP {resp.status_code}"
+
+    return await _timed("tee_sheet", probe())
+
+
+async def check_groupme() -> ServiceStatus:
+    if _missing("GROUPME_ACCESS_TOKEN", "GROUPME_GROUP_ID"):
+        return ServiceStatus("groupme", "not_configured")
+
+    async def probe() -> str:
+        token = os.environ["GROUPME_ACCESS_TOKEN"]
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(f"https://api.groupme.com/v3/groups?token={token}")
+            resp.raise_for_status()
+            return f"HTTP {resp.status_code}"
+
+    return await _timed("groupme", probe())
+
+
+async def check_ghin() -> ServiceStatus:
+    if _missing("GHIN_API_USER", "GHIN_API_PASS"):
+        return ServiceStatus("ghin", "not_configured")
+
+    async def probe() -> str:
+        # Mirrors GHINService.initialize(): POST golfer_login.json with the
+        # email_or_ghin/password user block, source "GHINcom", and a static
+        # token (default "ghincom"). Read-only login handshake — no scores
+        # posted, no state mutated.
+        static_token = os.environ.get("GHIN_API_STATIC_TOKEN") or "ghincom"
+        payload = {
+            "user": {
+                "email_or_ghin": os.environ["GHIN_API_USER"],
+                "password": os.environ["GHIN_API_PASS"],
+            },
+            "source": "GHINcom",
+            "token": static_token,
+        }
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            ),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Origin": "https://www.ghin.com",
+            "Referer": "https://www.ghin.com/",
+        }
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                "https://api2.ghin.com/api/v1/golfer_login.json",
+                json=payload,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            if not resp.json().get("golfer_user", {}).get("golfer_user_token"):
+                raise ValueError("GHIN login returned no token")
+            return "authenticated"
+
+    return await _timed("ghin", probe())
+
+
+async def check_foretees() -> ServiceStatus:
+    if _missing("FORETEES_USERNAME", "FORETEES_PASSWORD"):
+        return ServiceStatus("foretees", "not_configured")
+
+    async def probe() -> str:
+        from app.services.foretees_service import ForeteesConfig, ForeteesService
+
+        # Build an explicitly-enabled config (mirrors create_user_foretees_service)
+        # rather than ForeteesConfig.from_env(): from_env() couples reachability to
+        # the FORETEES_ENABLED feature flag, so a creds-present-but-flag-off service
+        # would falsely report "down". Keying the probe off the same creds the
+        # not_configured gate uses keeps probe semantics consistent with the gate.
+        # Tradeoff: if creds are set AND the flag is disabled, this reports "down" —
+        # acceptable, since creds present means the operator intends it reachable.
+        config = ForeteesConfig(
+            enabled=True,
+            username=os.environ["FORETEES_USERNAME"],
+            password=os.environ["FORETEES_PASSWORD"],
+        )
+        service = ForeteesService(config)
+        try:
+            ok = await service._ensure_session()
+        finally:
+            await service.close()
+        if not ok:
+            raise ValueError("ForeTees login handshake failed")
+        return "session established"
+
+    return await _timed("foretees", probe())
+
+
+async def check_google() -> ServiceStatus:
+    if _missing("GOOGLE_OAUTH_CREDENTIALS", "LIVE_TEST_SHEET_ID"):
+        return ServiceStatus("google", "not_configured")
+
+    async def probe() -> str:
+        from app.services import spreadsheet_sync_service
+
+        sheet_id = os.environ["LIVE_TEST_SHEET_ID"]
+        data = await asyncio.to_thread(spreadsheet_sync_service._sheets_api_get, sheet_id, "A1:A1")
+        if not data:
+            raise ValueError("Google Sheets read returned no data")
+        return "sheet readable"
+
+    return await _timed("google", probe())
+
+
+async def check_all() -> list[ServiceStatus]:
+    """Run all external checks concurrently and return their statuses."""
+    return await asyncio.gather(
+        check_groq(),
+        check_auth0(),
+        check_google(),
+        check_ghin(),
+        check_groupme(),
+        check_foretees(),
+        check_resend(),
+        check_tee_sheet(),
+    )

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -10,12 +10,16 @@ Uses new utility patterns:
 
 import logging
 import os
+import time as _time
 from typing import Any, cast
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Header, HTTPException
+from fastapi.responses import JSONResponse
+from sentry_sdk import capture_message
 from sqlalchemy import text
 
 from .. import models
+from ..observability.external_checks import check_all
 from ..state.course_manager import CourseManager
 from ..utils.api_helpers import handle_api_errors, managed_session
 from ..utils.time import utc_now
@@ -342,3 +346,42 @@ def seed_course_holes() -> dict[str, Any]:
         results["status"] = "error"
         results["message"] = str(e)
         return results
+
+
+_EXTERNAL_CACHE: dict[str, Any] = {"at": 0.0, "payload": None, "http_status": 200}
+
+
+@router.get("/health/external")
+async def external_health(x_monitor_key: str | None = Header(default=None)) -> JSONResponse:
+    """Read-only health of the external services WGP depends on.
+
+    Guarded by X-Monitor-Key when MONITOR_KEY is set (allow when unset). Cached
+    for EXTERNAL_HEALTH_TTL seconds so frequent monitor pings don't re-probe.
+    200 when no configured service is down; 503 when any is.
+    """
+    monitor_key = os.getenv("MONITOR_KEY")
+    if monitor_key and x_monitor_key != monitor_key:
+        return JSONResponse(status_code=403, content={"detail": "forbidden"})
+
+    ttl = int(os.getenv("EXTERNAL_HEALTH_TTL", "300"))
+    now = _time.monotonic()
+    if _EXTERNAL_CACHE["payload"] is not None and (now - _EXTERNAL_CACHE["at"]) < ttl:
+        payload = {**_EXTERNAL_CACHE["payload"], "cached": True}
+        return JSONResponse(status_code=_EXTERNAL_CACHE["http_status"], content=payload)
+
+    statuses = await check_all()
+    any_down = any(s.status == "down" for s in statuses)
+    payload = {
+        "status": "unhealthy" if any_down else "healthy",
+        "checked_at": utc_now().isoformat(),
+        "cached": False,
+        "services": {s.name: {"status": s.status, "latency_ms": s.latency_ms, "detail": s.detail} for s in statuses},
+    }
+    http_status = 503 if any_down else 200
+
+    if any_down:
+        down = [s.name for s in statuses if s.status == "down"]
+        capture_message(f"External services down: {', '.join(down)}", level="error")
+
+    _EXTERNAL_CACHE.update(at=now, payload=payload, http_status=http_status)
+    return JSONResponse(status_code=http_status, content={**payload, "cached": False})

--- a/backend/tests/unit/observability/test_external_checks.py
+++ b/backend/tests/unit/observability/test_external_checks.py
@@ -1,0 +1,347 @@
+"""Unit tests for external_checks: each checker maps good/error/absent to
+ok/down/not_configured. All HTTP mocked — no real network."""
+
+import httpx
+import pytest
+import respx
+
+from app.observability import external_checks as ec
+
+
+@pytest.fixture(autouse=True)
+def _no_proxy(monkeypatch):
+    for v in ("ALL_PROXY", "all_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"):
+        monkeypatch.delenv(v, raising=False)
+
+
+# --------------------------------------------------------------------------
+# groq
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_groq_not_configured(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    s = await ec.check_groq()
+    assert s.status == "not_configured"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_groq_ok(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "k")
+    respx.post("https://api.groq.com/openai/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json={"choices": [{"message": {"content": "x"}}]})
+    )
+    s = await ec.check_groq()
+    assert s.status == "ok"
+    assert s.latency_ms is not None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_groq_down_on_error(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "k")
+    respx.post("https://api.groq.com/openai/v1/chat/completions").mock(
+        return_value=httpx.Response(500, json={"error": "boom"})
+    )
+    s = await ec.check_groq()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# auth0
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_auth0_not_configured(monkeypatch):
+    monkeypatch.delenv("AUTH0_DOMAIN", raising=False)
+    s = await ec.check_auth0()
+    assert s.status == "not_configured"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_auth0_ok(monkeypatch):
+    monkeypatch.setenv("AUTH0_DOMAIN", "x.auth0.com")
+    respx.get("https://x.auth0.com/.well-known/jwks.json").mock(
+        return_value=httpx.Response(200, json={"keys": [{"kid": "test", "kty": "RSA"}]})
+    )
+    s = await ec.check_auth0()
+    assert s.status == "ok"
+    assert "1 signing key" in s.detail
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_auth0_down_when_no_keys(monkeypatch):
+    monkeypatch.setenv("AUTH0_DOMAIN", "x.auth0.com")
+    respx.get("https://x.auth0.com/.well-known/jwks.json").mock(return_value=httpx.Response(200, json={"keys": []}))
+    s = await ec.check_auth0()
+    assert s.status == "down"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_auth0_down_on_http_error(monkeypatch):
+    monkeypatch.setenv("AUTH0_DOMAIN", "x.auth0.com")
+    respx.get("https://x.auth0.com/.well-known/jwks.json").mock(return_value=httpx.Response(500))
+    s = await ec.check_auth0()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# resend
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_resend_not_configured(monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    s = await ec.check_resend()
+    assert s.status == "not_configured"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resend_ok(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "k")
+    respx.get("https://api.resend.com/domains").mock(return_value=httpx.Response(200, json={"data": []}))
+    s = await ec.check_resend()
+    assert s.status == "ok"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resend_down_on_401(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "k")
+    respx.get("https://api.resend.com/domains").mock(return_value=httpx.Response(401, json={"error": "bad key"}))
+    s = await ec.check_resend()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# groupme
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_groupme_not_configured(monkeypatch):
+    monkeypatch.delenv("GROUPME_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("GROUPME_GROUP_ID", raising=False)
+    s = await ec.check_groupme()
+    assert s.status == "not_configured"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_groupme_ok(monkeypatch):
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("GROUPME_GROUP_ID", "123")
+    respx.get(url__startswith="https://api.groupme.com/v3/groups").mock(
+        return_value=httpx.Response(200, json={"response": [], "meta": {"code": 200}})
+    )
+    s = await ec.check_groupme()
+    assert s.status == "ok"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_groupme_down_on_401(monkeypatch):
+    monkeypatch.setenv("GROUPME_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("GROUPME_GROUP_ID", "123")
+    respx.get(url__startswith="https://api.groupme.com/v3/groups").mock(return_value=httpx.Response(401))
+    s = await ec.check_groupme()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# ghin
+# --------------------------------------------------------------------------
+GHIN_LOGIN_URL = "https://api2.ghin.com/api/v1/golfer_login.json"
+
+
+@pytest.mark.asyncio
+async def test_ghin_not_configured(monkeypatch):
+    monkeypatch.delenv("GHIN_API_USER", raising=False)
+    monkeypatch.delenv("GHIN_API_PASS", raising=False)
+    s = await ec.check_ghin()
+    assert s.status == "not_configured"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_ghin_ok(monkeypatch):
+    monkeypatch.setenv("GHIN_API_USER", "golfer@example.com")
+    monkeypatch.setenv("GHIN_API_PASS", "secret")
+    respx.post(GHIN_LOGIN_URL).mock(
+        return_value=httpx.Response(200, json={"golfer_user": {"golfer_user_token": "tok-abc"}})
+    )
+    s = await ec.check_ghin()
+    assert s.status == "ok"
+    assert s.detail == "authenticated"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_ghin_down_when_no_token(monkeypatch):
+    monkeypatch.setenv("GHIN_API_USER", "golfer@example.com")
+    monkeypatch.setenv("GHIN_API_PASS", "secret")
+    respx.post(GHIN_LOGIN_URL).mock(return_value=httpx.Response(200, json={"golfer_user": {}}))
+    s = await ec.check_ghin()
+    assert s.status == "down"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_ghin_down_on_401(monkeypatch):
+    monkeypatch.setenv("GHIN_API_USER", "golfer@example.com")
+    monkeypatch.setenv("GHIN_API_PASS", "wrong")
+    respx.post(GHIN_LOGIN_URL).mock(return_value=httpx.Response(401, json={"error": "invalid"}))
+    s = await ec.check_ghin()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# foretees
+# --------------------------------------------------------------------------
+FT_LOGIN_URL = "https://www.wingpointgolf.com/public/member-login-465.html"
+FT_TEE_PAGE_URL = "https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html"
+FT_SSO_PREFIX = "https://ftapp.wingpointgolf.com/v5/wingpointgcc_flxrez0_m30/Member_select"
+FT_TEE_PAGE_OK = "<html><body><script>var ftSSOKey = 'sso-key-abc'; var ftSSOIV = 'sso-iv-def';</script></body></html>"
+FT_TEE_PAGE_BAD = "<html><body><p>Invalid username or password.</p></body></html>"
+
+
+@pytest.mark.asyncio
+async def test_foretees_not_configured(monkeypatch):
+    monkeypatch.delenv("FORETEES_USERNAME", raising=False)
+    monkeypatch.delenv("FORETEES_PASSWORD", raising=False)
+    s = await ec.check_foretees()
+    assert s.status == "not_configured"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_foretees_ok(monkeypatch):
+    monkeypatch.setenv("FORETEES_USERNAME", "u")
+    monkeypatch.setenv("FORETEES_PASSWORD", "p")
+    respx.get(FT_LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>login</html>"))
+    respx.post(FT_LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>ok</html>"))
+    respx.get(FT_TEE_PAGE_URL).mock(return_value=httpx.Response(200, text=FT_TEE_PAGE_OK))
+    respx.get(url__startswith=FT_SSO_PREFIX).mock(return_value=httpx.Response(200, text="<html>sso</html>"))
+    s = await ec.check_foretees()
+    assert s.status == "ok"
+    assert s.detail == "session established"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_foretees_down_on_bad_login(monkeypatch):
+    # Login succeeds but the tee page lacks SSO markers → handshake fails → down.
+    monkeypatch.setenv("FORETEES_USERNAME", "u")
+    monkeypatch.setenv("FORETEES_PASSWORD", "p")
+    respx.get(FT_LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>login</html>"))
+    respx.post(FT_LOGIN_URL).mock(return_value=httpx.Response(200, text="<html>ok</html>"))
+    respx.get(FT_TEE_PAGE_URL).mock(return_value=httpx.Response(200, text=FT_TEE_PAGE_BAD))
+    s = await ec.check_foretees()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# google (urllib seam — patched at _sheets_api_get)
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_google_not_configured(monkeypatch):
+    monkeypatch.delenv("GOOGLE_OAUTH_CREDENTIALS", raising=False)
+    monkeypatch.delenv("LIVE_TEST_SHEET_ID", raising=False)
+    s = await ec.check_google()
+    assert s.status == "not_configured"
+
+
+@pytest.mark.asyncio
+async def test_google_ok(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CREDENTIALS", "{}")
+    monkeypatch.setenv("LIVE_TEST_SHEET_ID", "sheet-id")
+    from app.services import spreadsheet_sync_service
+
+    monkeypatch.setattr(
+        spreadsheet_sync_service,
+        "_sheets_api_get",
+        lambda sheet_id, range_spec: {"values": [["x"]]},
+    )
+    s = await ec.check_google()
+    assert s.status == "ok"
+    assert s.detail == "sheet readable"
+
+
+@pytest.mark.asyncio
+async def test_google_down_when_no_data(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CREDENTIALS", "{}")
+    monkeypatch.setenv("LIVE_TEST_SHEET_ID", "sheet-id")
+    from app.services import spreadsheet_sync_service
+
+    # _sheets_api_get returns None on any failure (bad token, HTTP error, etc.).
+    monkeypatch.setattr(
+        spreadsheet_sync_service,
+        "_sheets_api_get",
+        lambda sheet_id, range_spec: None,
+    )
+    s = await ec.check_google()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# tee_sheet (no not_configured case — always configured)
+# --------------------------------------------------------------------------
+TEE_SHEET_URL = "https://thousand-cranes.com/WolfGoatPig"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_tee_sheet_ok():
+    respx.get(TEE_SHEET_URL).mock(return_value=httpx.Response(200, text="<html>ok</html>"))
+    s = await ec.check_tee_sheet()
+    assert s.status == "ok"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_tee_sheet_down_on_500():
+    respx.get(TEE_SHEET_URL).mock(return_value=httpx.Response(500))
+    s = await ec.check_tee_sheet()
+    assert s.status == "down"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_tee_sheet_down_on_connect_error():
+    respx.get(TEE_SHEET_URL).mock(side_effect=httpx.ConnectError("no route to host"))
+    s = await ec.check_tee_sheet()
+    assert s.status == "down"
+
+
+# --------------------------------------------------------------------------
+# check_all
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+@respx.mock
+async def test_check_all_returns_all_eight(monkeypatch):
+    for n in (
+        "GROQ_API_KEY",
+        "AUTH0_DOMAIN",
+        "RESEND_API_KEY",
+        "GHIN_API_USER",
+        "GHIN_API_PASS",
+        "GROUPME_ACCESS_TOKEN",
+        "GROUPME_GROUP_ID",
+        "FORETEES_USERNAME",
+        "FORETEES_PASSWORD",
+        "GOOGLE_OAUTH_CREDENTIALS",
+        "LIVE_TEST_SHEET_ID",
+    ):
+        monkeypatch.delenv(n, raising=False)
+    # tee_sheet has no creds gate, so it always fires a real GET — mock it so the
+    # suite makes no live network call. The other seven short-circuit to
+    # not_configured and make no HTTP request.
+    respx.get(TEE_SHEET_URL).mock(return_value=httpx.Response(200, text="<html>ok</html>"))
+
+    results = await ec.check_all()
+    names = {r.name for r in results}
+    assert names == {"groq", "auth0", "google", "ghin", "groupme", "foretees", "resend", "tee_sheet"}
+    by = {r.name: r.status for r in results}
+    assert by["groq"] == "not_configured"
+    assert by["ghin"] == "not_configured"
+    assert by["tee_sheet"] == "ok"

--- a/backend/tests/unit/routers/test_health_external.py
+++ b/backend/tests/unit/routers/test_health_external.py
@@ -1,0 +1,71 @@
+"""Tests for GET /health/external: guard, cache, and status aggregation.
+external_checks.check_all is patched so no real network occurs."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.observability.external_checks import ServiceStatus
+from app.routers import health
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    health._EXTERNAL_CACHE.update(at=0.0, payload=None, http_status=200)
+    yield
+    health._EXTERNAL_CACHE.update(at=0.0, payload=None, http_status=200)
+
+
+def _stub(monkeypatch, statuses, counter=None):
+    async def fake_check_all():
+        if counter is not None:
+            counter.append(1)
+        return statuses
+
+    monkeypatch.setattr(health, "check_all", fake_check_all)
+
+
+def test_all_ok_returns_200_healthy(monkeypatch):
+    monkeypatch.delenv("MONITOR_KEY", raising=False)
+    _stub(monkeypatch, [ServiceStatus("groq", "ok", 10, "ok"), ServiceStatus("ghin", "not_configured")])
+    resp = client.get("/health/external")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_one_down_returns_503_unhealthy(monkeypatch):
+    monkeypatch.delenv("MONITOR_KEY", raising=False)
+    _stub(monkeypatch, [ServiceStatus("groq", "down", 10, "boom"), ServiceStatus("ghin", "not_configured")])
+    resp = client.get("/health/external")
+    assert resp.status_code == 503
+    assert resp.json()["status"] == "unhealthy"
+
+
+def test_not_configured_does_not_make_unhealthy(monkeypatch):
+    monkeypatch.delenv("MONITOR_KEY", raising=False)
+    _stub(monkeypatch, [ServiceStatus("groq", "not_configured"), ServiceStatus("ghin", "not_configured")])
+    resp = client.get("/health/external")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_guard_rejects_without_key(monkeypatch):
+    monkeypatch.setenv("MONITOR_KEY", "secret")
+    _stub(monkeypatch, [ServiceStatus("groq", "ok", 10, "ok")])
+    assert client.get("/health/external").status_code == 403
+    assert client.get("/health/external", headers={"X-Monitor-Key": "wrong"}).status_code == 403
+    assert client.get("/health/external", headers={"X-Monitor-Key": "secret"}).status_code == 200
+
+
+def test_cache_avoids_reprobe(monkeypatch):
+    monkeypatch.delenv("MONITOR_KEY", raising=False)
+    monkeypatch.setenv("EXTERNAL_HEALTH_TTL", "300")
+    calls = []
+    _stub(monkeypatch, [ServiceStatus("groq", "ok", 10, "ok")], counter=calls)
+    first = client.get("/health/external")
+    second = client.get("/health/external")
+    assert len(calls) == 1
+    assert first.json()["cached"] is False
+    assert second.json()["cached"] is True

--- a/docs/observability/uptime-setup.md
+++ b/docs/observability/uptime-setup.md
@@ -1,0 +1,26 @@
+# Uptime monitoring setup (Phase 2b)
+
+`GET /health/external` runs read-only probes of the 8 external services (cached
+~5 min, guarded by `X-Monitor-Key` when `MONITOR_KEY` is set). An external uptime
+service pings it + `/health` and emails on failure.
+
+## 1. Set the monitor key (Render)
+- In the Render backend service env, set `MONITOR_KEY` to a long random value.
+- (Optional) set `EXTERNAL_HEALTH_TTL` (seconds, default 300).
+
+## 2. Create the monitors (UptimeRobot or BetterStack — free tier)
+- **Monitor A — app up:** `GET https://wolf-goat-pig.onrender.com/health`, every 5 min. Alert if non-200.
+- **Monitor B — externals:** `GET https://wolf-goat-pig.onrender.com/health/external`, every 5–15 min, with a custom request header `X-Monitor-Key: <the MONITOR_KEY value>`. Alert if non-200 **or** response body contains `"unhealthy"`.
+- To reduce flapping, set the monitor to alert only after 2 consecutive failures.
+
+## 3. Alerts → email
+- Add stuagano@gmail.com as the alert contact on both monitors.
+
+## What this catches (that Sentry/2a can't)
+- **Total downtime** — `/health` unreachable.
+- **A genuinely-down external** even with no user traffic — `/health/external` returns 503 listing the down services. (`not_configured` services never trigger an alert.)
+
+## Notes
+- The endpoint is cached, so pinging more often than the TTL does not increase real external calls (Groq spend / GHIN-ForeTees logins are bounded to ≤ once per TTL per instance).
+- Down services are also sent to Sentry (`capture_message`) when `SENTRY_DSN` is set — a secondary signal alongside the monitor email.
+- If `MONITOR_KEY` is unset, the endpoint is open (intended for local/dev, where no creds are configured so the probes all report `not_configured`). Always set `MONITOR_KEY` in production.


### PR DESCRIPTION
## Summary
Phase 2b — the final piece of per-endpoint alerting. A cached, guarded `GET /health/external` runs read-only probes of the 8 external services so an uptime monitor can catch the two things Sentry (2a) can't: **total downtime** and **a genuinely-down external with no triggering traffic**.

- `app/observability/external_checks.py` — one read-only async checker per external (Groq, Auth0, Google, GHIN, GroupMe, ForeTees, Resend, thousand-cranes) → `ok` / `down` / `not_configured`; `not_configured` **never** alerts. `check_all()` runs them concurrently.
- `GET /health/external` — `X-Monitor-Key` guard (when `MONITOR_KEY` set; allow when unset for local/dev), ~5 min cache (bounds Groq spend / GHIN-ForeTees logins regardless of ping rate), **200 healthy / 503 unhealthy**, and `capture_message` to Sentry on any down (unifies with 2a).
- `docs/observability/uptime-setup.md` — UptimeRobot/BetterStack runbook (monitor `/health` + `/health/external`, set `MONITOR_KEY`, email alerts).

Probes mirror the Phase-1 live suite; GHIN sends the real browser headers (fewer bot-block false-downs) and ForeTees uses an explicitly-enabled config (no creds-present-but-flag-off false down).

Spec: docs/superpowers/specs/2026-06-15-synthetic-external-monitoring-design.md

## Test plan
- [x] backend: ruff clean; **1382 passed** incl. 27 per-checker (ok/down/not_configured) + 5 endpoint (guard/cache/aggregation) tests; all mocked, no real network. (1 local-only SOCKS `startup_test` failure — passes in CI.)
- [x] no-creds locally → every service `not_configured` → healthy (no false alert)

Completes Phase 2 (2a Sentry merged in #257). With both phases live + DSNs/monitors configured: raised errors → Sentry, silent external failures + downtime → uptime monitor + Sentry.

This pull request and its description were written by Isaac.