### PR TITLE
chore(vercel): VITE_SENTRY_DSN in vercel.json (frontend Sentry live)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,7 @@
       "VITE_AUTH0_AUDIENCE": "https://wolf-goat-pig.onrender.com",
       "VITE_ENABLE_ANALYTICS": "true",
       "VITE_DEPLOY_PLATFORM": "vercel",
+      "VITE_SENTRY_DSN": "https://aabb92ca227138a3deafbab2b4375bb3@o4511570300502016.ingest.us.sentry.io/4511570438586368",
       "CI": "false"
     }
   },


### PR DESCRIPTION
## Summary
Wires the frontend Sentry DSN into `vercel.json` `build.env` (alongside the existing `VITE_*` build vars), activating frontend error tracking on the next Vercel build — version-controlled, same IaC treatment as `render.yaml`.

A frontend Sentry DSN is public by design (it ships in the browser bundle), so committing it adds no exposure.

Completes the observability stack: backend Sentry (render.yaml) + frontend Sentry (vercel.json) + `/health/external` synthetic monitoring.

This pull request and its description were written by Isaac.