### PR TITLE
feat(health): /health/external accepts ?monitor_key= (no header needed)

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -13,7 +13,7 @@ import os
 import time as _time
 from typing import Any, cast
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
 from sentry_sdk import capture_message
 from sqlalchemy import text
@@ -352,15 +352,20 @@ _EXTERNAL_CACHE: dict[str, Any] = {"at": 0.0, "payload": None, "http_status": 20
 
 
 @router.get("/health/external")
-async def external_health(x_monitor_key: str | None = Header(default=None)) -> JSONResponse:
+async def external_health(
+    x_monitor_key: str | None = Header(default=None),
+    monitor_key: str | None = Query(default=None),
+) -> JSONResponse:
     """Read-only health of the external services WGP depends on.
 
-    Guarded by X-Monitor-Key when MONITOR_KEY is set (allow when unset). Cached
-    for EXTERNAL_HEALTH_TTL seconds so frequent monitor pings don't re-probe.
-    200 when no configured service is down; 503 when any is.
+    Guarded when MONITOR_KEY is set (allow when unset): the key may be supplied
+    either as the `X-Monitor-Key` header OR a `?monitor_key=` query param — the
+    latter for uptime tools (e.g. UptimeRobot free) that can't send custom
+    headers. Cached for EXTERNAL_HEALTH_TTL seconds so frequent pings don't
+    re-probe. 200 when no configured service is down; 503 when any is.
     """
-    monitor_key = os.getenv("MONITOR_KEY")
-    if monitor_key and x_monitor_key != monitor_key:
+    expected = os.getenv("MONITOR_KEY")
+    if expected and x_monitor_key != expected and monitor_key != expected:
         return JSONResponse(status_code=403, content={"detail": "forbidden"})
 
     ttl = int(os.getenv("EXTERNAL_HEALTH_TTL", "300"))

--- a/backend/tests/unit/routers/test_health_external.py
+++ b/backend/tests/unit/routers/test_health_external.py
@@ -59,6 +59,14 @@ def test_guard_rejects_without_key(monkeypatch):
     assert client.get("/health/external", headers={"X-Monitor-Key": "secret"}).status_code == 200
 
 
+def test_guard_accepts_query_param_key(monkeypatch):
+    # Uptime tools that can't send custom headers can pass ?monitor_key=.
+    monkeypatch.setenv("MONITOR_KEY", "secret")
+    _stub(monkeypatch, [ServiceStatus("groq", "ok", 10, "ok")])
+    assert client.get("/health/external?monitor_key=wrong").status_code == 403
+    assert client.get("/health/external?monitor_key=secret").status_code == 200
+
+
 def test_cache_avoids_reprobe(monkeypatch):
     monkeypatch.delenv("MONITOR_KEY", raising=False)
     monkeypatch.setenv("EXTERNAL_HEALTH_TTL", "300")

--- a/docs/observability/uptime-setup.md
+++ b/docs/observability/uptime-setup.md
@@ -5,12 +5,15 @@
 service pings it + `/health` and emails on failure.
 
 ## 1. Set the monitor key (Render)
-- In the Render backend service env, set `MONITOR_KEY` to a long random value.
+- In the Render backend service env (`wolf-goat-pig-api` → Environment), set `MONITOR_KEY` to a **URL-safe** random value — generate one with `openssl rand -hex 32` (hex has no `/ + =`, so it works in a URL).
 - (Optional) set `EXTERNAL_HEALTH_TTL` (seconds, default 300).
 
 ## 2. Create the monitors (UptimeRobot or BetterStack — free tier)
-- **Monitor A — app up:** `GET https://wolf-goat-pig.onrender.com/health`, every 5 min. Alert if non-200.
-- **Monitor B — externals:** `GET https://wolf-goat-pig.onrender.com/health/external`, every 5–15 min, with a custom request header `X-Monitor-Key: <the MONITOR_KEY value>`. Alert if non-200 **or** response body contains `"unhealthy"`.
+- **Monitor A — app up:** `GET https://wolf-goat-pig.onrender.com/health`, every 5 min. Alert if non-200. (No key needed.)
+- **Monitor B — externals:** every 5–15 min, alert if non-200. The guard key can be sent two ways — use whichever your tool supports:
+  - **Query param (works everywhere, incl. UptimeRobot free):**
+    `GET https://wolf-goat-pig.onrender.com/health/external?monitor_key=<MONITOR_KEY>`
+  - **Custom header (if your tool allows it):** `GET …/health/external` with header `X-Monitor-Key: <MONITOR_KEY>`.
 - To reduce flapping, set the monitor to alert only after 2 consecutive failures.
 
 ## 3. Alerts → email

--- a/render.yaml
+++ b/render.yaml
@@ -83,11 +83,12 @@ services:
       # it in Sentry → Settings → Client Keys (DSN) and update this value.
       - key: SENTRY_DSN
         value: "https://71a92590788aa98bc7e15b021ad1a0c1@o4511570300502016.ingest.us.sentry.io/4511570301616128"
-      # Guard for GET /health/external. Render generates a strong value (never
-      # committed to git); copy it from the dashboard into the uptime monitor's
-      # X-Monitor-Key request header.
+      # Guard for GET /health/external. Set a URL-safe value in the Render
+      # dashboard (e.g. `openssl rand -hex 32` — no /, +, = so it works as a
+      # ?monitor_key= query param) and put the same value in the uptime monitor.
+      # sync:false so it's never committed to this public repo.
       - key: MONITOR_KEY
-        generateValue: true
+        sync: false
       - key: EXTERNAL_HEALTH_TTL
         value: "300"
     healthCheckPath: /ready


### PR DESCRIPTION
## Summary
UptimeRobot's free tier can't send custom request headers, so `/health/external` now accepts the guard key as a **query param** (`?monitor_key=`) in addition to the `X-Monitor-Key` header. Also flips `MONITOR_KEY` to `sync: false` (set a URL-safe value in the Render dashboard, e.g. `openssl rand -hex 32`) and updates the uptime runbook.

6 endpoint tests pass (incl. new query-param guard test); ruff clean.

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check endpoint now accepts monitor key as a query parameter (`monitor_key=`) in addition to the existing header method for greater flexibility.

* **Documentation**
  * Updated uptime monitoring setup guide with clearer configuration instructions and simplified alerting conditions.

* **Chores**
  * Updated environment variable configuration for improved secret management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->