### PR TITLE
chore(render): observability config in render.yaml + blueprint guide

### DIFF
--- a/docs/observability/render-blueprint.md
+++ b/docs/observability/render-blueprint.md
@@ -1,0 +1,64 @@
+# Making render.yaml authoritative (Render Blueprint)
+
+`render.yaml` is version-controlled IaC for the backend + booking services, but
+it only drives the live services if they are connected to Render as a
+**Blueprint**. Today the live service was created/managed manually, so
+`render.yaml` env changes do **not** auto-apply (you've been setting env in the
+dashboard). This is how to make `render.yaml` the source of truth — and the one
+trap to avoid first.
+
+## ⚠️ Read this before connecting the Blueprint
+
+When a Blueprint syncs, every env var with a literal `value:` in `render.yaml`
+is **written to the service**, overwriting whatever is in the dashboard. Vars
+with `sync: false` are left alone (dashboard-managed); `generateValue: true`
+are generated once.
+
+`render.yaml` currently declares these as **empty** literals:
+
+```
+FORETEES_USERNAME       value: ""
+FORETEES_PASSWORD       value: ""
+FORETEES_ENCRYPTION_KEY value: ""   # ← if this is set in the dashboard, a sync BLANKS it
+```
+
+`FORETEES_ENCRYPTION_KEY` is the Fernet key that decrypts per-user ForeTees
+credentials — blanking it breaks ForeTees. **Before connecting the Blueprint**,
+either confirm these are genuinely unused (per-user creds only, no global
+account) or change them to `sync: false` so the Blueprint leaves the dashboard
+values intact. (Ask Isaac to flip them to `sync: false` if unsure.)
+
+## Connect the Blueprint
+
+1. In the Render dashboard: **New → Blueprint** (or **Blueprints → New Blueprint Instance**), pick the `stuagano/wolf-goat-pig` repo.
+2. Render reads `render.yaml` and lists the services. Because the names match
+   the existing services (`wolf-goat-pig-api`, `wolf-goat-pig-booking`), Render
+   **adopts** them rather than creating duplicates. Confirm it shows "update
+   existing," not "create new" — if it offers to create new ones, the names
+   don't match; stop and reconcile (don't end up with duplicate services).
+3. Apply. From now on, a push to `main` that changes `render.yaml` syncs the
+   `value:` env vars automatically. Secrets stay `sync: false` (set once in the
+   dashboard); `MONITOR_KEY` is generated once by Render.
+
+## What's already in code (this PR)
+
+- `SENTRY_DSN` — `value:` (Sentry ingestion key, public by design). Applies on Blueprint sync.
+- `MONITOR_KEY` — `generateValue: true` (Render makes a strong value; copy it from the dashboard into the uptime monitor's `X-Monitor-Key` header).
+- `EXTERNAL_HEALTH_TTL` — `value: "300"`.
+
+## Interim (before the Blueprint is connected)
+
+Until you connect the Blueprint, the live service still ignores `render.yaml`.
+To turn Sentry on **now**, set one env var in the Render dashboard:
+`SENTRY_DSN` = the value in `render.yaml`. Once the Blueprint is connected you
+can delete that manual override and let `render.yaml` drive it.
+
+## Why some things must stay out of render.yaml
+
+- True secrets (`DATABASE_URL`, `RESEND_API_KEY`, `GHIN_API_PASS`,
+  `BOOKING_SERVICE_SECRET`, the ForeTees creds) → `sync: false`. Never commit
+  them to this public repo.
+- The frontend `VITE_SENTRY_DSN` lives in **Vercel** (it's a frontend build
+  var), not here. It's public-safe (ships in the browser), so it can go in
+  `vercel.json` `build.env` for version control once a frontend Sentry project
+  exists — or be set in the Vercel dashboard.

--- a/docs/observability/sentry-setup.md
+++ b/docs/observability/sentry-setup.md
@@ -1,16 +1,19 @@
 # Sentry setup (Phase 2a)
 
-The code ships **no-op until these env vars are set**. One-time owner setup:
+The code ships **no-op until the DSN env vars are set**. Sentry's **free tier**
+(5k errors/mo, 1 dev) covers this project at **$0** — no paid plan needed.
 
-## 1. Create Sentry projects
-- Create a Sentry org (free tier is fine).
-- New project **wolf-goat-pig-backend** — Platform: **Python / FastAPI**.
-- New project **wolf-goat-pig-frontend** — Platform: **React**.
-- Copy each project's **DSN**.
+Org: `o4511570300502016` (created 2026-06-15). Backend project DSN is committed
+in `render.yaml` (a Sentry DSN is a public-safe ingestion key).
 
-## 2. Set the DSNs as env vars
-- **Render** (backend service → Environment): `SENTRY_DSN = <backend DSN>`.
-- **Vercel** (frontend project → Settings → Environment Variables): `VITE_SENTRY_DSN = <frontend DSN>` (Production; add Preview if desired). Redeploy so Vite inlines it at build time.
+## 1. Create Sentry projects (under the existing org)
+- **wolf-goat-pig-backend** — Platform: **Python / FastAPI** (its DSN is the one in `render.yaml`).
+- **wolf-goat-pig-frontend** — Platform: **React** (separate DSN; not yet wired).
+- A DSN is at **Settings → Projects → [project] → Client Keys (DSN)**. The org id alone is NOT a DSN.
+
+## 2. Where the DSNs live
+- **Backend** — `SENTRY_DSN` is in **`render.yaml`** (version-controlled). It applies once the service is Blueprint-connected (see `render-blueprint.md`); until then, set `SENTRY_DSN` once in the Render dashboard to activate it now.
+- **Frontend** — `VITE_SENTRY_DSN` goes in **Vercel** (frontend build var) once a frontend Sentry project exists; redeploy so Vite inlines it. It's public-safe (ships in the browser), so it can also be committed to `vercel.json` `build.env`.
 
 ## 3. Email alerts to stuagano@gmail.com
 - In each project: Settings → Alerts. Sentry's default rule emails on a new issue's first occurrence — confirm it's enabled and the email is verified.

--- a/render.yaml
+++ b/render.yaml
@@ -61,12 +61,15 @@ services:
         sync: false
       - key: FORETEES_ENABLED
         value: "true"
+      # Dashboard-managed secrets — NOT committed. Previously `value: ""`, which
+      # a Blueprint sync would write over the live values; FORETEES_ENCRYPTION_KEY
+      # is the Fernet key for per-user ForeTees creds, so blanking it breaks them.
       - key: FORETEES_USERNAME
-        value: ""
+        sync: false
       - key: FORETEES_PASSWORD
-        value: ""
+        sync: false
       - key: FORETEES_ENCRYPTION_KEY
-        value: ""
+        sync: false
       - key: WEB_CONCURRENCY
         value: "1"
       - key: FORWARDED_ALLOW_IPS

--- a/render.yaml
+++ b/render.yaml
@@ -73,6 +73,20 @@ services:
         value: "*"
       - key: TIMEOUT_KEEP_ALIVE
         value: "75"
+      # --- Observability (Phase 2) ---
+      # SENTRY_DSN is a Sentry ingestion key (public by design — the frontend
+      # DSN even ships in the browser bundle); committed for version control.
+      # If the public DSN ever gets abused to spam the free-tier quota, rotate
+      # it in Sentry → Settings → Client Keys (DSN) and update this value.
+      - key: SENTRY_DSN
+        value: "https://71a92590788aa98bc7e15b021ad1a0c1@o4511570300502016.ingest.us.sentry.io/4511570301616128"
+      # Guard for GET /health/external. Render generates a strong value (never
+      # committed to git); copy it from the dashboard into the uptime monitor's
+      # X-Monitor-Key request header.
+      - key: MONITOR_KEY
+        generateValue: true
+      - key: EXTERNAL_HEALTH_TTL
+        value: "300"
     healthCheckPath: /ready
     autoDeploy: true
 


### PR DESCRIPTION
## Summary
Puts the Phase-2 observability config under version control in `render.yaml` (the user's IaC goal — stop hand-setting env in the dashboard).

- **`SENTRY_DSN`** — committed as a `value:` (Sentry ingestion key, public by design; the frontend DSN even ships in the browser). Rotate in Sentry → Client Keys if the public DSN ever gets quota-spammed.
- **`MONITOR_KEY`** — `generateValue: true` (Render generates a strong value; stays out of the public repo; copy it from the dashboard into the uptime monitor's `X-Monitor-Key` header).
- **`EXTERNAL_HEALTH_TTL`** — `value: "300"`.
- **`docs/observability/render-blueprint.md`** — how to make `render.yaml` authoritative by connecting the Render Blueprint, **with the empty-value-secret landmine flagged** (`FORETEES_ENCRYPTION_KEY` is `value: ""` — a Blueprint sync would blank it; convert ForeTees secrets to `sync: false` first).
- **`sentry-setup.md`** — reflects DSN-in-code, the free tier ($0), and the org id.

## Notes
- `render.yaml` only drives the live service once it's Blueprint-connected (it isn't today). Until then, set `SENTRY_DSN` once in the Render dashboard to activate Sentry now; the blueprint guide covers the permanent fix.
- No code/tests touched → backend/frontend CI don't run on this PR.

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide on Render Blueprint synchronization for managing render.yaml configuration and environment variable handling.
  * Updated Sentry setup documentation with refined backend and frontend DSN placement instructions.
* **New Features**
  * Added observability environment variables: SENTRY_DSN, MONITOR_KEY for health endpoint security, and EXTERNAL_HEALTH_TTL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->