### PR TITLE
feat(admin): roster management screen

### DIFF
--- a/CAPABILITIES_ONBOARDING.md
+++ b/CAPABILITIES_ONBOARDING.md
@@ -51,6 +51,7 @@ to a returning player's history; it is not a prerequisite for using the app.
 | **Canonical roster (DB-backed, auto-updating)** | The set of valid player names — your tee-sheet dropdown — lives in the database (seeded from your roster) and **auto-reconciles every 2 hours** against players seen in round history, so it stays current instead of being a frozen file. Additive only (never deletes). |
 | **New-player capture + admin alert** | When a brand-new golfer signs up with no match on your roster, they're **captured into a pending queue** and admins get an **email alert** to add them to your tee sheet. Login is never blocked by this. |
 | **Admin roster management (API)** | Endpoints to add a name to the canonical roster, list pending new players, and **promote** one onto the roster (or dismiss a misspelling) once they're on your sheet. |
+| **Admin roster management (UI)** | Organizer-facing screen at `/admin/roster` (linked from the Admin dashboard): lists pending sign-ups with Promote/Dismiss actions, plus a form to add a name directly to the canonical roster. |
 | **Direct profile-create API** | A `POST /players` endpoint exists for programmatic/admin profile creation. |
 | **Legacy-name fuzzy matching** | On first login, the app guesses the player's legacy tee-sheet name and suggests it. |
 | **Onboarding modal (legacy-name link)** | One searchable step to confirm/select the legacy identity; "skip for now" supported. |
@@ -85,11 +86,7 @@ decide together what matters:
    sync is finished.
 3. **No welcome / onboarding email.** Players get sign-up and match emails, but nothing
    on account creation — no "welcome to WGP, here's how it works" message.
-4. ~~**No organizer-facing *UI* for roster management.**~~ ✅ **Done** — the
-   add/pending/promote capabilities (§2) are now wrapped by an admin screen at
-   `/admin/roster` (linked from the Admin dashboard): list pending sign-ups with
-   Promote/Dismiss actions, plus a form to add a name directly to the roster.
-5. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
+4. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
    (note: Auth0 itself can be configured for passwordless if we want it).
 
 ---

--- a/CAPABILITIES_ONBOARDING.md
+++ b/CAPABILITIES_ONBOARDING.md
@@ -85,8 +85,10 @@ decide together what matters:
    sync is finished.
 3. **No welcome / onboarding email.** Players get sign-up and match emails, but nothing
    on account creation — no "welcome to WGP, here's how it works" message.
-4. **No organizer-facing *UI* for roster management.** The add/pending/promote
-   capabilities exist as APIs (§2); there's no admin screen wrapping them yet.
+4. ~~**No organizer-facing *UI* for roster management.**~~ ✅ **Done** — the
+   add/pending/promote capabilities (§2) are now wrapped by an admin screen at
+   `/admin/roster` (linked from the Admin dashboard): list pending sign-ups with
+   Promote/Dismiss actions, plus a form to add a name directly to the roster.
 5. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
    (note: Auth0 itself can be configured for passwordless if we want it).
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,7 @@ const AboutPage = React.lazy(() => import("./pages/AboutPage"));
 const RulesPage = React.lazy(() => import("./pages/RulesPage"));
 const AdminPage = React.lazy(() => import("./pages/AdminPage"));
 const DatabaseMigrations = React.lazy(() => import("./components/admin/DatabaseMigrations"));
+const RosterManager = React.lazy(() => import("./components/admin/RosterManager"));
 const CreateGamePage = React.lazy(() => import("./pages/CreateGamePage"));
 const JoinGamePage = React.lazy(() => import("./pages/JoinGamePage"));
 const GameLobbyPage = React.lazy(() => import("./pages/GameLobbyPage"));
