### PR TITLE
fix(render): correct backend SENTRY_DSN project

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -82,7 +82,7 @@ services:
       # If the public DSN ever gets abused to spam the free-tier quota, rotate
       # it in Sentry → Settings → Client Keys (DSN) and update this value.
       - key: SENTRY_DSN
-        value: "https://71a92590788aa98bc7e15b021ad1a0c1@o4511570300502016.ingest.us.sentry.io/4511570301616128"
+        value: "https://a2c007dfb1792d9f41e2d6c8c838dfcd@o4511570300502016.ingest.us.sentry.io/4511570311839744"
       # Guard for GET /health/external. Set a URL-safe value in the Render
       # dashboard (e.g. `openssl rand -hex 32` — no /, +, = so it works as a
       # ?monitor_key= query param) and put the same value in the uptime monitor.


### PR DESCRIPTION
Points the backend SENTRY_DSN at the FastAPI Sentry project (...311839744) instead of the wrong one. Config-only.

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend error tracking and monitoring configuration to maintain system observability and support efficient incident response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->