### PR TITLE
feat(onboarding): capture unmatched signups + auto-sync canonical roster

### DIFF
--- a/.ctk/ledger.json
+++ b/.ctk/ledger.json
@@ -28,8 +28,8 @@
     "waiver": null
   },
   "api-surface-no-drift": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
-    "fingerprint": "sha256:3c0be64b5fe91bcf4b3eb533ecb37eee64e609f6b097831f7c58c39e876e7704",
+    "at": "2026-06-17T17:53:41.822843+00:00",
+    "fingerprint": "sha256:f8b4e5a05bdf57ea0929081415ddbf4822afca29608d94289157f88eb56ffaee",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
@@ -42,8 +42,8 @@
     "waiver": null
   },
   "auth0-contract": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
-    "fingerprint": "sha256:f7e803af895f7c0c522629273d87f5238c82c0d1e006145a6f623fcd255d974b",
+    "at": "2026-06-17T17:53:40.956407+00:00",
+    "fingerprint": "sha256:ddf4fe45cde6d47072a8984e5e40a7ad03dcbd4ed2c2bb99bcc74de76311f334",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
@@ -202,6 +202,13 @@
     "tier": "cheap",
     "waiver": null
   },
+  "new-player-capture-persists": {
+    "at": "2026-06-17T18:21:07.150409+00:00",
+    "fingerprint": "sha256:0f8c0780826a7265c9a09a832101d132a2171541f8cb4d1ec321ae61b249a9cc",
+    "result": "pass",
+    "tier": "cheap",
+    "waiver": null
+  },
   "notifications-mark-read-persists": {
     "at": "2026-06-17T02:54:58.714644+00:00",
     "fingerprint": "sha256:d37313c6c8341863a8df9266b6427d7d72d7f8b8b278271704b01747b9c0140b",
@@ -245,15 +252,15 @@
     "waiver": null
   },
   "request-validation-422-envelope": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
-    "fingerprint": "sha256:037dfb1892fa0a741e55e47c3fba456e71fc520b1f8ad6738d122426128d1476",
+    "at": "2026-06-17T17:53:38.447079+00:00",
+    "fingerprint": "sha256:bf8934b2575a216a70b8056b7dc70c6afcd74610278a1bfa8e5aa67479e9e9fd",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "resend-email-contract": {
-    "at": "2026-06-17T15:40:15.911810+00:00",
-    "fingerprint": "sha256:ef778d02d746c6af8ca9f90d55f27e1f6476fbde2135d65cb52ea807ad2c921c",
+    "at": "2026-06-17T17:53:40.067461+00:00",
+    "fingerprint": "sha256:a9ff6a80eb83a652238993b8a37329b78b0a5fb90b312c4fa7e647598d37ff3f",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
@@ -273,8 +280,8 @@
     "waiver": null
   },
   "signups-create-persists": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
-    "fingerprint": "sha256:0cf2a23bc565411fa02551daf200aa37b542a8ded057c6e735c9e76e59a1e252",
+    "at": "2026-06-17T17:53:42.859474+00:00",
+    "fingerprint": "sha256:1f85f378f935234beee8b52c7cf239005a5557b26ae464ef883fad75715acdec",
     "result": "pass",
     "tier": "cheap",
     "waiver": null

