### PR TITLE
Display Wing Point course handicap

### DIFF
--- a/frontend/src/components/game/ScoreInputField.jsx
+++ b/frontend/src/components/game/ScoreInputField.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from '../../theme/Provider';
 import { Input } from '../ui';
 import { SCORE_CONSTRAINTS } from '../../hooks/useScoreValidation';
+import { calculateCourseHandicap } from '../../utils';
 import '../../styles/mobile-touch.css';
 
 /**
@@ -152,7 +153,7 @@ const ScoreInputField = ({
             fontWeight: 'normal',
             marginLeft: '10px'
           }}>
-            (Hdcp {player.handicap})
+            (Hdcp {calculateCourseHandicap(player.handicap)})
           </span>
         )}
       </h3>

--- a/frontend/src/components/game/Scorecard.jsx
+++ b/frontend/src/components/game/Scorecard.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Card, Button, Input } from '../ui';
 import { useTheme } from '../../theme/Provider';
+import { calculateCourseHandicap } from '../../utils';
 
 /**
  * Unified Scorecard component for both real games and simulations
@@ -481,7 +482,7 @@ const Scorecard = ({
                   >
                     {isHuman ? '👤 ' : '🤖 '}
                     {playerName}
-                    {player.handicap != null && <span style={{ fontSize: '10px', marginLeft: '4px', opacity: 0.7 }}>({player.handicap})</span>}
+                    {player.handicap != null && <span style={{ fontSize: '10px', marginLeft: '4px', opacity: 0.7 }}>({calculateCourseHandicap(player.handicap)})</span>}
                     {onPlayerNameChange && <span style={{ fontSize: '10px', marginLeft: '4px', opacity: 0.5 }}>✏️</span>}
                   </div>
                   <div>Stroke</div>

--- a/frontend/src/components/game/__tests__/ScoreInputField.test.jsx
+++ b/frontend/src/components/game/__tests__/ScoreInputField.test.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import ScoreInputField from '../ScoreInputField';
+import { calculateCourseHandicap } from '../../../utils';
 
 // Mock the useTheme hook
 vi.mock('../../../theme/Provider', () => ({
@@ -103,9 +104,26 @@ describe('ScoreInputField', () => {
       expect(screen.getByText('Test Player')).toBeInTheDocument();
     });
 
-    test('shows player handicap', () => {
-      render(<ScoreInputField {...fullModeProps} />);
-      expect(screen.getByText(/Hdcp 15/)).toBeInTheDocument();
+    test('shows Wing Point course handicap as a whole number', () => {
+      const player = { ...mockPlayer, handicap: 12.4 };
+      const courseHandicap = calculateCourseHandicap(player.handicap);
+
+      render(<ScoreInputField {...fullModeProps} player={player} />);
+
+      expect(courseHandicap).toBe(13);
+      expect(screen.getByText(`(Hdcp ${courseHandicap})`)).toBeInTheDocument();
+      expect(screen.queryByText('(Hdcp 12.4)')).not.toBeInTheDocument();
+    });
+
+    test('preserves zero and missing handicap display handling', () => {
+      const { rerender } = render(
+        <ScoreInputField {...fullModeProps} player={{ ...mockPlayer, handicap: 0 }} />
+      );
+
+      expect(screen.getByText('(Hdcp 0)')).toBeInTheDocument();
+
+      rerender(<ScoreInputField {...fullModeProps} player={{ ...mockPlayer, handicap: undefined }} />);
+      expect(screen.queryByText(/Hdcp/)).not.toBeInTheDocument();
     });
 
     test('renders input field', () => {

--- a/frontend/src/components/game/__tests__/Scorecard.test.jsx
+++ b/frontend/src/components/game/__tests__/Scorecard.test.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Scorecard from '../Scorecard';
+import { calculateCourseHandicap } from '../../../utils';
 import {
   createMockTheme,
   createMockPlayers,
@@ -164,11 +165,14 @@ describe('Scorecard', () => {
       expect(robotEmojis.length).toBeGreaterThan(0);
     });
 
-    test('shows player handicaps', () => {
+    test('shows player course handicaps', () => {
       render(<Scorecard {...defaultProps} />);
+      const playerOneCourseHandicap = calculateCourseHandicap(mockPlayers[0].handicap);
+      const playerTwoCourseHandicap = calculateCourseHandicap(mockPlayers[1].handicap);
+
       // Multiple instances in new layout (front 9, back 9, totals)
-      expect(screen.getAllByText(/\(15\)/).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/\(18\)/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(`(${playerOneCourseHandicap})`).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(`(${playerTwoCourseHandicap})`).length).toBeGreaterThan(0);
     });
   });
 

--- a/frontend/src/components/integration/GHINIntegration.jsx
+++ b/frontend/src/components/integration/GHINIntegration.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTheme } from '../../theme/Provider';
 import { apiConfig } from '../../config/api.config';
+import { calculateCourseHandicap } from '../../utils';
 
 const API_URL = apiConfig.baseUrl;
 
@@ -299,7 +300,7 @@ const GHINIntegration = () => {
                       {player.ghin_id || 'None'}
                     </td>
                     <td style={{ padding: '12px' }}>
-                      {player.handicap ? player.handicap.toFixed(1) : 'N/A'}
+                      {player.handicap ? calculateCourseHandicap(player.handicap) : 'N/A'}
                       {player.ghin_last_updated && (
                         <div style={{ fontSize: '12px', color: theme.colors.textSecondary }}>
                           Updated: {new Date(player.ghin_last_updated).toLocaleDateString()}

--- a/frontend/src/components/signup/DailySignupView.jsx
+++ b/frontend/src/components/signup/DailySignupView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import '../../styles/mobile-touch.css';
 import { apiConfig } from '../../config/api.config';
+import { calculateCourseHandicap } from '../../utils';
 
 const API_URL = apiConfig.baseUrl;
 
@@ -787,7 +788,7 @@ const DailySignupView = ({ selectedDate: initialDate, onBack }) => {
                         {p.player_name}
                         {p.handicap && (
                           <span style={{ color: '#6b7280', fontSize: '12px', marginLeft: '6px' }}>
-                            ({p.handicap} HCP)
+                            ({calculateCourseHandicap(p.handicap)} HCP)
                           </span>
                         )}
                       </div>

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -9,6 +9,7 @@
 
 // Stroke allocation utilities (Creecher Feature)
 export {
+  calculateCourseHandicap,
   getStrokesForHole,
   calculateNetHandicaps,
   calculateStrokeAllocation,
@@ -41,4 +42,3 @@ export {
   getProbabilityColor,
   formatActionText
 } from './bettingHelpers';
-


### PR DESCRIPTION
## Summary
- Switches four player-handicap display surfaces to show the Wing Point course handicap only as a whole number: Scorecard, ScoreInputField, DailySignupView, and GHINIntegration.
- Reuses the existing calculateCourseHandicap helper with Wing Point Blacks data: slope 124, rating 70.3, par 71.
- Leaves internal stroke-allocation and net-handicap logic untouched.

## Verification
- npx tsc --noEmit
- npx vitest run src/components/game/__tests__/ScoreInputField.test.jsx src/components/game/__tests__/Scorecard.test.jsx
