### PR TITLE
feat(health): /health/sentry-test diagnostic

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 
 from fastapi import APIRouter, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
-from sentry_sdk import capture_message
+from sentry_sdk import capture_message, get_client
 from sqlalchemy import text
 
 from .. import models
@@ -390,3 +390,28 @@ async def external_health(
 
     _EXTERNAL_CACHE.update(at=now, payload=payload, http_status=http_status)
     return JSONResponse(status_code=http_status, content={**payload, "cached": False})
+
+
+@router.get("/health/sentry-test")
+async def sentry_test(
+    send: int = Query(default=0),
+    monitor_key: str | None = Query(default=None),
+    x_monitor_key: str | None = Header(default=None),
+) -> JSONResponse:
+    """Diagnostic: is Sentry initialized in this process? (`sentry_initialized`
+    is true only when SENTRY_DSN is configured and the SDK started.) Pass
+    `?send=1` with the MONITOR_KEY (header or query param) to fire a real test
+    event you can confirm in the Sentry dashboard."""
+    initialized = get_client().is_active()
+    result: dict[str, Any] = {
+        "sentry_initialized": initialized,
+        "environment": os.getenv("ENVIRONMENT", "development"),
+    }
+    if send:
+        expected = os.getenv("MONITOR_KEY")
+        if expected and x_monitor_key != expected and monitor_key != expected:
+            return JSONResponse(status_code=403, content={"detail": "forbidden"})
+        result["test_event_sent"] = initialized
+        if initialized:
+            result["test_event_id"] = capture_message("WGP backend Sentry self-test", level="info")
+    return JSONResponse(content=result)

--- a/backend/tests/unit/routers/test_health_external.py
+++ b/backend/tests/unit/routers/test_health_external.py
@@ -77,3 +77,18 @@ def test_cache_avoids_reprobe(monkeypatch):
     assert len(calls) == 1
     assert first.json()["cached"] is False
     assert second.json()["cached"] is True
+
+
+def test_sentry_test_reports_status(monkeypatch):
+    monkeypatch.delenv("MONITOR_KEY", raising=False)
+    resp = client.get("/health/sentry-test")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "sentry_initialized" in body
+    assert isinstance(body["sentry_initialized"], bool)
+
+
+def test_sentry_test_send_is_guarded(monkeypatch):
+    monkeypatch.setenv("MONITOR_KEY", "secret")
+    assert client.get("/health/sentry-test?send=1").status_code == 403
+    assert client.get("/health/sentry-test?send=1&monitor_key=secret").status_code == 200


### PR DESCRIPTION
## Summary
Adds `GET /health/sentry-test` so backend Sentry can be verified:
- Reports `sentry_initialized` (true only when `SENTRY_DSN` is set and the SDK started) — verifiable remotely, no dashboard needed.
- `?send=1` with the `MONITOR_KEY` (header or query) fires a real test event to confirm in the Sentry dashboard.

8 endpoint tests pass; ruff clean.

This pull request and its description were written by Isaac.