### PR TITLE
feat(observability): resilient Sentry init + DSN diagnostics

### DIFF
--- a/backend/app/observability/sentry.py
+++ b/backend/app/observability/sentry.py
@@ -7,12 +7,19 @@ sent and auth/secret fields are scrubbed before send.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
 
 import sentry_sdk
 
+logger = logging.getLogger(__name__)
+
 _SECRET_KEY_HINTS = ("authorization", "api_key", "apikey", "token", "password", "secret")
+
+# Set by init_sentry() so diagnostics can explain a failed init (e.g. a malformed
+# DSN) without crashing the app. None means "no init error this run".
+last_init_error: str | None = None
 
 
 def _redact(obj: Any) -> Any:
@@ -45,15 +52,22 @@ def init_sentry() -> bool:
     sentry-sdk[fastapi] auto-enables the FastAPI/Starlette integration, so every
     route's unhandled exceptions and 500s are captured once this runs.
     """
+    global last_init_error
+    last_init_error = None
     dsn = os.getenv("SENTRY_DSN")
     if not dsn:
         return False
-    sentry_sdk.init(
-        dsn=dsn,
-        environment=os.getenv("ENVIRONMENT", "development"),
-        release=os.getenv("RENDER_GIT_COMMIT") or os.getenv("GIT_SHA") or None,
-        send_default_pii=False,
-        traces_sample_rate=0.0,
-        before_send=_scrub,
-    )
-    return True
+    try:
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=os.getenv("ENVIRONMENT", "development"),
+            release=os.getenv("RENDER_GIT_COMMIT") or os.getenv("GIT_SHA") or None,
+            send_default_pii=False,
+            traces_sample_rate=0.0,
+            before_send=_scrub,
+        )
+        return True
+    except Exception as e:  # a bad DSN must not crash app startup
+        last_init_error = f"{type(e).__name__}: {e}"
+        logger.error("Sentry init failed: %s", last_init_error)
+        return False

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -402,9 +402,16 @@ async def sentry_test(
     is true only when SENTRY_DSN is configured and the SDK started.) Pass
     `?send=1` with the MONITOR_KEY (header or query param) to fire a real test
     event you can confirm in the Sentry dashboard."""
+    from ..observability import sentry as _sentry_mod
+
     initialized = get_client().is_active()
+    dsn = os.getenv("SENTRY_DSN")
     result: dict[str, Any] = {
         "sentry_initialized": initialized,
+        # Diagnostics (no secret revealed — only presence/length/init error):
+        "sentry_dsn_present": bool(dsn),
+        "sentry_dsn_len": len(dsn) if dsn else 0,
+        "sentry_init_error": _sentry_mod.last_init_error,
         "environment": os.getenv("ENVIRONMENT", "development"),
     }
     if send:


### PR DESCRIPTION
Makes init_sentry resilient to a bad SENTRY_DSN (no app crash; records last_init_error) and adds sentry_dsn_present / sentry_dsn_len / sentry_init_error to /health/sentry-test so the 'wired but inactive' state is diagnosable remotely without leaking the value.

This pull request and its description were written by Isaac.