### PR TITLE
feat(onboarding): welcome email on account creation

### DIFF
--- a/.ctk/ledger.json
+++ b/.ctk/ledger.json
@@ -1,6 +1,6 @@
 {
   "admin-banner-readback": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:0d729383ddd7b13084bb972240c26d4c2baf4a2b808014fbfbebd1821a04a1f8",
     "result": "pass",
     "tier": "cheap",
@@ -28,28 +28,28 @@
     "waiver": null
   },
   "api-surface-no-drift": {
-    "at": "2026-06-17T17:53:41.822843+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:f8b4e5a05bdf57ea0929081415ddbf4822afca29608d94289157f88eb56ffaee",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "auth-rejects-junk-token": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": null,
     "result": "pass",
     "tier": "live",
     "waiver": null
   },
   "auth0-contract": {
-    "at": "2026-06-17T17:53:40.956407+00:00",
-    "fingerprint": "sha256:ddf4fe45cde6d47072a8984e5e40a7ad03dcbd4ed2c2bb99bcc74de76311f334",
+    "at": "2026-06-17T20:11:34.290087+00:00",
+    "fingerprint": "sha256:ee3c5d1288de6ff3fc7ef9b7bdc972c8a67be77c0233af03b61ca17577ca22dd",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "badges-awarded": {
-    "at": "2026-06-17T15:48:47.655647+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:3df0be0ed6d3282a4b052efd31c1e21c446b20ea82e40d63b8bb018a7d7fb480",
     "result": "pass",
     "tier": "cheap",
@@ -63,7 +63,7 @@
     "waiver": null
   },
   "betting-odds-probabilities": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:091f2109fadc3961b1c4178df4e5f289e811fda8753cccaa78adf5052fb9c5a7",
     "result": "pass",
     "tier": "cheap",
@@ -77,77 +77,77 @@
     "waiver": null
   },
   "course-update-preserves-holes": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:0d1e1013615abe81f7b0a11bad29826fe19eaa9d8087f2865dc7fa2115d6a844",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "external-health-monitoring": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:179e60db1e765cf8951db61198c3f110cc2abe78d3664ee819d89b9abe923fc8",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "foretees-contract": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:c0596bf6f32df7a01fdf601592c8e1e98577adcd063c69763a6a87db6cbe58cf",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "game-state-db-authoritative": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:5dfc5022da3a0af1defedc508ac1af94c980772699c66ffa0bc7e35e21b2dd3d",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "ghin-client-contract": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:19bba70760e7dcfc318c08b383c312dca7f30d957d81a9ad8fb1381686c09ec1",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "google-sheets-contract": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:279ef89448c0fb0c44e274103975e302f5a484bbe9c470f3257cf166caf062d5",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "groq-commissioner-contract": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:d8eb31ab1dc25d48937c816f7679089e141f7cec038311f771c18b3eb1b6f5c0",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "groupme-contract": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:18bf88d9a6e4d8bf8798b2b13ff89537a0ff29fa737c1e76dfed843eddf5913d",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "health-live-production": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": null,
     "result": "pass",
     "tier": "live",
     "waiver": null
   },
   "hole-completion-distinct-18": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:0448fe9b0150f76e0314815add8e57f53485a19e9117c0cef67e19988da49f5b",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "leaderboard-from-db": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:79b30232e40a716a3a0cef8290043c1df519754b239d104d0357f267da8a05fe",
     "result": "pass",
     "tier": "cheap",
