### PR TITLE
fix(health): correct tee_sheet + resend external probes (false downs)

### DIFF
--- a/backend/app/observability/external_checks.py
+++ b/backend/app/observability/external_checks.py
@@ -86,6 +86,13 @@ async def check_resend() -> ServiceStatus:
                 "https://api.resend.com/domains",
                 headers={"Authorization": f"Bearer {os.environ['RESEND_API_KEY']}"},
             )
+            # A send-scoped key (least-privilege, the common case) returns 401/403
+            # on /domains even though it can send email — that is NOT an outage.
+            # We can't read-only validate a send key without sending, so treat
+            # auth-rejection as "reachable + key set" and only flag real outages
+            # (5xx / timeout / connection error) as down.
+            if resp.status_code in (401, 403):
+                return "reachable; key set (send-scoped — not read-only verifiable)"
             resp.raise_for_status()
             return f"HTTP {resp.status_code}"
 
@@ -95,8 +102,12 @@ async def check_resend() -> ServiceStatus:
 async def check_tee_sheet() -> ServiceStatus:
     # Public page, no creds required — always "configured".
     async def probe() -> str:
-        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.get("https://thousand-cranes.com/WolfGoatPig")
+        # Probe the exact endpoint the app reads (the bare base path 301-redirects),
+        # following redirects, with the same Referer the real request sends.
+        from app.routers.tee_sheet import TEE_SHEET_READ_URL
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=True) as client:
+            resp = await client.get(TEE_SHEET_READ_URL, headers={"Referer": TEE_SHEET_READ_URL})
             resp.raise_for_status()
             return f"HTTP {resp.status_code}"
 

--- a/backend/tests/unit/observability/test_external_checks.py
+++ b/backend/tests/unit/observability/test_external_checks.py
@@ -108,9 +108,20 @@ async def test_resend_ok(monkeypatch):
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_resend_down_on_401(monkeypatch):
+async def test_resend_401_is_ok_send_scoped(monkeypatch):
+    # A send-scoped key 401s on /domains but can still send — treat as ok, not down.
     monkeypatch.setenv("RESEND_API_KEY", "k")
-    respx.get("https://api.resend.com/domains").mock(return_value=httpx.Response(401, json={"error": "bad key"}))
+    respx.get("https://api.resend.com/domains").mock(return_value=httpx.Response(401, json={"error": "restricted"}))
+    s = await ec.check_resend()
+    assert s.status == "ok"
+    assert "send-scoped" in s.detail
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resend_down_on_500(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "k")
+    respx.get("https://api.resend.com/domains").mock(return_value=httpx.Response(500, json={"error": "boom"}))
     s = await ec.check_resend()
     assert s.status == "down"
 
@@ -286,7 +297,8 @@ async def test_google_down_when_no_data(monkeypatch):
 # --------------------------------------------------------------------------
 # tee_sheet (no not_configured case — always configured)
 # --------------------------------------------------------------------------
-TEE_SHEET_URL = "https://thousand-cranes.com/WolfGoatPig"
+# The probe reads the real .cgi endpoint (the bare base path 301-redirects).
+TEE_SHEET_URL = "https://thousand-cranes.com/WolfGoatPig/wgp_tee_sheet.cgi"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
`/health/external`'s first prod run flagged two services `down` that aren't — both were probe bugs:

- **tee_sheet** — probed the bare base path `…/WolfGoatPig` (which 301-redirects) instead of the real endpoint the app reads. Now probes `TEE_SHEET_READ_URL` (`…/wgp_tee_sheet.cgi`, imported from the router) with `follow_redirects=True` and the app's `Referer`.
- **resend** — a send-scoped key (least-privilege, the common case) 401s on `/domains` but can still send email. Treat 401/403 as `ok` (reachable, key set; not read-only verifiable) and only flag real outages (5xx/timeout/connection) as `down`.

Tests updated; 28 checker + 5 endpoint tests green; ruff clean.

This pull request and its description were written by Isaac.