--- a/CAPABILITIES_ONBOARDING.md
+++ b/CAPABILITIES_ONBOARDING.md
@@ -1,0 +1,167 @@
+# Wolf Goat Pig — Player Sign-Up & Onboarding Capabilities
+
+**Prepared for:** Jeff Green
+**Scope:** Player sign-up, account creation, and onboarding only. Game scoring/wagering mechanics are intentionally out of scope for this review.
+**Status legend:** ✅ Live · ⚠️ Partial · ❌ Not built yet
+**As of:** June 2026
+
+---
+
+## 1. How it works today (the happy path)
+
+A player never fills out our own registration form. The flow is identity-first, and it
+works for **both** returning players and brand-new golfers:
+
+1. **Player visits the app and signs up / logs in via Auth0** (hosted login — Google or
+   email, no password for us to manage). The same Auth0 screen has a **Sign Up** tab for
+   first-timers and a **Log In** tab for returners. Auth0 returns name, email, and avatar.
+2. **The backend auto-creates a player profile** on that first login — there is no
+   separate form for us to maintain. Name, email, and avatar come straight from Auth0;
+   handicap defaults to 18.0; email notification preferences are created with sane
+   defaults. This happens for everyone, whether or not they exist on the legacy sheet.
+3. **The app attempts to fuzzy-match the player to a name on the legacy tee sheet**
+   (your system). If it finds a likely match, it pre-fills it.
+4. **One optional onboarding step:** a modal asks the player to confirm/select their
+   **legacy name** from a searchable dropdown of known tee-sheet players — this links
+   the new account to their existing history on your system. A brand-new golfer with no
+   match simply taps **"Skip for now"** and continues; they're fully functional without it.
+   Behind the scenes, a golfer with no match is **captured and an admin is emailed** so
+   they can be added to your tee sheet (see §2 and §5).
+5. Player is in. From there, sign-ups for specific play dates flow back to the legacy
+   tee sheet.
+
+```
+Visit app → Auth0 sign-up OR log in → profile auto-created (everyone)
+   → fuzzy-match legacy name → confirm/select OR skip (optional) → done
+   → daily sign-ups sync to legacy sheet
+```
+
+The design intent: **creating an account always works** — anyone can self-sign-up
+through Auth0. The legacy-sheet link is an *optional enrichment* that ties a new account
+to a returning player's history; it is not a prerequisite for using the app.
+
+---
+
+## 2. What's live today ✅
+
+| Capability | What it does |
+|---|---|
+| **Auth0 sign-up & sign-in** | Self-service account creation (Sign Up tab) and login on the same hosted screen; token refresh; no passwords stored by us. |
+| **Auto-create profile on account creation** | Name/email/avatar pulled from Auth0; profile is created for any new account, legacy match or not — no manual data entry to get started. |
+| **Canonical roster (DB-backed, auto-updating)** | The set of valid player names — your tee-sheet dropdown — lives in the database (seeded from your roster) and **auto-reconciles every 2 hours** against players seen in round history, so it stays current instead of being a frozen file. Additive only (never deletes). |
+| **New-player capture + admin alert** | When a brand-new golfer signs up with no match on your roster, they're **captured into a pending queue** and admins get an **email alert** to add them to your tee sheet. Login is never blocked by this. |
+| **Admin roster management (API)** | Endpoints to add a name to the canonical roster, list pending new players, and **promote** one onto the roster (or dismiss a misspelling) once they're on your sheet. |
+| **Direct profile-create API** | A `POST /players` endpoint exists for programmatic/admin profile creation. |
+| **Legacy-name fuzzy matching** | On first login, the app guesses the player's legacy tee-sheet name and suggests it. |
+| **Onboarding modal (legacy-name link)** | One searchable step to confirm/select the legacy identity; "skip for now" supported. |
+| **Daily sign-up → legacy sheet sync** | When a player signs up / changes / cancels for a date, it replicates to the legacy tee sheet. |
+| **Sign-up confirmation email** | Player gets an email when they sign up for a date (via Resend/SMTP). |
+| **Match & pairing notifications** | Availability-match and pairing emails are wired up. |
+| **Profile self-service fields** | Players can set Venmo handle and a short bio/description after onboarding. |
+| **ForeTees credentials (self-service, encrypted)** | Players set their own ForeTees username/password on the Account page. The app **verifies the login against ForeTees before saving**, stores the password Fernet-encrypted (per-user, in `player_profiles`), shows a configured/masked status, and supports removal. Used for that player's tee-time booking. |
+| **GroupMe read/post** | Reads league GroupMe; can post pairing announcements (not used for sign-up). |
+
+---
+
+## 3. What's partial ⚠️
+
+| Capability | State today | Gap |
+|---|---|---|
+| **GHIN / handicap integration** | Data model and a GHIN API service exist; profile has a `ghin_id` field. | The actual GHIN lookup/sync is a stub — endpoints are scaffolded but not fully wired. Handicap defaults to 18.0 until then. |
+
+---
+
+## 4. What's not built yet ❌
+
+These are the onboarding gaps most relevant to you. Listing them plainly so we can
+decide together what matters:
+
+1. **No automated push of a new golfer onto *your* tee sheet.** The app now captures a
+   brand-new golfer and alerts an admin (see §2), but actually adding them to your
+   dropdown on thousand-cranes.com is still a **manual step on your side**. We chose this
+   deliberately — see §5 and question 1.
+2. **No handicap capture during sign-up.** There's no onboarding step that asks for or
+   verifies a GHIN ID / handicap. New players sit at the 18.0 default until handicap
+   sync is finished.
+3. **No welcome / onboarding email.** Players get sign-up and match emails, but nothing
+   on account creation — no "welcome to WGP, here's how it works" message.
+4. **No organizer-facing *UI* for roster management.** The add/pending/promote
+   capabilities exist as APIs (§2); there's no admin screen wrapping them yet.
+5. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
+   (note: Auth0 itself can be configured for passwordless if we want it).
+
+---
+
+## 5. Where this touches your legacy system
+
+**Your tee sheet is canonical.** The app does not keep a competing roster of who's a
+"real" WGP player — it treats your tee sheet as the single source of truth for player
+identity and seeds from it. The app sits **on top of** your system, not beside it:
+
+- **The tee sheet seeds the roster, and the roster now auto-updates.** The list of league
+  players the app knows about started as a snapshot of your dropdown, and is now kept
+  current automatically: the same 2-hourly sync that pulls round history also reconciles
+  the canonical roster, adding any player who appears in recent rounds. So a golfer you
+  added to the sheet who has since played shows up in the app without anyone touching a
+  file. (This is *additive* — names are never removed, so a player who stops playing
+  doesn't vanish.) Onboarding's job is matching a person's Auth0 login to their canonical
+  name — that match is what makes them a recognized player.
+- **Two distinct layers.** Auth0 handles *login* (anyone can authenticate); your tee
+  sheet defines *who's a player*. A login with no matching canonical name is just an
+  unseeded account — not a new roster entry to reconcile.
+- **Your spreadsheet's round history is fully mirrored into our database.** A background
+  job pulls the complete round history from the Google Sheet into our `LegacyRound`
+  table **every 2 hours** (plus on startup, plus an on-demand admin trigger). That DB
+  copy is what the app reads for leaderboards and history — so the app stays fast and
+  keeps working even if the sheet is briefly unreachable, while your sheet remains the
+  upstream source. (Note: the "copy" is the continuously-refreshed table, not a frozen
+  CSV dump.)
+- **Sign-ups and completed games replicate back to the tee sheet.** Create/update/cancel
+  a date sign-up → it syncs to your system; completed app games queue and write back to
+  the writable sheet nightly (with dedup), so the canonical sheet stays authoritative.
+- **New golfers are captured, never silently promoted.** When someone signs up who isn't
+  on your roster, the app queues them and emails an admin — but it does **not** invent
+  them as a canonical player, because a name that isn't on your dropdown would just make
+  their sign-ups fail at your CGI. They become canonical one of two ways: an admin
+  *promotes* the queued entry, **or** the auto-sync above resolves it automatically once
+  that golfer turns up in round history. The only manual step is adding them to your
+  dropdown so they can actually sign up there.
+- **One honest residual gap:** the auto-sync learns players from *round history*, so a
+  golfer you add to the dropdown who hasn't played a round yet won't be auto-added — if
+  they sign up in the app first, they'll be captured (and an admin can promote them).
+  True real-time lockstep with the dropdown itself would require reading your CGI's
+  player list directly, which is question 1 territory.
+- **Why we didn't auto-write to your sheet:** your tee-sheet CGI accepts sign-ups only
+  for names already in its dropdown, and we don't have a documented way to add a *new*
+  name to it programmatically. Rather than guess at that and risk silent failures, we
+  kept the dropdown-add on your side — see question 1.
+
+---
+
+## 6. Questions for you, Jeff
+
+Where your input would most change priorities:
+
+1. **New golfers — the one piece still on your side:** the app now captures a brand-new
+   golfer and emails an admin to add them to your tee sheet; an admin then promotes them
+   to canonical. Adding the name to your thousand-cranes.com dropdown is still manual.
+   **Is that dropdown-add something that can be done via a URL/form we could automate, or
+   is it a hand-edit on your end?** If the former, tell us the mechanism and we'll wire
+   the push so even that step disappears. If the latter, the capture-and-promote flow we
+   built is the clean handoff.
+2. **Handicap source of truth:** GHIN sync, the legacy sheet, or manual entry — which
+   should drive a player's handicap?
+3. **Name matching (a real correctness risk worth your eyes):** at first login we
+   fuzzy-match the player's Auth0 name to your roster. If a *new* golfer's name is close
+   to an existing player's (e.g. "Jon Smith" vs "John Smith"), today the app may
+   auto-link them to that other person's legacy identity — and their date sign-ups would
+   then post under the wrong name. How clean/distinct are the names on your sheet? Any
+   known near-duplicates or aliases we should harden the matching against?
+4. **Bulk onboarding:** is there value in importing the full roster from a sheet in one
+   pass, or is per-player self-claim sufficient?
+
+---
+
+*All capabilities above are traceable to the current codebase (Auth0 auth service,
+player/sign-up routers, GHIN service, email/Resend provider, and the React onboarding
+components). Happy to walk through any of it live.*

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -119,6 +119,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception as e:
         logger.error(f"Badge seeding failed: {e}")
 
+    # Seed the canonical legacy roster if empty (mirrors Jeff's tee-sheet dropdown)
+    try:
+        from .database import SessionLocal
+        from .services.legacy_player_service import seed_roster_if_empty
+
+        _roster_db = SessionLocal()
+        try:
+            inserted = seed_roster_if_empty(_roster_db)
+            if inserted:
+                logger.info(f"⛳ Seeded {inserted} canonical legacy players")
+            else:
+                logger.info("⛳ Legacy roster already seeded")
+        finally:
+            _roster_db.close()
+    except Exception as e:
+        logger.error(f"Legacy roster seeding failed: {e}")
+
     # Initialize email scheduler if enabled
     if os.getenv("ENABLE_EMAIL_NOTIFICATIONS", "true").lower() == "true":
         try:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -723,3 +723,46 @@ class LivSowTeamContent(Base):
     logo_url = Column(String, nullable=True)
     updated_by = Column(String, nullable=True)  # display name of editor
     updated_at = Column(String, nullable=True)
+
+
+class LegacyRosterPlayer(Base):
+    """Canonical roster of player names — the single source of truth for who
+    is a recognized WGP player.
+
+    This table mirrors the fixed dropdown on Jeff Green's legacy tee sheet
+    (thousand-cranes.com/WolfGoatPig), which only accepts signups for names it
+    already knows. Seeded from data/legacy_players.json; an admin adds names
+    here once they exist on the legacy dropdown. All canonical reads
+    (onboarding dropdown, fuzzy matching, validation) come from this table —
+    never from pending captures (see PendingLegacyPlayer).
+    """
+
+    __tablename__ = "legacy_roster"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    source = Column(String, default="seed")  # "seed" | "admin" | "promoted"
+    added_at = Column(String, nullable=True)
+    notes = Column(String, nullable=True)
+
+
+class PendingLegacyPlayer(Base):
+    """Queue of self-signed-up golfers who have no match on the canonical
+    roster yet.
+
+    Captured (not promoted) when a brand-new player signs up via Auth0 and
+    no canonical name matches. Kept structurally separate from
+    legacy_roster so a pending name can NEVER leak into canonical reads and
+    falsely validate — their signups would silently fail at the legacy CGI
+    until Jeff adds them to his dropdown. An admin promotes a pending row
+    into legacy_roster once that manual step is done.
+    """
+
+    __tablename__ = "pending_legacy_players"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    email = Column(String, nullable=True, index=True)
+    player_profile_id = Column(Integer, nullable=True, index=True)
+    status = Column(String, default="pending", index=True)  # "pending" | "promoted" | "dismissed"
+    created_at = Column(String)
+    resolved_at = Column(String, nullable=True)
+    notes = Column(String, nullable=True)

--- a/backend/app/routers/signups.py
+++ b/backend/app/routers/signups.py
@@ -7,14 +7,20 @@ Legacy player lookup and daily sign-up management.
 import logging
 from datetime import datetime, timedelta
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Header, HTTPException, Query
+from pydantic import BaseModel
 
 from .. import database, models, schemas
 from ..services.legacy_player_service import (
+    add_legacy_player,
+    dismiss_pending_player,
     get_legacy_players,
+    list_pending_players,
+    promote_pending_player,
     validate_player_for_legacy,
 )
 from ..services.legacy_signup_service import get_legacy_signup_service
+from ..utils.admin_auth import require_admin
 from ..utils.time import utc_now
 
 logger = logging.getLogger("app.routers.signups")
@@ -53,6 +59,66 @@ def search_legacy_players(q: str = Query(description="Search query for player na
     query_lower = q.lower()
     matches = [p for p in players if query_lower in p.lower()]
     return {"query": q, "count": len(matches), "players": matches}
+
+
+# ── Admin: canonical roster + pending-capture management ─────────────────────
+
+
+class AddLegacyPlayerRequest(BaseModel):
+    name: str
+
+
+@router.post("/legacy-players")
+def admin_add_legacy_player(
+    body: AddLegacyPlayerRequest,
+    x_admin_email: str | None = Header(None),
+):
+    """Add a name to the canonical roster (admin only).
+
+    Use once the player is known to exist on the legacy tee-sheet dropdown.
+    """
+    require_admin(x_admin_email)
+    return add_legacy_player(body.name, source="admin")
+
+
+@router.get("/legacy-players/pending")
+def admin_list_pending_players(
+    status: str = Query("pending", description="pending | promoted | dismissed"),
+    x_admin_email: str | None = Header(None),
+):
+    """List golfers captured at sign-up who have no canonical match yet (admin only)."""
+    require_admin(x_admin_email)
+    players = list_pending_players(status=status)
+    return {"count": len(players), "status": status, "players": players}
+
+
+@router.post("/legacy-players/pending/{pending_id}/promote")
+def admin_promote_pending_player(
+    pending_id: int,
+    x_admin_email: str | None = Header(None),
+):
+    """Promote a pending capture into the canonical roster (admin only).
+
+    Call this once the player has been added to Jeff's legacy dropdown.
+    """
+    require_admin(x_admin_email)
+    result = promote_pending_player(pending_id)
+    if not result.get("promoted"):
+        raise HTTPException(status_code=404, detail=result.get("message", "Cannot promote"))
+    return result
+
+
+@router.post("/legacy-players/pending/{pending_id}/dismiss")
+def admin_dismiss_pending_player(
+    pending_id: int,
+    x_admin_email: str | None = Header(None),
+):
+    """Dismiss a pending capture, e.g. a misspelling of an existing player (admin only)."""
+    require_admin(x_admin_email)
+    result = dismiss_pending_player(pending_id)
+    if not result.get("dismissed"):
+        raise HTTPException(status_code=404, detail=result.get("message", "Cannot dismiss"))
+    return result
 
 
 @router.get("/signups/weekly", response_model=schemas.WeeklySignupView)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -4,6 +4,7 @@ Authentication Service for linking Auth0 users to PlayerProfile records
 
 import logging
 import os
+import threading
 from collections.abc import Generator
 from typing import Any
 
@@ -16,7 +17,7 @@ from sqlalchemy.orm import Session
 from ..database import SessionLocal, get_db
 from ..models import EmailPreferences, PlayerProfile
 from ..utils.time import utc_now
-from .legacy_player_service import find_similar_players, get_canonical_name
+from .legacy_player_service import capture_pending_player, find_similar_players, get_canonical_name
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,29 @@ AUTH0_ALGORITHMS = ["RS256"]
 
 # Security scheme for FastAPI
 security = HTTPBearer()
+
+
+def _notify_admins_of_new_player(name: str, email: str | None) -> None:
+    """Best-effort, non-blocking admin alert for a newly captured player.
+
+    Runs the (external, potentially slow) email send on a daemon thread so it
+    can never add latency to or break the first-login path.
+    """
+
+    def _send() -> None:
+        try:
+            from ..utils.admin_auth import get_admin_emails
+            from .email_service import get_email_service
+
+            svc = get_email_service()
+            if not svc.is_configured():
+                return
+            for admin_email in get_admin_emails():
+                svc.send_new_player_notification(admin_email, name, email)
+        except Exception as exc:  # never surface to the login path
+            logger.warning(f"Failed to notify admins of new player '{name}': {exc}")
+
+    threading.Thread(target=_send, daemon=True, name="new-player-notify").start()
 
 
 class AuthService:
@@ -101,11 +125,12 @@ class AuthService:
         player = db.query(PlayerProfile).filter(PlayerProfile.email == email).first()
 
         if not player:
-            # Try to match name to legacy tee sheet system
-            legacy_name = get_canonical_name(name)
+            # Try to match name to legacy tee sheet system (same session as the
+            # profile write so the whole flow is transactionally consistent).
+            legacy_name = get_canonical_name(name, db)
             if not legacy_name:
                 # Try fuzzy matching
-                suggestions = find_similar_players(name, max_results=1)
+                suggestions = find_similar_players(name, max_results=1, db=db)
                 if suggestions:
                     legacy_name = suggestions[0]
                     logger.info(f"Fuzzy matched '{name}' to legacy name '{legacy_name}'")
@@ -142,6 +167,18 @@ class AuthService:
             db.commit()
 
             logger.info(f"Created new player profile for {name} ({email})")
+
+            # No canonical legacy match → capture into the pending queue and
+            # alert admins so the golfer can be added to Jeff's tee-sheet
+            # dropdown (a manual step on the legacy side). Best-effort: never
+            # block account creation if capture/notify fails.
+            if not legacy_name:
+                try:
+                    result = capture_pending_player(name, email=email, player_profile_id=player.id, db=db)
+                    if result.get("captured"):
+                        _notify_admins_of_new_player(name, email)
+                except Exception as exc:
+                    logger.warning(f"Failed to capture pending player '{name}': {exc}")
         else:
             # Update existing player with Auth0 info if needed
             update_needed = False

--- a/backend/app/services/email_scheduler.py
+++ b/backend/app/services/email_scheduler.py
@@ -350,6 +350,17 @@ class EmailScheduler:
                 )
             db.commit()
             logger.info("Legacy rounds sync complete: %d rows written", len(rounds))
+
+            # Keep the canonical player roster in lockstep with the dropdown by
+            # reconciling it against the players seen in round history. Isolated
+            # so a roster-sync bug can never take down the load-bearing rounds
+            # sync (rounds are already committed above).
+            try:
+                from ..services.legacy_player_service import sync_roster_from_members
+
+                sync_roster_from_members({r.member for r in rounds}, db=db)
+            except Exception as roster_exc:
+                logger.warning("Roster reconcile skipped (rounds sync unaffected): %s", roster_exc)
         except Exception as exc:
             logger.error("Legacy rounds sync failed: %s", exc)
             db.rollback()

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -198,6 +198,41 @@ class EmailService:
             html_body=html_body,
         )
 
+    def send_new_player_notification(
+        self,
+        to_email: str,
+        new_player_name: str,
+        new_player_email: str | None = None,
+    ) -> bool:
+        """Alert an admin that a new golfer signed up with no canonical match.
+
+        The player can use the app, but their signups will not sync to the
+        legacy tee sheet until they are added to the dropdown on Jeff's system
+        and then promoted in the admin roster view.
+        """
+        email_line = f"<p>Email: <strong>{new_player_email}</strong></p>" if new_player_email else ""
+        content = f"""
+        <h2>New player needs onboarding</h2>
+        <p><strong>{new_player_name}</strong> just signed up for Wolf Goat Pig but isn't
+        on the legacy tee-sheet roster yet.</p>
+        {email_line}
+        <p>To enable their sign-ups to sync to the tee sheet:</p>
+        <ol>
+            <li>Add <strong>{new_player_name}</strong> to the dropdown on the
+            thousand-cranes.com tee sheet.</li>
+            <li>Promote them in the app's pending-players admin view.</li>
+        </ol>
+        <p>Until then they can play, but their date sign-ups won't reach the legacy board.</p>
+        """
+        template = Template(self._get_base_template())
+        html_body = template.render(subject="New WGP player needs onboarding", content=content)
+
+        return self._send_email(
+            to_email=to_email,
+            subject=f"New WGP player needs onboarding: {new_player_name}",
+            html_body=html_body,
+        )
+
     def send_pairing_notification(
         self,
         to_email: str,

--- a/backend/app/services/legacy_player_service.py
+++ b/backend/app/services/legacy_player_service.py
@@ -1,11 +1,24 @@
 """Service for managing and validating players against the legacy tee sheet system.
 
 The legacy system at thousand-cranes.com/WolfGoatPig only accepts signups for
-players that exist in its dropdown list. This service provides:
+players that exist in its dropdown list. This service is the app-side mirror of
+that canonical roster, plus a capture queue for golfers who sign up in the app
+before they exist on the legacy dropdown.
 
-1. A cached list of known legacy players
-2. Validation to check if a player name will work with the legacy system
-3. Fuzzy matching to suggest corrections for misspelled names
+Two stores, one invariant:
+
+1. ``legacy_roster`` (canonical) — the names that are valid on the legacy
+   dropdown. ALL canonical reads come from here: the onboarding dropdown,
+   fuzzy matching, and validation. Seeded from ``data/legacy_players.json``.
+2. ``pending_legacy_players`` (capture queue) — self-signed-up golfers with no
+   canonical match yet. Kept structurally separate so a pending name can NEVER
+   validate as canonical (which would let their signups silently fail at the
+   legacy CGI). An admin promotes a pending row into the canonical roster once
+   the player has been added to Jeff's dropdown.
+
+The canonical reads fall back to the JSON seed file only when the roster table
+is empty (e.g. a fresh dev DB before the startup seed runs), so behaviour is
+stable everywhere.
 """
 
 from __future__ import annotations
@@ -14,90 +27,120 @@ import json
 import logging
 from difflib import get_close_matches
 from pathlib import Path
+from typing import Any
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from ..database import SessionLocal
+from ..models import LegacyRosterPlayer, PendingLegacyPlayer
+from ..utils.time import utc_now
 
 logger = logging.getLogger(__name__)
 
-# Path to the static player list
+# Path to the static seed list (mirrors the legacy dropdown at first deploy).
 _PLAYERS_FILE = Path(__file__).parent.parent / "data" / "legacy_players.json"
 
-# Cached player data
-_players_cache: list[str] | None = None
-_players_cache_lower: dict[str, str] | None = None  # lowercase -> original mapping
 
-
-def _load_players() -> list[str]:
-    """Load the player list from the JSON file."""
-    global _players_cache, _players_cache_lower
-
-    if _players_cache is not None:
-        return _players_cache
-
+def _seed_names() -> list[str]:
+    """Read the static seed player list from the JSON file."""
     try:
         with open(_PLAYERS_FILE) as f:
             data = json.load(f)
-            _players_cache = data.get("players", [])
-            # Build lowercase lookup for case-insensitive matching
-            _players_cache_lower = {p.lower(): p for p in _players_cache}
-            logger.info(f"Loaded {len(_players_cache)} legacy players from {_PLAYERS_FILE}")
-            return _players_cache
+            return list(data.get("players", []))
     except FileNotFoundError:
-        logger.warning(f"Legacy players file not found: {_PLAYERS_FILE}")
-        _players_cache = []
-        _players_cache_lower = {}
+        logger.warning(f"Legacy players seed file not found: {_PLAYERS_FILE}")
         return []
     except json.JSONDecodeError as e:
-        logger.error(f"Invalid JSON in legacy players file: {e}")
-        _players_cache = []
-        _players_cache_lower = {}
+        logger.error(f"Invalid JSON in legacy players seed file: {e}")
         return []
 
 
-def get_legacy_players() -> list[str]:
-    """Return the list of all known legacy players."""
-    return _load_players()
+def seed_roster_if_empty(db: Any) -> int:
+    """Populate ``legacy_roster`` from the JSON seed when the table is empty.
 
-
-def is_valid_legacy_player(name: str) -> bool:
-    """Check if a player name exists in the legacy system (case-insensitive)."""
-    _load_players()
-    return name.lower() in _players_cache_lower  # type: ignore[operator]
-
-
-def get_canonical_name(name: str) -> str | None:
-    """Get the canonical (correctly cased) name for a player.
-
-    Returns None if the player is not found.
+    Idempotent: a no-op once the table has any rows. Returns the number of
+    names inserted.
     """
-    _load_players()
-    return _players_cache_lower.get(name.lower())  # type: ignore[union-attr]
+    existing = db.query(LegacyRosterPlayer).count()
+    if existing:
+        return 0
+
+    names = _seed_names()
+    now = utc_now().isoformat()
+    for name in names:
+        db.add(LegacyRosterPlayer(name=name, source="seed", added_at=now))
+    db.commit()
+    logger.info(f"Seeded {len(names)} canonical players into legacy_roster")
+    return len(names)
 
 
-def find_similar_players(name: str, max_results: int = 5) -> list[str]:
-    """Find players with names similar to the given name.
+def _canonical_names(db: Any = None) -> list[str]:
+    """Return canonical player names from the roster table.
 
-    Useful for suggesting corrections when a name doesn't match exactly.
+    Falls back to the JSON seed (read-only) when the table is empty so reads
+    are stable before the startup seed has run.
     """
-    players = _load_players()
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+    try:
+        names = [row[0] for row in db.query(LegacyRosterPlayer.name).all()]
+        if not names:
+            return _seed_names()
+        return names
+    except SQLAlchemyError as exc:
+        # Roster table missing/unavailable (e.g. pre-migration) — degrade to the
+        # static seed rather than 500 the login/onboarding read path.
+        logger.warning(f"Legacy roster read failed, falling back to JSON seed: {exc}")
+        if own_session:
+            db.rollback()
+        return _seed_names()
+    finally:
+        if own_session:
+            db.close()
+
+
+def get_legacy_players(db: Any = None) -> list[str]:
+    """Return the sorted list of all canonical legacy players."""
+    return sorted(_canonical_names(db))
+
+
+def is_valid_legacy_player(name: str, db: Any = None) -> bool:
+    """Check if a player name exists in the canonical roster (case-insensitive)."""
+    lowered = name.lower()
+    return any(p.lower() == lowered for p in _canonical_names(db))
+
+
+def get_canonical_name(name: str, db: Any = None) -> str | None:
+    """Get the canonical (correctly cased) name for a player, or None."""
+    lowered = name.lower()
+    for p in _canonical_names(db):
+        if p.lower() == lowered:
+            return p
+    return None
+
+
+def find_similar_players(name: str, max_results: int = 5, db: Any = None) -> list[str]:
+    """Find canonical players with names similar to the given name."""
+    players = _canonical_names(db)
     if not players:
         return []
 
-    # Use difflib for fuzzy matching
-    matches = get_close_matches(name.lower(), [p.lower() for p in players], n=max_results, cutoff=0.6)
-
-    # Return the original-cased versions
-    return [_players_cache_lower[m] for m in matches]  # type: ignore[index]
+    lower_to_original = {p.lower(): p for p in players}
+    matches = get_close_matches(name.lower(), list(lower_to_original.keys()), n=max_results, cutoff=0.6)
+    return [lower_to_original[m] for m in matches]
 
 
-def validate_player_for_legacy(name: str) -> dict:
+def validate_player_for_legacy(name: str, db: Any = None) -> dict:
     """Validate a player name for legacy system compatibility.
 
     Returns a dict with:
-    - valid: bool - whether the name is valid
+    - valid: bool - whether the name is canonical (will sync to the legacy sheet)
     - canonical_name: str or None - the correctly-cased name if valid
     - suggestions: list - similar names if not valid
     - message: str - human-readable explanation
     """
-    canonical = get_canonical_name(name)
+    canonical = get_canonical_name(name, db)
 
     if canonical:
         return {
@@ -107,7 +150,7 @@ def validate_player_for_legacy(name: str) -> dict:
             "message": f"Player '{canonical}' found in legacy system",
         }
 
-    suggestions = find_similar_players(name)
+    suggestions = find_similar_players(name, db=db)
 
     if suggestions:
         return {
@@ -125,13 +168,247 @@ def validate_player_for_legacy(name: str) -> dict:
     }
 
 
-def reload_players() -> int:
-    """Force reload of the player list from disk.
+# ---------------------------------------------------------------------------
+# Canonical roster writes
+# ---------------------------------------------------------------------------
+def add_legacy_player(name: str, *, source: str = "admin", db: Any = None) -> dict:
+    """Add a name to the canonical roster.
 
-    Returns the number of players loaded.
+    Use this once the player is known to exist on the legacy dropdown.
+    Idempotent: returns ``added=False`` if the name is already canonical.
     """
-    global _players_cache, _players_cache_lower
-    _players_cache = None
-    _players_cache_lower = None
-    players = _load_players()
-    return len(players)
+    name = (name or "").strip()
+    if not name:
+        return {"added": False, "message": "Empty name"}
+
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+    try:
+        existing = get_canonical_name(name, db)
+        if existing:
+            return {"added": False, "canonical_name": existing, "message": f"'{existing}' already in roster"}
+
+        db.add(LegacyRosterPlayer(name=name, source=source, added_at=utc_now().isoformat()))
+        db.commit()
+        logger.info(f"Added canonical legacy player '{name}' (source={source})")
+        return {"added": True, "canonical_name": name, "message": f"Added '{name}' to roster"}
+    finally:
+        if own_session:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# Pending capture queue
+# ---------------------------------------------------------------------------
+def capture_pending_player(
+    name: str,
+    *,
+    email: str | None = None,
+    player_profile_id: int | None = None,
+    db: Any = None,
+) -> dict:
+    """Capture a self-signed-up golfer who has no canonical match yet.
+
+    No-op when the name is already canonical or already queued. Returns a dict
+    describing what happened (``captured`` flag + reason).
+    """
+    name = (name or "").strip()
+    if not name or name == "Unknown Player":
+        return {"captured": False, "reason": "blank_or_unknown"}
+
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+    try:
+        if get_canonical_name(name, db):
+            return {"captured": False, "reason": "already_canonical"}
+
+        already = (
+            db.query(PendingLegacyPlayer)
+            .filter(PendingLegacyPlayer.name == name, PendingLegacyPlayer.status == "pending")
+            .first()
+        )
+        if already:
+            return {"captured": False, "reason": "already_pending", "pending_id": already.id}
+
+        row = PendingLegacyPlayer(
+            name=name,
+            email=email,
+            player_profile_id=player_profile_id,
+            status="pending",
+            created_at=utc_now().isoformat(),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        logger.info(f"Captured pending legacy player '{name}' (id={row.id})")
+        return {"captured": True, "pending_id": row.id, "name": name}
+    finally:
+        if own_session:
+            db.close()
+
+
+def list_pending_players(status: str = "pending", db: Any = None) -> list[dict]:
+    """List capture-queue rows for the given status (default: pending)."""
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+    try:
+        rows = (
+            db.query(PendingLegacyPlayer)
+            .filter(PendingLegacyPlayer.status == status)
+            .order_by(PendingLegacyPlayer.created_at.desc())
+            .all()
+        )
+        return [
+            {
+                "id": r.id,
+                "name": r.name,
+                "email": r.email,
+                "player_profile_id": r.player_profile_id,
+                "status": r.status,
+                "created_at": r.created_at,
+                "resolved_at": r.resolved_at,
+            }
+            for r in rows
+        ]
+    finally:
+        if own_session:
+            db.close()
+
+
+def promote_pending_player(pending_id: int, db: Any = None) -> dict:
+    """Promote a pending capture into the canonical roster.
+
+    Call this once the player has been added to Jeff's legacy dropdown.
+    """
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+    try:
+        row = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.id == pending_id).first()
+        if not row:
+            return {"promoted": False, "message": f"No pending player with id={pending_id}"}
+        if row.status != "pending":
+            return {"promoted": False, "message": f"Pending player id={pending_id} is already {row.status}"}
+
+        add_legacy_player(row.name, source="promoted", db=db)
+        row.status = "promoted"
+        row.resolved_at = utc_now().isoformat()
+        db.commit()
+        logger.info(f"Promoted pending player '{row.name}' (id={pending_id}) to canonical roster")
+        return {"promoted": True, "canonical_name": row.name}
+    finally:
+        if own_session:
+            db.close()
+
+
+def dismiss_pending_player(pending_id: int, db: Any = None) -> dict:
+    """Dismiss a pending capture (e.g. a misspelling of an existing player)."""
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+    try:
+        row = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.id == pending_id).first()
+        if not row:
+            return {"dismissed": False, "message": f"No pending player with id={pending_id}"}
+
+        row.status = "dismissed"
+        row.resolved_at = utc_now().isoformat()
+        db.commit()
+        logger.info(f"Dismissed pending player '{row.name}' (id={pending_id})")
+        return {"dismissed": True, "name": row.name}
+    finally:
+        if own_session:
+            db.close()
+
+
+def _looks_like_dropdown_name(name: str) -> bool:
+    """Heuristic: does this look like a canonical 'First Last' dropdown name?
+
+    The legacy CGI dropdown uses full first-and-last names. We refuse to inject
+    round-history member strings that diverge from that shape ("Last, First",
+    "Mike S.") as canonical, because a name the dropdown does not actually have
+    would let that player's sign-ups silently fail at the CGI. Format-divergent
+    members fall through to the pending-capture queue instead (safe).
+    """
+    if "," in name:
+        return False
+    tokens = name.split()
+    if len(tokens) < 2:
+        return False
+    # Reject a trailing single-letter initial like "Mike S" / "Mike S.".
+    return len(tokens[-1].rstrip(".")) >= 2
+
+
+def sync_roster_from_members(names: Any, db: Any = None) -> dict:
+    """Additively reconcile the canonical roster with names seen in round history.
+
+    Round history is synced from the Google Sheet every 2h; the distinct member
+    names are players who have signed up and played, i.e. real dropdown members.
+    This adds any new dropdown-shaped name to the canonical roster and resolves
+    any matching pending capture. It is an *additive reconcile*, not a full
+    mirror: names are never removed (a player dropped from the sheet but still
+    linked to a profile must persist). Returns a summary dict.
+    """
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+    try:
+        added: list[str] = []
+        skipped_format: list[str] = []
+        resolved: list[str] = []
+        seen_lower: set[str] = set()
+        confirmed_lower: set[str] = set()
+
+        for raw in names:
+            name = (raw or "").strip()
+            if not name or name == "Unknown Player":
+                continue
+            low = name.lower()
+            if low in seen_lower:
+                continue
+            seen_lower.add(low)
+
+            existing = get_canonical_name(name, db)
+            if existing:
+                confirmed_lower.add(existing.lower())
+                continue
+            if not _looks_like_dropdown_name(name):
+                skipped_format.append(name)
+                continue
+
+            db.add(LegacyRosterPlayer(name=name, source="sheet_sync", added_at=utc_now().isoformat()))
+            added.append(name)
+            confirmed_lower.add(low)
+
+        # Resolve pending captures whose name is now confirmed canonical.
+        pending = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.status == "pending").all()
+        for p in pending:
+            if (p.name or "").strip().lower() in confirmed_lower:
+                p.status = "promoted"
+                p.resolved_at = utc_now().isoformat()
+                resolved.append(p.name)
+
+        db.commit()
+        if added or resolved or skipped_format:
+            logger.info(
+                "Roster sync from rounds: +%d canonical, %d pending resolved, %d skipped (format divergence)",
+                len(added),
+                len(resolved),
+                len(skipped_format),
+            )
+        return {"added": added, "resolved": resolved, "skipped_format": skipped_format}
+    except SQLAlchemyError as exc:
+        logger.warning(f"Roster sync from rounds failed: {exc}")
+        db.rollback()
+        return {"added": [], "resolved": [], "skipped_format": [], "error": str(exc)}
+    finally:
+        if own_session:
+            db.close()
+
+
+def reload_players() -> int:
+    """Return the current canonical roster size (kept for API compatibility)."""
+    return len(get_legacy_players())

--- a/backend/app/utils/admin_auth.py
+++ b/backend/app/utils/admin_auth.py
@@ -8,11 +8,16 @@ from fastapi import Header, HTTPException
 _DEFAULT_ADMIN_EMAILS = {"stuagano@gmail.com", "admin@wgp.com"}
 
 
-def _get_admin_emails() -> set[str]:
+def get_admin_emails() -> set[str]:
+    """Return the set of allowed admin emails (env-configured or default)."""
     env = os.getenv("ADMIN_EMAILS")
     if env:
         return {e.strip() for e in env.split(",") if e.strip()}
     return _DEFAULT_ADMIN_EMAILS
+
+
+# Backwards-compatible private alias for existing internal callers.
+_get_admin_emails = get_admin_emails
 
 
 def require_admin(x_admin_email: str | None = Header(None)) -> None:

--- a/backend/migrations/add_legacy_roster_postgres.sql
+++ b/backend/migrations/add_legacy_roster_postgres.sql
@@ -1,0 +1,27 @@
+-- Canonical roster + pending-capture queue for player onboarding.
+-- legacy_roster mirrors Jeff Green's legacy tee-sheet dropdown (the canonical
+-- set of valid player names). pending_legacy_players queues self-signed-up
+-- golfers who have no canonical match yet, kept separate so they can never
+-- leak into canonical reads and falsely validate. See app/models.py.
+CREATE TABLE IF NOT EXISTS legacy_roster (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR UNIQUE,
+    source VARCHAR DEFAULT 'seed',
+    added_at VARCHAR,
+    notes VARCHAR
+);
+CREATE INDEX IF NOT EXISTS ix_legacy_roster_name ON legacy_roster (name);
+
+CREATE TABLE IF NOT EXISTS pending_legacy_players (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR,
+    email VARCHAR,
+    player_profile_id INTEGER,
+    status VARCHAR DEFAULT 'pending',
+    created_at VARCHAR,
+    resolved_at VARCHAR,
+    notes VARCHAR
+);
+CREATE INDEX IF NOT EXISTS ix_pending_legacy_players_name ON pending_legacy_players (name);
+CREATE INDEX IF NOT EXISTS ix_pending_legacy_players_email ON pending_legacy_players (email);
+CREATE INDEX IF NOT EXISTS ix_pending_legacy_players_status ON pending_legacy_players (status);

--- a/backend/tests/unit/routers/test_legacy_roster_admin.py
+++ b/backend/tests/unit/routers/test_legacy_roster_admin.py
@@ -1,0 +1,90 @@
+"""Router tests for the admin canonical-roster + pending-capture endpoints."""
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.database import engine
+from app.main import app
+from app.models import Base
+from app.services import legacy_player_service as svc
+
+# Ensure the new tables exist in the dev DB (lifespan isn't run by TestClient).
+Base.metadata.create_all(bind=engine)
+
+client = TestClient(app)
+
+ADMIN = {"X-Admin-Email": "stuagano@gmail.com"}
+
+
+def _novel_name(prefix: str) -> str:
+    return f"{prefix} {uuid.uuid4().hex[:8]}"
+
+
+# ── auth ─────────────────────────────────────────────────────────────────────
+
+
+def test_add_legacy_player_requires_admin():
+    resp = client.post("/legacy-players", json={"name": "No Auth"})
+    assert resp.status_code == 403
+
+
+def test_list_pending_requires_admin():
+    resp = client.get("/legacy-players/pending")
+    assert resp.status_code == 403
+
+
+# ── add to canonical roster ──────────────────────────────────────────────────
+
+
+def test_admin_add_legacy_player():
+    name = _novel_name("Roster Add")
+    resp = client.post("/legacy-players", json={"name": name}, headers=ADMIN)
+    assert resp.status_code == 200
+    assert resp.json()["added"] is True
+
+    # Now appears in the canonical list.
+    listing = client.get("/legacy-players").json()
+    assert name in listing["players"]
+
+
+# ── pending capture lifecycle ────────────────────────────────────────────────
+
+
+def test_list_and_promote_pending_player():
+    name = _novel_name("Pending Promote")
+    captured = svc.capture_pending_player(name, email="p@example.com")
+    assert captured["captured"] is True
+    pending_id = captured["pending_id"]
+
+    listing = client.get("/legacy-players/pending", headers=ADMIN).json()
+    assert any(p["id"] == pending_id and p["name"] == name for p in listing["players"])
+
+    resp = client.post(f"/legacy-players/pending/{pending_id}/promote", headers=ADMIN)
+    assert resp.status_code == 200
+    assert resp.json()["promoted"] is True
+
+    # Promoted → now canonical, no longer pending.
+    assert name in client.get("/legacy-players").json()["players"]
+    still_pending = client.get("/legacy-players/pending", headers=ADMIN).json()
+    assert not any(p["id"] == pending_id for p in still_pending["players"])
+
+
+def test_dismiss_pending_player():
+    name = _novel_name("Pending Dismiss")
+    captured = svc.capture_pending_player(name)
+    pending_id = captured["pending_id"]
+
+    resp = client.post(f"/legacy-players/pending/{pending_id}/dismiss", headers=ADMIN)
+    assert resp.status_code == 200
+    assert resp.json()["dismissed"] is True
+
+    # Not canonical, not pending.
+    assert name not in client.get("/legacy-players").json()["players"]
+    still_pending = client.get("/legacy-players/pending", headers=ADMIN).json()
+    assert not any(p["id"] == pending_id for p in still_pending["players"])
+
+
+def test_promote_missing_pending_returns_404():
+    resp = client.post("/legacy-players/pending/99999999/promote", headers=ADMIN)
+    assert resp.status_code == 404

--- a/backend/tests/unit/services/test_auth_new_player_capture.py
+++ b/backend/tests/unit/services/test_auth_new_player_capture.py
@@ -1,0 +1,100 @@
+"""Tests for new-player capture + notify on first Auth0 login.
+
+When a brand-new golfer signs up with no canonical roster match, the profile
+is still created (login always works), they are captured into the pending
+queue, and admins are notified. A returning player who matches the canonical
+roster is linked and NOT captured.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base, PendingLegacyPlayer, PlayerProfile
+from app.services import auth_service as auth_module
+from app.services import legacy_player_service as svc
+from app.services.auth_service import AuthService
+
+TEST_DATABASE_URL = "sqlite:///./test_auth_capture.db"
+engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def notify_spy(monkeypatch):
+    """Replace the (threaded, external) admin notify with a synchronous spy."""
+    spy = Mock()
+    monkeypatch.setattr(auth_module, "_notify_admins_of_new_player", spy)
+    return spy
+
+
+def test_unmatched_new_player_is_captured_and_notifies(db, notify_spy):
+    # Anchor row → table non-empty → no JSON-seed fallback during lookups.
+    svc.add_legacy_player("Anchor Player", db=db)
+
+    auth0_user = {
+        "sub": "auth0|brandnew",
+        "email": "brandnew@example.com",
+        "name": "Brand New Golfer",
+        "picture": None,
+    }
+    player = AuthService.get_or_create_player_profile(db, auth0_user)
+
+    # Account is created regardless (login always works).
+    assert player.id is not None
+    assert player.legacy_name is None
+
+    # Captured into the pending queue.
+    pending = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.name == "Brand New Golfer").first()
+    assert pending is not None
+    assert pending.email == "brandnew@example.com"
+    assert pending.player_profile_id == player.id
+
+    notify_spy.assert_called_once()
+
+
+def test_matched_returning_player_is_not_captured(db, notify_spy):
+    svc.add_legacy_player("Returning Golfer", db=db)
+
+    auth0_user = {
+        "sub": "auth0|returning",
+        "email": "returning@example.com",
+        "name": "Returning Golfer",
+        "picture": None,
+    }
+    player = AuthService.get_or_create_player_profile(db, auth0_user)
+
+    assert player.legacy_name == "Returning Golfer"
+    assert db.query(PendingLegacyPlayer).count() == 0
+    notify_spy.assert_not_called()
+
+
+def test_existing_account_relogin_does_not_recapture(db, notify_spy):
+    svc.add_legacy_player("Anchor Player", db=db)
+    auth0_user = {
+        "sub": "auth0|brandnew",
+        "email": "brandnew@example.com",
+        "name": "Brand New Golfer",
+        "picture": None,
+    }
+    AuthService.get_or_create_player_profile(db, auth0_user)
+    notify_spy.reset_mock()
+
+    # Second login for the same email must not capture or notify again.
+    AuthService.get_or_create_player_profile(db, auth0_user)
+    assert db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.name == "Brand New Golfer").count() == 1
+    assert db.query(PlayerProfile).filter(PlayerProfile.email == "brandnew@example.com").count() == 1
+    notify_spy.assert_not_called()