@@ -161,14 +161,14 @@
     "waiver": null
   },
   "livsow-transactions": {
-    "at": "2026-06-17T15:48:57.330829+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:20e3c16bd375a0dd87aaf75d98c8c9376f54e3cd0520dec3ded3b209e2812ae5",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "matchmaking-pairs": {
-    "at": "2026-06-17T15:48:49.356413+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:cd65b449219d75ccce365cb0734c0c95a47513221382e4a137141dcb66afab3e",
     "result": "pass",
     "tier": "cheap",
@@ -182,7 +182,7 @@
     "waiver": null
   },
   "messages-create-readback": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:29a809c920289e4d6ebefb04b2c1941c2075a95ed3fcffb5f1dd9b12f6d4011c",
     "result": "pass",
     "tier": "cheap",
@@ -196,21 +196,21 @@
     "waiver": null
   },
   "migrations-apply-on-startup": {
-    "at": "2026-06-17T04:14:31.643472+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:f6262668eb20197511742ece3852d2a671b3902d9e22d67dd1ad0a182fd689cc",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "new-player-capture-persists": {
-    "at": "2026-06-17T18:21:07.150409+00:00",
-    "fingerprint": "sha256:0f8c0780826a7265c9a09a832101d132a2171541f8cb4d1ec321ae61b249a9cc",
+    "at": "2026-06-17T20:11:34.290087+00:00",
+    "fingerprint": "sha256:d5eb0e114b4065c142ae073d71f49cdff7c94996fa934aa0cd3f5e5ee170814e",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "notifications-mark-read-persists": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:d37313c6c8341863a8df9266b6427d7d72d7f8b8b278271704b01747b9c0140b",
     "result": "pass",
     "tier": "cheap",
@@ -224,43 +224,43 @@
     "waiver": null
   },
   "player-profiles-persist": {
-    "at": "2026-06-17T15:48:42.599249+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:fdcb06a23cb8f367c760217030366a02cccd7e501c3f19e60b26fc9df10e848e",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "player-updates-persist": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:2af87265ff3585961ea778fa89fca403b6896ebf878235ed0802d36dd22cc5e9",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "post-hole-analytics": {
-    "at": "2026-06-17T15:48:41.670077+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:fcb6e6ba10bab9e72d89d4b8cccc6d0b2ef331f1ec9f2d67578f24c2a14dd3bd",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "request-shape-validation-on-models": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:641e3882cb938f12d28153548bdea69016f0fbc9513ab6ebebdc3fc252d606e9",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "request-validation-422-envelope": {
-    "at": "2026-06-17T17:53:38.447079+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:bf8934b2575a216a70b8056b7dc70c6afcd74610278a1bfa8e5aa67479e9e9fd",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "resend-email-contract": {
-    "at": "2026-06-17T17:53:40.067461+00:00",
-    "fingerprint": "sha256:a9ff6a80eb83a652238993b8a37329b78b0a5fb90b312c4fa7e647598d37ff3f",
+    "at": "2026-06-17T20:11:34.290087+00:00",
+    "fingerprint": "sha256:671d8d7b4bba982fe2bf9940c86c724a096446dc8334daf500437c1fe3be9b44",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
@@ -273,14 +273,14 @@
     "waiver": null
   },
   "scorecard-scan": {
-    "at": "2026-06-17T15:48:55.163090+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:6df755ee0b7c676b045575dbe2e041abf85749e18360e1b9e8ba113c57d6be5d",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "signups-create-persists": {
-    "at": "2026-06-17T17:53:42.859474+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:1f85f378f935234beee8b52c7cf239005a5557b26ae464ef883fad75715acdec",
     "result": "pass",
     "tier": "cheap",
@@ -294,28 +294,28 @@
     "waiver": null
   },
   "stale-local-heals-from-server": {
-    "at": "2026-06-17T15:37:30.033719+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:ce068cb3539df28ccda34ceaaff828f1dfcf32336f47db7a8b508ee2e40f138c",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "statistics-computed": {
-    "at": "2026-06-17T15:48:50.243089+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:69a2fd5a28b104f2aaf89cf612f96546debe147bed57b32f401f8dafeb27876b",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "swallowed-outages-are-captured": {
-    "at": "2026-06-17T15:40:14.199706+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:636921372dc5fbc6e6b744dbfbc75399014623f051246794f98c43a98490b363",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "team-formation-partitions-roster": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:d0eb38f3103796876d4e3e48c3fa78bd20b34c089661a729748abacb29f92aa4",
     "result": "pass",
     "tier": "cheap",
@@ -329,14 +329,14 @@
     "waiver": null
   },
   "tee-sheet-contract": {
-    "at": "2026-06-17T02:54:58.714644+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:ad4615c52d605df1d3148914bd268cb797121fbd081dfa3b2d701cb9a1c553db",
     "result": "pass",
     "tier": "cheap",
     "waiver": null
   },
   "unified-data-aggregation": {
-    "at": "2026-06-17T15:48:56.344023+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:8820ead3838c461c2e56c05f6e667fd882446cd758e622ec77b8d72b18bbe123",
     "result": "pass",
     "tier": "cheap",
@@ -349,8 +349,15 @@
     "tier": "cheap",
     "waiver": null
   },
+  "welcome-email-sent": {
+    "at": "2026-06-17T20:11:34.290087+00:00",
+    "fingerprint": "sha256:ecc7ecd09ae71ea2c86ee4d46791e457a9b0615cc4164917edede8a5c6e6ea43",
+    "result": "pass",
+    "tier": "cheap",
+    "waiver": null
+  },
   "wgp-scoring-rules": {
-    "at": "2026-06-17T15:48:40.602231+00:00",
+    "at": "2026-06-17T20:11:34.290087+00:00",
     "fingerprint": "sha256:786c7bdbf8ce57aaef4e8ad9466020aeb9657b6eed31646c7d8f88e74f31bd3f",
     "result": "pass",
     "tier": "cheap",

--- a/CAPABILITIES_ONBOARDING.md
+++ b/CAPABILITIES_ONBOARDING.md
@@ -18,7 +18,8 @@ works for **both** returning players and brand-new golfers:
 2. **The backend auto-creates a player profile** on that first login — there is no
    separate form for us to maintain. Name, email, and avatar come straight from Auth0;
    handicap defaults to 18.0; email notification preferences are created with sane
-   defaults. This happens for everyone, whether or not they exist on the legacy sheet.
+   defaults; and a one-time **welcome email** goes out. This happens for everyone,
+   whether or not they exist on the legacy sheet.
 3. **The app attempts to fuzzy-match the player to a name on the legacy tee sheet**
    (your system). If it finds a likely match, it pre-fills it.
 4. **One optional onboarding step:** a modal asks the player to confirm/select their
@@ -55,6 +56,7 @@ to a returning player's history; it is not a prerequisite for using the app.
 | **Legacy-name fuzzy matching** | On first login, the app guesses the player's legacy tee-sheet name and suggests it. |
 | **Onboarding modal (legacy-name link)** | One searchable step to confirm/select the legacy identity; "skip for now" supported. |
 | **Daily sign-up → legacy sheet sync** | When a player signs up / changes / cancels for a date, it replicates to the legacy tee sheet. |
+| **Welcome email on account creation** | When a profile is auto-created on first login, the player gets a one-time "welcome to WGP, here's how it works" email (via Resend/SMTP). Best-effort: it runs off the login path, so a mail outage never blocks or slows sign-in. |
 | **Sign-up confirmation email** | Player gets an email when they sign up for a date (via Resend/SMTP). |
 | **Match & pairing notifications** | Availability-match and pairing emails are wired up. |
 | **Profile self-service fields** | Players can set Venmo handle and a short bio/description after onboarding. |
@@ -83,11 +85,9 @@ decide together what matters:
 2. **No handicap capture during sign-up.** There's no onboarding step that asks for or
    verifies a GHIN ID / handicap. New players sit at the 18.0 default until handicap
    sync is finished.
-3. **No welcome / onboarding email.** Players get sign-up and match emails, but nothing
-   on account creation — no "welcome to WGP, here's how it works" message.
-4. **No organizer-facing *UI* for roster management.** The add/pending/promote
+3. **No organizer-facing *UI* for roster management.** The add/pending/promote
    capabilities exist as APIs (§2); there's no admin screen wrapping them yet.
-5. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
+4. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
    (note: Auth0 itself can be configured for passwordless if we want it).
 
 ---

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -9,6 +9,7 @@ from collections.abc import Generator
 from typing import Any
 
 import httpx as _httpx
+import sentry_sdk
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
@@ -51,6 +52,42 @@ def _notify_admins_of_new_player(name: str, email: str | None) -> None:
             logger.warning(f"Failed to notify admins of new player '{name}': {exc}")
 
     threading.Thread(target=_send, daemon=True, name="new-player-notify").start()
+
+
+def _deliver_welcome_email(name: str, email: str | None) -> None:
+    """Synchronously deliver the first-login welcome email. Best-effort.
+
+    Any failure (provider outage, misconfig) is swallowed so it can never break
+    the login path, but it is reported to Sentry — matching the
+    swallowed-outages-are-captured convention used at the Resend/GHIN/Sheets/
+    ForeTees swallow sites — so an outage is observable, not silent.
+    """
+    if not email:
+        return
+    try:
+        from .email_service import get_email_service
+
+        svc = get_email_service()
+        if not svc.is_configured():
+            return
+        svc.send_welcome_email(email, name)
+    except Exception as exc:  # never surface to the login path
+        logger.warning(f"Failed to send welcome email to '{email}': {exc}")
+        sentry_sdk.capture_exception(exc)
+
+
+def _send_welcome_email(name: str, email: str | None) -> None:
+    """Best-effort, non-blocking welcome email on first-login profile creation.
+
+    Runs the (external, potentially slow) send on a daemon thread so it can
+    never add latency to or break the first-login path.
+    """
+    threading.Thread(
+        target=_deliver_welcome_email,
+        args=(name, email),
+        daemon=True,
+        name="welcome-email",
+    ).start()
 
 
 class AuthService:
@@ -167,6 +204,15 @@ class AuthService:
             db.commit()
 
             logger.info(f"Created new player profile for {name} ({email})")
+
+            # Welcome email — fires ONLY on this new-profile branch, never on a
+            # returning login. Best-effort and wrapped so even dispatching it can
+            # never add latency to or break first login; failures go to Sentry.
+            try:
+                _send_welcome_email(name, email)
+            except Exception as exc:
+                logger.warning(f"Failed to dispatch welcome email for '{name}': {exc}")
+                sentry_sdk.capture_exception(exc)
 
             # No canonical legacy match → capture into the pending queue and
             # alert admins so the golfer can be added to Jeff's tee-sheet

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -198,6 +198,46 @@ class EmailService:
             html_body=html_body,
         )
 
+    def send_welcome_email(self, to_email: str, player_name: str) -> bool:
+        """Sends a welcome email when a new account is auto-created on first login.
+
+        A one-time "welcome to WGP, here's how it works" transactional email,
+        styled like send_signup_confirmation (HTML + plaintext via the base
+        template). Matches the existing convention: the method just builds and
+        sends — no per-method opt-out gate (preferences are seeded with sane
+        defaults at account creation and managed via /me/email-preferences).
+        """
+        content = f"""
+        <h2>Welcome to Wolf Goat Pig!</h2>
+        <p>Hi {player_name},</p>
+        <p>Your account is all set &mdash; welcome to the league. Here's how it works:</p>
+        <ul>
+            <li><strong>Sign up for play dates</strong> and we'll sync you to the tee sheet.</li>
+            <li><strong>Get matched &amp; paired</strong> &mdash; we'll email you when a group comes together.</li>
+            <li><strong>Track your games and standings</strong> right in the app.</li>
+        </ul>
+        <p>See you on the course! &#127948;</p>
+        """
+        template = Template(self._get_base_template())
+        html_body = template.render(subject="Welcome to Wolf Goat Pig", content=content)
+
+        text_body = (
+            f"Welcome to Wolf Goat Pig!\n\n"
+            f"Hi {player_name},\n\n"
+            "Your account is all set - welcome to the league. Here's how it works:\n"
+            "- Sign up for play dates and we'll sync you to the tee sheet.\n"
+            "- Get matched & paired - we'll email you when a group comes together.\n"
+            "- Track your games and standings right in the app.\n\n"
+            "See you on the course!"
+        )
+
+        return self._send_email(
+            to_email=to_email,
+            subject="Welcome to Wolf Goat Pig",
+            html_body=html_body,
+            text_body=text_body,
+        )
+
     def send_new_player_notification(
         self,
         to_email: str,

--- a/backend/tests/unit/services/test_auth_welcome_email.py
+++ b/backend/tests/unit/services/test_auth_welcome_email.py
@@ -1,0 +1,116 @@
+"""Tests for the welcome email sent on first-login profile creation.
+
+When a brand-new account is auto-created on first Auth0 login, the player gets
+a one-time welcome email. It fires ONLY on the new-profile branch (never on a
+returning login), and it is strictly best-effort: any failure is captured to
+Sentry but never blocks or breaks login.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+import sentry_sdk
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.services import auth_service as auth_module
+from app.services import legacy_player_service as svc
+from app.services.auth_service import AuthService
+
+TEST_DATABASE_URL = "sqlite:///./test_auth_welcome.db"
+engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def welcome_spy(monkeypatch):
+    """Replace the (threaded, external) welcome send with a synchronous spy."""
+    spy = Mock()
+    monkeypatch.setattr(auth_module, "_send_welcome_email", spy)
+    return spy
+
+
+@pytest.fixture
+def notify_spy(monkeypatch):
+    """Silence the threaded admin-notify so it can't fire real emails/threads."""
+    spy = Mock()
+    monkeypatch.setattr(auth_module, "_notify_admins_of_new_player", spy)
+    return spy
+
+
+def test_welcome_email_sent_once_for_new_profile(db, welcome_spy):
+    # Canonical match present → isolates the welcome path from pending-capture.
+    svc.add_legacy_player("Brand New Golfer", db=db)
+
+    auth0_user = {
+        "sub": "auth0|brandnew",
+        "email": "brandnew@example.com",
+        "name": "Brand New Golfer",
+        "picture": None,
+    }
+    player = AuthService.get_or_create_player_profile(db, auth0_user)
+
+    assert player.id is not None
+    welcome_spy.assert_called_once_with("Brand New Golfer", "brandnew@example.com")
+
+
+def test_welcome_email_not_sent_for_returning_player(db, welcome_spy):
+    svc.add_legacy_player("Returning Golfer", db=db)
+    auth0_user = {
+        "sub": "auth0|returning",
+        "email": "returning@example.com",
+        "name": "Returning Golfer",
+        "picture": None,
+    }
+    # First login creates the profile (welcome fires once).
+    AuthService.get_or_create_player_profile(db, auth0_user)
+    welcome_spy.reset_mock()
+
+    # Second login returns the existing profile — welcome must NOT fire again.
+    player = AuthService.get_or_create_player_profile(db, auth0_user)
+    assert player.email == "returning@example.com"
+    welcome_spy.assert_not_called()
+
+
+def test_welcome_email_failure_is_captured_and_login_survives(db, monkeypatch):
+    """When the email send raises, it is reported to Sentry and login still works."""
+    svc.add_legacy_player("Brand New Golfer", db=db)
+
+    # Run delivery synchronously (no daemon thread) so we can assert on it,
+    # exercising the real dispatch -> deliver -> send path.
+    monkeypatch.setattr(auth_module, "_send_welcome_email", auth_module._deliver_welcome_email)
+
+    boom_svc = Mock()
+    boom_svc.is_configured.return_value = True
+    boom_svc.send_welcome_email.side_effect = RuntimeError("resend down")
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: boom_svc)
+
+    captured: list[BaseException] = []
+    monkeypatch.setattr(sentry_sdk, "capture_exception", lambda e: captured.append(e))
+
+    auth0_user = {
+        "sub": "auth0|brandnew",
+        "email": "brandnew@example.com",
+        "name": "Brand New Golfer",
+        "picture": None,
+    }
+    # Login must still succeed and return the persisted profile.
+    player = AuthService.get_or_create_player_profile(db, auth0_user)
+
+    assert player.id is not None
+    assert player.email == "brandnew@example.com"
+    boom_svc.send_welcome_email.assert_called_once()
+    assert len(captured) == 1
+    assert isinstance(captured[0], RuntimeError)

--- a/capabilities.yaml
+++ b/capabilities.yaml
@@ -462,6 +462,22 @@ capabilities:
     check:
       shell: cd backend && venv/bin/python -m pytest tests/unit/services/test_livsow_transactions.py
         -q -p no:cacheprovider
+  - id: welcome-email-sent
+    description: a one-time welcome email is sent exactly when a new player profile is
+      auto-created on first login, never on a returning login, and best-effort so a send
+      failure is captured to Sentry but never breaks or blocks login
+    given: an Auth0 login that either creates a new profile or returns an existing one
+    when: get_or_create_player_profile runs
+    then: send_welcome_email fires once on the new-profile branch and not at all for a
+      returning player; if the send raises, the exception is captured to Sentry and the
+      profile is still returned (login unbroken)
+    tier: cheap
+    deps:
+    - backend/app/services/auth_service.py
+    - backend/app/services/email_service.py
+    check:
+      shell: cd backend && venv/bin/python -m pytest tests/unit/services/test_auth_welcome_email.py
+        -q -p no:cacheprovider
   - id: new-player-capture-persists
     description: a self-signed-up golfer with no canonical match is captured into the
       pending queue, never reads as canonical while pending, and round-trips to the


### PR DESCRIPTION
## What

Sends a one-time **welcome / onboarding email** when a new player profile is auto-created on first Auth0 login. Closes the §4 "No welcome / onboarding email" gap in `CAPABILITIES_ONBOARDING.md`.

## How

- **`EmailService.send_welcome_email(to_email, player_name)`** — styled like the existing `send_signup_confirmation` (HTML + plaintext, "here's how it works" intro). No new opt-out gate: it fires at the instant the profile + default `EmailPreferences` are created, matching how the other transactional emails behave.
- **Wired into `auth_service.get_or_create_player_profile`** — fires **only** on the new-profile branch, never on a returning login. Delivery runs on a **daemon thread** (mirroring the existing `_notify_admins_of_new_player`) so it adds **zero latency** to the first-login path, and the dispatch is wrapped so any failure is caught, reported via `sentry_sdk.capture_exception`, and **never raises into login**.

## Safety

The first-login path "can never add latency to or break" login — honored: the background thread closes over **plain `name`/`email` values only** (no request-scoped DB session or ORM object crosses the thread boundary), and both the dispatch site and the in-thread send are failure-isolated + Sentry-captured.

## Proof

- New test `backend/tests/unit/services/test_auth_welcome_email.py`: (a) sent once on a new profile, (b) **not** sent on a returning login, (c) a raising send is captured to Sentry **and** the profile is still returned. — 3 passed.
- New `caps` capability **`welcome-email-sent`** (tier cheap) wired into the green gate. `caps verify` → exit 0, `welcome-email-sent: pass`.
- No regressions: player_service / resend_contract / silent_failure_capture — 43 passed.
- Independent cross-vendor review (Codex): no blocking/non-blocking/suggestion findings.

## Docs

`CAPABILITIES_ONBOARDING.md`: moved welcome email out of §4 "not built yet" → §2 "live today", renumbered §4, kept the §1 happy-path note consistent.

## Files

- `backend/app/services/email_service.py`
- `backend/app/services/auth_service.py`
- `backend/tests/unit/services/test_auth_welcome_email.py` (new)
- `capabilities.yaml`
- `CAPABILITIES_ONBOARDING.md`
- `.ctk/ledger.json` (caps proof artifact)