### PR TITLE
docs: correct onboarding note for Jeff (remove stale roster-UI gap)

### DIFF
--- a/CAPABILITIES_ONBOARDING.md
+++ b/CAPABILITIES_ONBOARDING.md
@@ -86,9 +86,7 @@ decide together what matters:
 2. **No handicap capture during sign-up.** There's no onboarding step that asks for or
    verifies a GHIN ID / handicap. New players sit at the 18.0 default until handicap
    sync is finished.
-3. **No organizer-facing *UI* for roster management.** The add/pending/promote
-   capabilities exist as APIs (§2); there's no admin screen wrapping them yet.
-4. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
+3. **No magic-link / passwordless email sign-up.** Auth0 redirect is the only entry
    (note: Auth0 itself can be configured for passwordless if we want it).
 
 ---


### PR DESCRIPTION
Single factual correction to CAPABILITIES_ONBOARDING.md (the capabilities note for Jeff Green), flagged by a cross-vendor fact-check: Section 4 listed 'No organizer-facing UI for roster management' as not-built, but the /admin/roster screen exists (RosterManager, frontend/src/App.jsx:411-417, linked from AdminPage.jsx:521) and Section 2 already lists it as live. Removed the contradictory item and renumbered. Rest of the note verified accurate against code.