### PR TITLE
chore(render): nudge blueprint re-sync

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -76,7 +76,7 @@ services:
         value: "*"
       - key: TIMEOUT_KEEP_ALIVE
         value: "75"
-      # --- Observability (Phase 2) ---
+      # --- Observability (Phase 2) ---  (blueprint re-sync nudge 2026-06-15)
       # SENTRY_DSN is a Sentry ingestion key (public by design — the frontend
       # DSN even ships in the browser bundle); committed for version control.
       # If the public DSN ever gets abused to spam the free-tier quota, rotate


### PR DESCRIPTION
No-op render.yaml comment so Render's Blueprint re-detects the latest commit and applies the correct SENTRY_DSN (sync was stuck 4h stale).

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an internal documentation note related to observability tracking for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->