### PR TITLE
Fix GitHub labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,50 +1,35 @@
-# Configuration for automatic PR labeling (labeler v5 format)
-
-backend:
+documentation:
   - changed-files:
-    - any-glob-to-any-file: 'backend/**/*'
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
 
 frontend:
   - changed-files:
-    - any-glob-to-any-file: 'frontend/**/*'
+      - any-glob-to-any-file:
+          - 'frontend/**'
 
-documentation:
+backend:
   - changed-files:
-    - any-glob-to-any-file:
-      - '**/*.md'
-      - 'docs/**/*'
+      - any-glob-to-any-file:
+          - 'backend/**'
 
-tests:
+ci:
   - changed-files:
-    - any-glob-to-any-file:
-      - '**/test_*.py'
-      - '**/*.test.js'
-      - '**/*.test.jsx'
-      - '**/*.test.ts'
-      - '**/*.test.tsx'
-      - '**/tests/**/*'
+      - any-glob-to-any-file:
+          - '.github/**'
 
 dependencies:
   - changed-files:
-    - any-glob-to-any-file:
-      - '**/requirements*.txt'
-      - '**/package.json'
-      - '**/package-lock.json'
-      - '**/yarn.lock'
+      - any-glob-to-any-file:
+          - 'requirements*.txt'
+          - '**/requirements*.txt'
+          - '**/package.json'
+          - '**/package-lock.json'
+          - '**/pnpm-lock.yaml'
 
-ci/cd:
+tests:
   - changed-files:
-    - any-glob-to-any-file:
-      - '.github/workflows/*'
-      - '.github/actions/*'
-      - '**/Dockerfile'
-      - '**/docker-compose*.yml'
-
-configuration:
-  - changed-files:
-    - any-glob-to-any-file:
-      - '**/*.env*'
-      - '**/*.config.js'
-      - '**/*.config.ts'
-      - '**/settings.py'
-      - '**/config.py'
+      - any-glob-to-any-file:
+          - '**/tests/**'
+          - '**/*test*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,15 +5,6 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  label-pr:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/labeler@v5
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/labeler.yml
-
   check-pr-size:
     runs-on: ubuntu-latest
     
@@ -74,4 +65,3 @@ jobs:
     - uses: kentaro-m/auto-assign-action@v2.0.0
       with:
         configuration-path: ".github/auto-assign.yml"
-


### PR DESCRIPTION
## Summary
- Migrates `.github/labeler.yml` to valid `actions/labeler@v5` nested `changed-files` syntax.
- Uses real repository paths for docs, frontend, backend, CI, dependency, and test labeling.
- Moves the labeler into a dedicated `pull_request_target` workflow with read contents and pull-request write permissions.

## Missing labels
`actions/labeler` only applies labels that already exist. The repo currently has `documentation`, but these referenced labels still need to be created:

```sh
gh label create frontend --description "Frontend changes" --color 1D76DB
gh label create backend --description "Backend changes" --color 0E8A16
gh label create ci --description "CI and GitHub workflow changes" --color 5319E7
gh label create dependencies --description "Dependency manifest or lockfile changes" --color 0366D6
gh label create tests --description "Test changes" --color FBCA04
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured pull request labeling system with newly defined label categories (documentation, frontend, backend, CI, dependencies, and tests) to better organize contributions
  * Implemented automatic pull request labeling workflow to streamline the labeling process
  * Removed automatic pull request assignment functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->