### PR TITLE
fix(api): normalize malformed-request (422) errors into the app envelope

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from fastapi import (
     HTTPException,
     Request,
 )
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -324,6 +325,28 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
     return JSONResponse(
         status_code=exc.status_code,
         content={"error": "HTTP error", "detail": exc.detail},
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Normalize malformed-request (Pydantic) errors into the app's standard
+    error envelope, instead of FastAPI's default `{"detail": [ {loc,msg,type} ]}`
+    array — so every error response has the same shape for the frontend."""
+    fields = [
+        {
+            # Drop the leading "body"/"query"/"path" location marker for readability.
+            "field": ".".join(str(p) for p in err.get("loc", ()) if p not in ("body", "query", "path")) or "request",
+            "message": err.get("msg", "invalid"),
+            "type": err.get("type", ""),
+        }
+        for err in exc.errors()
+    ]
+    summary = "; ".join(f"{f['field']}: {f['message']}" for f in fields) or "Invalid request"
+    logger.warning("Request validation failed: %s", summary)
+    return JSONResponse(
+        status_code=422,
+        content={"error": "Validation error", "detail": summary, "fields": fields},
     )
 
 

--- a/backend/tests/unit/test_validation_error_envelope.py
+++ b/backend/tests/unit/test_validation_error_envelope.py
@@ -1,0 +1,24 @@
+"""Malformed requests (Pydantic validation failures) must return the app's
+standard error envelope, not FastAPI's default `{"detail": [...]}` array."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_validation_error_uses_standard_envelope():
+    # POST /courses requires name + holes; an empty body fails Pydantic validation.
+    resp = client.post("/courses", json={})
+    assert resp.status_code == 422
+    body = resp.json()
+    # Same shape as the HTTPException handler: top-level "error" + string "detail".
+    assert body["error"] == "Validation error"
+    assert isinstance(body["detail"], str)
+    # Plus a structured, frontend-friendly fields list.
+    assert isinstance(body["fields"], list) and body["fields"]
+    first = body["fields"][0]
+    assert {"field", "message", "type"} <= set(first)
+    # NOT FastAPI's default array-under-detail format.
+    assert not isinstance(body["detail"], list)


### PR DESCRIPTION
Malformed requests hit FastAPI's default RequestValidationError handler, which returns `{"detail": [{loc,msg,type}]}` — a different shape than every other error (`{"error", "detail"}`). Adds a handler returning `{"error":"Validation error","detail":"<summary>","fields":[...]}` so all errors share one shape. First step toward moving the 64 hand-rolled router 400-checks onto Pydantic models.

This pull request and its description were written by Isaac.