### PR TITLE
fix(health): accept HEAD on health endpoints (uptime monitors)

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -184,7 +184,7 @@ def _check_data_seeding(health_status: dict[str, Any]) -> bool:
     return True  # Seeding check doesn't fail health
 
 
-@router.get("/health")
+@router.api_route("/health", methods=["GET", "HEAD"])
 @handle_api_errors(operation_name="health check")
 def health_check() -> dict[str, Any]:
     """Comprehensive health check endpoint verifying all critical systems"""
@@ -226,7 +226,7 @@ def health_check() -> dict[str, Any]:
     return health_status
 
 
-@router.get("/healthz")
+@router.api_route("/healthz", methods=["GET", "HEAD"])
 def health_check_render_alias():
     """Simplified health endpoint for Render monitoring."""
     try:
@@ -238,7 +238,7 @@ def health_check_render_alias():
         raise exc
 
 
-@router.get("/ready")
+@router.api_route("/ready", methods=["GET", "HEAD"])
 def readiness_check():
     """
     Lightweight readiness probe for Render/K8s.
@@ -351,7 +351,7 @@ def seed_course_holes() -> dict[str, Any]:
 _EXTERNAL_CACHE: dict[str, Any] = {"at": 0.0, "payload": None, "http_status": 200}
 
 
-@router.get("/health/external")
+@router.api_route("/health/external", methods=["GET", "HEAD"])
 async def external_health(
     x_monitor_key: str | None = Header(default=None),
     monitor_key: str | None = Query(default=None),

--- a/backend/tests/unit/routers/test_health_external.py
+++ b/backend/tests/unit/routers/test_health_external.py
@@ -92,3 +92,12 @@ def test_sentry_test_send_is_guarded(monkeypatch):
     monkeypatch.setenv("MONITOR_KEY", "secret")
     assert client.get("/health/sentry-test?send=1").status_code == 403
     assert client.get("/health/sentry-test?send=1&monitor_key=secret").status_code == 200
+
+
+def test_health_endpoints_accept_head():
+    # Uptime monitors (e.g. BetterStack) default to HEAD — must not 405.
+    for path in ("/health", "/healthz", "/ready"):
+        get_status = client.get(path).status_code
+        head_status = client.head(path).status_code
+        assert head_status != 405, f"HEAD {path} returned 405"
+        assert head_status == get_status, f"HEAD {path}={head_status} != GET {get_status}"


### PR DESCRIPTION
Uptime monitors (BetterStack etc.) default to HEAD, but the GET-only health routes returned 405 → monitor read it as down. /health, /healthz, /ready, and /health/external now accept GET + HEAD. Regression test added.

This pull request and its description were written by Isaac.