--- a/backend/tests/unit/services/test_legacy_player_service.py
+++ b/backend/tests/unit/services/test_legacy_player_service.py
@@ -1,0 +1,233 @@
+"""Unit tests for the DB-backed legacy player service.
+
+Covers the canonical roster (seed, add, validate, fuzzy-match), the pending
+capture queue, and the load-bearing invariant: a captured-but-unpromoted
+player must NEVER read as canonical (otherwise their signups would silently
+fail at the legacy CGI).
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base, LegacyRosterPlayer, PendingLegacyPlayer
+from app.services import legacy_player_service as svc
+
+TEST_DATABASE_URL = "sqlite:///./test_legacy_roster.db"
+engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+# ── Seeding ──────────────────────────────────────────────────────────────────
+
+
+def test_seed_roster_if_empty_populates_table(db):
+    inserted = svc.seed_roster_if_empty(db)
+    assert inserted > 0
+    assert db.query(LegacyRosterPlayer).count() == inserted
+
+
+def test_seed_roster_if_empty_is_idempotent(db):
+    first = svc.seed_roster_if_empty(db)
+    second = svc.seed_roster_if_empty(db)
+    assert first > 0
+    assert second == 0
+    assert db.query(LegacyRosterPlayer).count() == first
+
+
+# ── Canonical reads ──────────────────────────────────────────────────────────
+
+
+def test_add_and_get_canonical_name_is_case_insensitive(db):
+    svc.add_legacy_player("Tiger Woods", db=db)
+    assert svc.get_canonical_name("tiger woods", db) == "Tiger Woods"
+    assert svc.get_canonical_name("TIGER WOODS", db) == "Tiger Woods"
+
+
+def test_is_valid_legacy_player(db):
+    svc.add_legacy_player("Phil Mickelson", db=db)
+    assert svc.is_valid_legacy_player("phil mickelson", db) is True
+    assert svc.is_valid_legacy_player("Nobody Here", db) is False
+
+
+def test_get_legacy_players_is_sorted(db):
+    svc.add_legacy_player("Zed Zee", db=db)
+    svc.add_legacy_player("Aaron Able", db=db)
+    players = svc.get_legacy_players(db)
+    assert players == sorted(players)
+    assert "Aaron Able" in players and "Zed Zee" in players
+
+
+def test_find_similar_players_fuzzy_matches(db):
+    svc.add_legacy_player("Jonathan Smith", db=db)
+    matches = svc.find_similar_players("Jonathon Smith", db=db)
+    assert "Jonathan Smith" in matches
+
+
+def test_validate_valid_player(db):
+    svc.add_legacy_player("Rory McIlroy", db=db)
+    result = svc.validate_player_for_legacy("rory mcilroy", db)
+    assert result["valid"] is True
+    assert result["canonical_name"] == "Rory McIlroy"
+
+
+def test_validate_unknown_player_with_suggestion(db):
+    svc.add_legacy_player("Brooks Koepka", db=db)
+    result = svc.validate_player_for_legacy("Brook Koepka", db)
+    assert result["valid"] is False
+    assert "Brooks Koepka" in result["suggestions"]
+
+
+# ── Canonical writes ─────────────────────────────────────────────────────────
+
+
+def test_add_legacy_player_dedups(db):
+    first = svc.add_legacy_player("Dustin Johnson", db=db)
+    second = svc.add_legacy_player("dustin johnson", db=db)
+    assert first["added"] is True
+    assert second["added"] is False
+    assert db.query(LegacyRosterPlayer).filter(LegacyRosterPlayer.name == "Dustin Johnson").count() == 1
+
+
+# ── Pending capture queue ────────────────────────────────────────────────────
+
+
+def test_capture_pending_player(db):
+    result = svc.capture_pending_player("New Golfer", email="new@example.com", db=db)
+    assert result["captured"] is True
+    row = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.name == "New Golfer").first()
+    assert row is not None
+    assert row.status == "pending"
+    assert row.email == "new@example.com"
+
+
+def test_capture_skips_already_canonical(db):
+    svc.add_legacy_player("Existing Player", db=db)
+    result = svc.capture_pending_player("existing player", db=db)
+    assert result["captured"] is False
+    assert result["reason"] == "already_canonical"
+
+
+def test_capture_skips_duplicate_pending(db):
+    svc.capture_pending_player("Repeat Golfer", db=db)
+    result = svc.capture_pending_player("Repeat Golfer", db=db)
+    assert result["captured"] is False
+    assert result["reason"] == "already_pending"
+
+
+def test_capture_skips_unknown_player(db):
+    result = svc.capture_pending_player("Unknown Player", db=db)
+    assert result["captured"] is False
+    assert result["reason"] == "blank_or_unknown"
+
+
+def test_list_pending_players(db):
+    svc.capture_pending_player("Pending One", db=db)
+    svc.capture_pending_player("Pending Two", db=db)
+    pending = svc.list_pending_players(db=db)
+    names = {p["name"] for p in pending}
+    assert {"Pending One", "Pending Two"} <= names
+
+
+def test_promote_pending_player_makes_canonical(db):
+    captured = svc.capture_pending_player("Promote Me", db=db)
+    pending_id = captured["pending_id"]
+
+    # Invariant precondition: not canonical while pending.
+    assert svc.get_canonical_name("Promote Me", db) is None
+    assert svc.validate_player_for_legacy("Promote Me", db)["valid"] is False
+
+    result = svc.promote_pending_player(pending_id, db=db)
+    assert result["promoted"] is True
+    assert svc.get_canonical_name("Promote Me", db) == "Promote Me"
+
+    row = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.id == pending_id).first()
+    assert row.status == "promoted"
+    assert row.resolved_at is not None
+
+
+def test_dismiss_pending_player(db):
+    captured = svc.capture_pending_player("Dismiss Me", db=db)
+    result = svc.dismiss_pending_player(captured["pending_id"], db=db)
+    assert result["dismissed"] is True
+    row = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.id == captured["pending_id"]).first()
+    assert row.status == "dismissed"
+
+
+# ── The load-bearing invariant ───────────────────────────────────────────────
+
+
+def test_pending_player_never_reads_as_canonical(db):
+    """A captured pending player must not leak into any canonical read."""
+    svc.add_legacy_player("Anchor Player", db=db)  # non-empty table → no JSON fallback
+    svc.capture_pending_player("Ghost Golfer", db=db)
+
+    assert svc.get_canonical_name("Ghost Golfer", db) is None
+    assert svc.is_valid_legacy_player("Ghost Golfer", db) is False
+    assert "Ghost Golfer" not in svc.get_legacy_players(db)
+    assert "Ghost Golfer" not in svc.find_similar_players("Ghost Golfer", db=db)
+    assert svc.validate_player_for_legacy("Ghost Golfer", db)["valid"] is False
+
+
+# ── Roster auto-sync from round history ──────────────────────────────────────
+
+
+def test_sync_adds_new_dropdown_shaped_members(db):
+    svc.add_legacy_player("Anchor Player", db=db)
+    result = svc.sync_roster_from_members(["Anchor Player", "Casey Newmember"], db=db)
+    assert result["added"] == ["Casey Newmember"]
+    assert svc.get_canonical_name("Casey Newmember", db) == "Casey Newmember"
+
+
+def test_sync_skips_format_divergent_names(db):
+    result = svc.sync_roster_from_members(["Smith, Mike", "Mike S", "Real Fullname"], db=db)
+    assert "Real Fullname" in result["added"]
+    assert set(result["skipped_format"]) == {"Smith, Mike", "Mike S"}
+    # Divergent formats must NOT become canonical (they'd silently fail at the CGI).
+    assert svc.get_canonical_name("Smith, Mike", db) is None
+    assert svc.get_canonical_name("Mike S", db) is None
+
+
+def test_sync_dedups_within_batch(db):
+    result = svc.sync_roster_from_members(["Dup Player", "dup player", "DUP PLAYER"], db=db)
+    assert result["added"] == ["Dup Player"]
+    assert db.query(LegacyRosterPlayer).filter(LegacyRosterPlayer.name == "Dup Player").count() == 1
+
+
+def test_sync_resolves_matching_pending(db):
+    svc.capture_pending_player("Returning Golfer", db=db)
+    assert svc.get_canonical_name("Returning Golfer", db) is None
+
+    result = svc.sync_roster_from_members(["Returning Golfer"], db=db)
+    assert "Returning Golfer" in result["added"]
+    assert "Returning Golfer" in result["resolved"]
+
+    row = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.name == "Returning Golfer").first()
+    assert row.status == "promoted"
+
+
+def test_sync_does_not_resolve_pending_for_format_divergent_member(db):
+    # A pending name that only appears in a format-divergent member string must
+    # stay pending (we never confirmed it canonical).
+    svc.capture_pending_player("Mike S", db=db)
+    result = svc.sync_roster_from_members(["Mike S"], db=db)
+    assert "Mike S" not in result["resolved"]
+    row = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.name == "Mike S").first()
+    assert row.status == "pending"
+
+
+def test_sync_never_deletes_existing(db):
+    svc.add_legacy_player("Kept Player", db=db)
+    svc.sync_roster_from_members(["Someone Else"], db=db)
+    assert svc.get_canonical_name("Kept Player", db) == "Kept Player"

--- a/capabilities.yaml
+++ b/capabilities.yaml
@@ -462,3 +462,20 @@ capabilities:
     check:
       shell: cd backend && venv/bin/python -m pytest tests/unit/services/test_livsow_transactions.py
         -q -p no:cacheprovider
+  - id: new-player-capture-persists
+    description: a self-signed-up golfer with no canonical match is captured into the
+      pending queue, never reads as canonical while pending, and round-trips to the
+      canonical roster on admin promote
+    given: a new Auth0 signup whose name is not on the canonical legacy roster
+    when: the profile is created and an admin later promotes the captured row
+    then: the player is queued (not canonical), and after promote validates as canonical
+      (write -> readback)
+    tier: cheap
+    deps:
+    - backend/app/services/legacy_player_service.py
+    - backend/app/services/auth_service.py
+    - backend/app/routers/signups.py
+    check:
+      shell: cd backend && venv/bin/python -m pytest tests/unit/services/test_legacy_player_service.py
+        tests/unit/services/test_auth_new_player_capture.py tests/unit/routers/test_legacy_roster_admin.py
+        -q -p no:cacheprovider


### PR DESCRIPTION
## What & why

Jeff Green owns the legacy tee-sheet system (thousand-cranes.com). His dropdown is the canonical roster, but the app mirrored it as a **static 91-name JSON snapshot** (last refreshed 2026-01-28) — so any golfer added since then failed to match at sign-up and had no home. This makes onboarding for new/returning golfers work end-to-end on the app side, while treating his sheet as the source of truth and **never blindly writing to his CGI**.

## Changes

- **DB-backed canonical roster** (`LegacyRosterPlayer`), seeded from `legacy_players.json`; replaces the static-file lookup. Reads fall back to the JSON seed if the table is empty/unavailable.
- **Pending capture queue** (`PendingLegacyPlayer`), kept **structurally separate** from the canonical roster so a pending name can never read as canonical — which would let that player's sign-ups silently fail at the legacy CGI (the exact silent-failure class this repo already fights).
- **Capture + notify on first login:** a new Auth0 signup with no canonical match is captured and admins are emailed on a **non-blocking daemon thread**; account creation/login is never blocked.
- **Roster auto-reconcile every 2h:** at the tail of the existing `_sync_legacy_rounds` job, the canonical roster is reconciled against players seen in round history — **additive-only** (never deletes), **shape-gated** to skip `"Last, First"`/`"Mike S."` format divergence, and auto-resolves matching pending captures. Isolated so a roster-sync bug can't take down round-history sync.
- **Admin endpoints** (`require_admin`): `POST /legacy-players`, `GET /legacy-players/pending`, `POST /legacy-players/pending/{id}/promote|dismiss`.
- **Migration** `add_legacy_roster_postgres.sql` (runs on Render startup); `create_all` covers sqlite/dev.
- **Capability** `new-player-capture-persists` added and proven.
- **Doc** `CAPABILITIES_ONBOARDING.md` — onboarding capabilities review for Jeff.

## Known residual (documented)

The auto-sync learns players from **round history**, not the live dropdown — so a golfer added to the dropdown who hasn't played yet won't be auto-added. If they sign up in-app first they're captured and an admin promotes them. True real-time lockstep would require reading the CGI's player list directly.

## Test plan

- [x] Backend gate: `ruff check` + `ruff format --check` clean; **1452 passed** (only the known Mac-local SOCKS `startup_test.py` failure, which passes in CI).
- [x] 19 new tests: roster CRUD + the load-bearing invariant (pending never reads as canonical), capture path (captures unmatched, links matched, no re-capture on relogin), admin endpoints (auth + lifecycle), and roster sync (adds dropdown-shaped, skips divergent formats, dedups, resolves pending, never deletes).
- [x] `caps gate` green; `new-player-capture-persists` proven.

This pull request and its description were written by Isaac.