@@ -403,6 +404,14 @@ function App() {
                 element={
                   <ProtectedRoute>
                     <DatabaseMigrations />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/admin/roster"
+                element={
+                  <ProtectedRoute>
+                    <RosterManager />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/components/admin/RosterManager.jsx
+++ b/frontend/src/components/admin/RosterManager.jsx
@@ -53,7 +53,7 @@ const RosterManager = () => {
     setLoading(true);
     setError("");
     try {
-      const response = await fetch(`${API_URL}/legacy-players/pending`, {
+      const response = await fetch(`${API_URL}/legacy-players/pending?status=pending`, {
         headers: adminHeaders(),
       });
       if (!response.ok) {
@@ -117,7 +117,7 @@ const RosterManager = () => {
         `${API_URL}/legacy-players/pending/${player.id}/promote`,
         {
           method: "POST",
-          headers: adminHeaders(),
+          headers: { "Content-Type": "application/json", ...adminHeaders() },
         },
       );
       const data = await response.json().catch(() => ({}));
@@ -142,7 +142,7 @@ const RosterManager = () => {
         `${API_URL}/legacy-players/pending/${player.id}/dismiss`,
         {
           method: "POST",
-          headers: adminHeaders(),
+          headers: { "Content-Type": "application/json", ...adminHeaders() },
         },
       );
       const data = await response.json().catch(() => ({}));

--- a/frontend/src/components/admin/RosterManager.jsx
+++ b/frontend/src/components/admin/RosterManager.jsx
@@ -1,0 +1,325 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth0 } from "@auth0/auth0-react";
+import { Card } from "../ui";
+import {
+  isAdminEmail,
+  getStoredUserEmail,
+  adminHeaders,
+} from "../../utils/adminAuth";
+import { apiConfig } from "../../config/api.config";
+
+const API_URL = apiConfig.baseUrl;
+
+/**
+ * Organizer-facing roster management.
+ *
+ * Wraps the admin legacy-roster endpoints (all gated by X-Admin-Email):
+ *   GET  /legacy-players/pending            — capture queue
+ *   POST /legacy-players/pending/{id}/promote
+ *   POST /legacy-players/pending/{id}/dismiss
+ *   POST /legacy-players  {name}            — add to canonical roster
+ *
+ * Promote a captured golfer once they exist on Jeff's legacy dropdown;
+ * dismiss a misspelling. Add a name directly when you already know it is
+ * on the dropdown.
+ */
+const RosterManager = () => {
+  const navigate = useNavigate();
+  const { user, isLoading: authLoading } = useAuth0();
+
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [checkingAdmin, setCheckingAdmin] = useState(true);
+
+  const [pending, setPending] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [feedback, setFeedback] = useState("");
+
+  const [newName, setNewName] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [actingId, setActingId] = useState(null);
+
+  // Auth0 identity is authoritative; stored email is a fallback on reload.
+  // No hardcoded default — unknown users are never admins.
+  useEffect(() => {
+    if (authLoading) return;
+    const email = user?.email || getStoredUserEmail();
+    setIsAdmin(isAdminEmail(email));
+    setCheckingAdmin(false);
+  }, [authLoading, user]);
+
+  const fetchPending = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch(`${API_URL}/legacy-players/pending`, {
+        headers: adminHeaders(),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      setPending(data.players || []);
+    } catch (err) {
+      setError(`Could not load pending players: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin) {
+      fetchPending();
+    }
+  }, [isAdmin, fetchPending]);
+
+  const addName = async (e) => {
+    e.preventDefault();
+    const name = newName.trim();
+    if (!name) return;
+
+    setAdding(true);
+    setFeedback("");
+    setError("");
+    try {
+      const response = await fetch(`${API_URL}/legacy-players`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...adminHeaders(),
+        },
+        body: JSON.stringify({ name }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.detail || `HTTP ${response.status}`);
+      }
+      if (data.added) {
+        setFeedback(`✓ Added "${data.canonical_name || name}" to the roster`);
+      } else {
+        setFeedback(data.message || `"${name}" is already in the roster`);
+      }
+      setNewName("");
+    } catch (err) {
+      setError(`Could not add player: ${err.message}`);
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const promote = async (player) => {
+    setActingId(player.id);
+    setFeedback("");
+    setError("");
+    try {
+      const response = await fetch(
+        `${API_URL}/legacy-players/pending/${player.id}/promote`,
+        {
+          method: "POST",
+          headers: adminHeaders(),
+        },
+      );
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.detail || `HTTP ${response.status}`);
+      }
+      setFeedback(`✓ Promoted "${player.name}" to the canonical roster`);
+      await fetchPending();
+    } catch (err) {
+      setError(`Could not promote "${player.name}": ${err.message}`);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const dismiss = async (player) => {
+    setActingId(player.id);
+    setFeedback("");
+    setError("");
+    try {
+      const response = await fetch(
+        `${API_URL}/legacy-players/pending/${player.id}/dismiss`,
+        {
+          method: "POST",
+          headers: adminHeaders(),
+        },
+      );
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.detail || `HTTP ${response.status}`);
+      }
+      setFeedback(`✓ Dismissed "${player.name}"`);
+      await fetchPending();
+    } catch (err) {
+      setError(`Could not dismiss "${player.name}": ${err.message}`);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  if (checkingAdmin) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div
+          className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"
+          data-testid="roster-loading"
+        ></div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen bg-gray-50 py-8">
+        <div className="max-w-4xl mx-auto px-4">
+          <Card className="p-8 text-center">
+            <h2 className="text-2xl font-bold text-red-600 mb-4">
+              Access Denied
+            </h2>
+            <p className="text-gray-600 mb-6">
+              You don't have permission to access this page.
+            </p>
+            <button
+              onClick={() => navigate("/")}
+              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+              Go to Home
+            </button>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-4xl mx-auto px-4">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            👥 Roster Management
+          </h1>
+          <p className="text-gray-600">
+            Promote captured sign-ups onto the canonical legacy roster, or add a
+            name directly once it exists on the tee-sheet dropdown.
+          </p>
+        </div>
+
+        {feedback && (
+          <div
+            className="mb-6 p-4 rounded-lg bg-green-100 text-green-800"
+            data-testid="roster-feedback"
+          >
+            {feedback}
+          </div>
+        )}
+        {error && (
+          <div
+            className="mb-6 p-4 rounded-lg bg-red-100 text-red-800"
+            data-testid="roster-error"
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Add a name directly to the canonical roster */}
+        <Card className="p-6 mb-6">
+          <h2 className="text-xl font-semibold mb-4">Add to Canonical Roster</h2>
+          <p className="text-sm text-gray-600 mb-4">
+            Use this once the player is known to exist on Jeff's legacy dropdown.
+          </p>
+          <form onSubmit={addName} className="flex space-x-4">
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Player full name (e.g. Jane Smith)"
+              aria-label="Player full name"
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+            <button
+              type="submit"
+              disabled={!newName.trim() || adding}
+              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {adding ? "Adding..." : "Add Player"}
+            </button>
+          </form>
+        </Card>
+
+        {/* Pending capture queue */}
+        <Card className="p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">
+              Pending Sign-ups{" "}
+              {pending.length > 0 && (
+                <span className="text-gray-500 font-normal">
+                  ({pending.length})
+                </span>
+              )}
+            </h2>
+            <button
+              onClick={fetchPending}
+              disabled={loading}
+              className="text-sm px-3 py-1 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 disabled:opacity-50"
+            >
+              {loading ? "Refreshing..." : "Refresh"}
+            </button>
+          </div>
+          <p className="text-sm text-gray-600 mb-4">
+            Golfers who signed up in the app but have no canonical match yet.
+            Promote once they're on the dropdown, or dismiss a misspelling.
+          </p>
+
+          {loading ? (
+            <div className="py-8 text-center text-gray-500" data-testid="pending-loading">
+              Loading pending players...
+            </div>
+          ) : pending.length === 0 ? (
+            <div
+              className="py-8 text-center text-gray-500"
+              data-testid="pending-empty"
+            >
+              No pending sign-ups. The capture queue is clear. 🎉
+            </div>
+          ) : (
+            <ul className="divide-y divide-gray-200">
+              {pending.map((player) => (
+                <li
+                  key={player.id}
+                  data-testid={`pending-row-${player.id}`}
+                  className="py-4 flex items-center justify-between"
+                >
+                  <div>
+                    <p className="font-medium text-gray-900">{player.name}</p>
+                    {player.email && (
+                      <p className="text-sm text-gray-500">{player.email}</p>
+                    )}
+                  </div>
+                  <div className="flex space-x-2">
+                    <button
+                      onClick={() => promote(player)}
+                      disabled={actingId === player.id}
+                      className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50"
+                    >
+                      {actingId === player.id ? "..." : "Promote"}
+                    </button>
+                    <button
+                      onClick={() => dismiss(player)}
+                      disabled={actingId === player.id}
+                      className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+                    >
+                      {actingId === player.id ? "..." : "Dismiss"}
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default RosterManager;

--- a/frontend/src/components/admin/__tests__/RosterManager.test.jsx
+++ b/frontend/src/components/admin/__tests__/RosterManager.test.jsx
@@ -1,0 +1,150 @@
+// frontend/src/components/admin/__tests__/RosterManager.test.jsx
+import React from "react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+import RosterManager from "../RosterManager";
+
+const ADMIN_EMAIL = "stuagano@gmail.com";
+const API_URL = "http://test-api.com"; // matches VITE_API_URL stub in setupTests
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+// Mutable auth identity so individual tests can switch admin/non-admin.
+let mockAuth = { user: { email: ADMIN_EMAIL }, isLoading: false };
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: () => mockAuth,
+}));
+
+const PENDING = [
+  { id: 11, name: "Alice Adams", email: "alice@example.com", status: "pending" },
+  { id: 22, name: "Bob Brown", email: null, status: "pending" },
+];
+
+const okJson = (body) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(""),
+  });
+
+function installAdminFetch(pending = PENDING) {
+  global.fetch.mockImplementation((url, opts = {}) => {
+    if (url.endsWith("/legacy-players/pending")) {
+      return okJson({ count: pending.length, status: "pending", players: pending });
+    }
+    if (url.includes("/promote")) {
+      return okJson({ promoted: true, canonical_name: "Alice Adams" });
+    }
+    if (url.includes("/dismiss")) {
+      return okJson({ dismissed: true, name: "Bob Brown" });
+    }
+    if (url.endsWith("/legacy-players") && opts.method === "POST") {
+      return okJson({ added: true, canonical_name: "Jane Smith", message: "Added" });
+    }
+    return okJson({});
+  });
+}
+
+/** Find the fetch call whose URL matches a predicate. */
+function findCall(predicate) {
+  return global.fetch.mock.calls.find(([url, opts]) => predicate(url, opts));
+}
+
+beforeEach(() => {
+  mockAuth = { user: { email: ADMIN_EMAIL }, isLoading: false };
+  mockNavigate.mockClear();
+  // adminHeaders() reads localStorage 'userEmail' for the X-Admin-Email header.
+  localStorage.setItem("userEmail", ADMIN_EMAIL);
+  installAdminFetch();
+});
+
+describe("RosterManager", () => {
+  test("renders a row for each pending player", async () => {
+    render(<RosterManager />);
+    expect(await screen.findByTestId("pending-row-11")).toBeInTheDocument();
+    expect(screen.getByTestId("pending-row-22")).toBeInTheDocument();
+    expect(screen.getByText("Alice Adams")).toBeInTheDocument();
+    expect(screen.getByText("Bob Brown")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+
+    // Pending list was fetched with the admin auth header.
+    const listCall = findCall((url) => url.endsWith("/legacy-players/pending"));
+    expect(listCall).toBeTruthy();
+    expect(listCall[1].headers["X-Admin-Email"]).toBe(ADMIN_EMAIL);
+  });
+
+  test("PROMOTE posts to the promote endpoint with the admin header", async () => {
+    render(<RosterManager />);
+    await screen.findByTestId("pending-row-11");
+
+    const row = screen.getByTestId("pending-row-11");
+    fireEvent.click(within(row).getByText("Promote"));
+
+    await waitFor(() => {
+      const call = findCall((url) => url.endsWith("/legacy-players/pending/11/promote"));
+      expect(call).toBeTruthy();
+      expect(call[1].method).toBe("POST");
+      expect(call[1].headers["X-Admin-Email"]).toBe(ADMIN_EMAIL);
+    });
+    // Success feedback shown + list refreshed.
+    expect(await screen.findByTestId("roster-feedback")).toHaveTextContent(/Promoted/i);
+  });
+
+  test("DISMISS posts to the dismiss endpoint with the admin header", async () => {
+    render(<RosterManager />);
+    await screen.findByTestId("pending-row-22");
+
+    const row = screen.getByTestId("pending-row-22");
+    fireEvent.click(within(row).getByText("Dismiss"));
+
+    await waitFor(() => {
+      const call = findCall((url) => url.endsWith("/legacy-players/pending/22/dismiss"));
+      expect(call).toBeTruthy();
+      expect(call[1].method).toBe("POST");
+      expect(call[1].headers["X-Admin-Email"]).toBe(ADMIN_EMAIL);
+    });
+    expect(await screen.findByTestId("roster-feedback")).toHaveTextContent(/Dismissed/i);
+  });
+
+  test("ADD form POSTs the new name to the canonical roster", async () => {
+    render(<RosterManager />);
+    await screen.findByTestId("pending-row-11");
+
+    fireEvent.change(screen.getByLabelText("Player full name"), {
+      target: { value: "Jane Smith" },
+    });
+    fireEvent.click(screen.getByText("Add Player"));
+
+    await waitFor(() => {
+      const call = findCall(
+        (url, opts) => url.endsWith("/legacy-players") && opts?.method === "POST",
+      );
+      expect(call).toBeTruthy();
+      expect(JSON.parse(call[1].body)).toEqual({ name: "Jane Smith" });
+      expect(call[1].headers["X-Admin-Email"]).toBe(ADMIN_EMAIL);
+      expect(call[1].headers["Content-Type"]).toBe("application/json");
+    });
+    expect(await screen.findByTestId("roster-feedback")).toHaveTextContent(/Added/i);
+  });
+
+  test("shows the empty state when there are no pending players", async () => {
+    installAdminFetch([]);
+    render(<RosterManager />);
+    expect(await screen.findByTestId("pending-empty")).toBeInTheDocument();
+  });
+
+  test("non-admins see Access Denied and no roster fetch is made", async () => {
+    mockAuth = { user: { email: "random@nobody.com" }, isLoading: false };
+    localStorage.setItem("userEmail", "random@nobody.com");
+
+    render(<RosterManager />);
+    expect(await screen.findByText("Access Denied")).toBeInTheDocument();
+
+    expect(
+      findCall((url) => url.endsWith("/legacy-players/pending")),
+    ).toBeFalsy();
+  });
+});

--- a/frontend/src/components/admin/__tests__/RosterManager.test.jsx
+++ b/frontend/src/components/admin/__tests__/RosterManager.test.jsx
@@ -32,7 +32,7 @@ const okJson = (body) =>
 
 function installAdminFetch(pending = PENDING) {
   global.fetch.mockImplementation((url, opts = {}) => {
-    if (url.endsWith("/legacy-players/pending")) {
+    if (url.includes("/legacy-players/pending") && !url.includes("/promote") && !url.includes("/dismiss")) {
       return okJson({ count: pending.length, status: "pending", players: pending });
     }
     if (url.includes("/promote")) {
@@ -70,8 +70,8 @@ describe("RosterManager", () => {
     expect(screen.getByText("Bob Brown")).toBeInTheDocument();
     expect(screen.getByText("alice@example.com")).toBeInTheDocument();
 
-    // Pending list was fetched with the admin auth header.
-    const listCall = findCall((url) => url.endsWith("/legacy-players/pending"));
+    // Pending list was fetched with ?status=pending filter and the admin auth header.
+    const listCall = findCall((url) => url.includes("/legacy-players/pending?status=pending"));
     expect(listCall).toBeTruthy();
     expect(listCall[1].headers["X-Admin-Email"]).toBe(ADMIN_EMAIL);
   });
@@ -88,9 +88,17 @@ describe("RosterManager", () => {
       expect(call).toBeTruthy();
       expect(call[1].method).toBe("POST");
       expect(call[1].headers["X-Admin-Email"]).toBe(ADMIN_EMAIL);
+      expect(call[1].headers["Content-Type"]).toBe("application/json");
     });
-    // Success feedback shown + list refreshed.
+    // Success feedback shown.
     expect(await screen.findByTestId("roster-feedback")).toHaveTextContent(/Promoted/i);
+    // List must be re-fetched after promote (refresh-after-mutation).
+    await waitFor(() => {
+      const refreshCalls = global.fetch.mock.calls.filter(
+        ([url]) => url.includes("/legacy-players/pending?status=pending"),
+      );
+      expect(refreshCalls.length).toBeGreaterThanOrEqual(2);
+    });
   });
 
   test("DISMISS posts to the dismiss endpoint with the admin header", async () => {
@@ -105,8 +113,16 @@ describe("RosterManager", () => {
       expect(call).toBeTruthy();
       expect(call[1].method).toBe("POST");
       expect(call[1].headers["X-Admin-Email"]).toBe(ADMIN_EMAIL);
+      expect(call[1].headers["Content-Type"]).toBe("application/json");
     });
     expect(await screen.findByTestId("roster-feedback")).toHaveTextContent(/Dismissed/i);
+    // List must be re-fetched after dismiss (refresh-after-mutation).
+    await waitFor(() => {
+      const refreshCalls = global.fetch.mock.calls.filter(
+        ([url]) => url.includes("/legacy-players/pending?status=pending"),
+      );
+      expect(refreshCalls.length).toBeGreaterThanOrEqual(2);
+    });
   });
 
   test("ADD form POSTs the new name to the canonical roster", async () => {
@@ -144,7 +160,7 @@ describe("RosterManager", () => {
     expect(await screen.findByText("Access Denied")).toBeInTheDocument();
 
     expect(
-      findCall((url) => url.endsWith("/legacy-players/pending")),
+      findCall((url) => url.includes("/legacy-players/pending")),
     ).toBeFalsy();
   });
 });

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -517,6 +517,12 @@ const AdminPage = () => {
           >
             🎲 Foursomes
           </button>
+          <button
+            onClick={() => navigate('/admin/roster')}
+            className="flex-1 px-4 py-2 rounded-md font-medium transition-colors text-gray-600 hover:text-gray-900"
+          >
+            👥 Roster
+          </button>
         </div>
 
         {/* Email Settings Tab */}


### PR DESCRIPTION
## What

Organizer-facing **Roster Management** admin screen that wraps the existing legacy-roster admin APIs. Closes gap #4 in `CAPABILITIES_ONBOARDING.md` ("No organizer-facing UI for roster management").

## Screen (`/admin/roster`)

- **Pending sign-ups list** — each captured golfer renders with a **Promote** and a **Dismiss** action wired to the real endpoints.
- **Add to canonical roster** — form to add a name directly once it's on Jeff's legacy dropdown.
- Success/error feedback, automatic list refresh after each action, plus loading and empty states.
- Surfaced from `AdminPage` via a new **👥 Roster** nav entry.

## How it's wired

- New route `/admin/roster` (lazy-loaded + `ProtectedRoute`), mirroring how `/admin/migrations` is wired in `App.jsx`.
- `RosterManager` self-gates with the same `adminAuth` pattern as the other admin routes (`isAdminEmail(user?.email || getStoredUserEmail())` → Access Denied for non-admins).
- API calls use the existing `adminHeaders()` (`X-Admin-Email`) + `apiConfig.baseUrl` pattern — no new ad-hoc fetch style.
- Tailwind + shared `Card` styling, matching `AdminPage`.

## Endpoint map (all pre-existing, admin-gated via `require_admin` / `X-Admin-Email`)

| Op | Method + path | Body | Response |
|----|---------------|------|----------|
| Add to roster | `POST /legacy-players` | `{name}` | `{added, canonical_name, message}` |
| List pending | `GET /legacy-players/pending` | — | `{count, status, players:[{id,name,email,…}]}` |
| Promote | `POST /legacy-players/pending/{id}/promote` | — | `{promoted, canonical_name}` (404 if not promotable) |
| Dismiss | `POST /legacy-players/pending/{id}/dismiss` | — | `{dismissed, name}` (404 if not dismissable) |

No endpoint had to be added — the screen purely wraps already-existing, already-proven endpoints (`backend/tests/unit/routers/test_legacy_roster_admin.py`). **No backend change → no new `caps` entry required.** The vitest component test is the proof.

## Tests — `frontend/src/components/admin/__tests__/RosterManager.test.jsx`

- pending list renders a row per player;
- **Promote** / **Dismiss** call the correct endpoint with the right id **and** the `X-Admin-Email` header;
- add-name form POSTs `{name}` with the header + `Content-Type`;
- empty-list state;
- non-admin → Access Denied and no roster fetch.

## Verification

- `npm run typecheck` ✅ (resolves the new lazy import + component + edits)
- `npx vitest run` ✅ 493 + 6 new pass. (Pre-existing `sentry.test.js` fails locally only — `@sentry/react`, a declared dep, isn't installed in the local `node_modules`; identical on `main`, green in CI which installs deps fresh.)

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced admin roster management interface for organizers at `/admin/roster`
  * Admins can now view pending sign-ups and take promote/dismiss actions on applicants
  * Added form to add player names directly to the canonical roster
  * New "Roster" navigation tab in Admin Dashboard for quick access

* **Documentation**
  * Documented the new admin roster management capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->