### PR TITLE
feat(backend): member round-posting + peer attestation

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -103,6 +103,26 @@ def get_isolated_session() -> Generator[Session, None, None]:
         logger.debug("Closed isolated database session")
 
 
+def ensure_legacy_rounds_official_view(bind) -> None:
+    """Create the ``legacy_rounds_official`` view on SQLite (dev/test) DBs.
+
+    The view excludes unattested member self-posts (``status='pending'``) and is
+    the only legacy-rounds source the Commissioner's read-only SQL path may query.
+    On PostgreSQL the view is created by the attestation migration (after the
+    ``status`` column is added), so this skips Postgres to avoid referencing a
+    column that may not exist yet at ``init_db`` time on an upgrading DB.
+    """
+    if bind.dialect.name == "postgresql":
+        return
+    with bind.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE VIEW IF NOT EXISTS legacy_rounds_official AS "
+                "SELECT * FROM legacy_rounds WHERE status <> 'pending'"
+            )
+        )
+
+
 def init_db():
     """Initialize database tables"""
     try:
@@ -111,6 +131,9 @@ def init_db():
 
         # Create all tables
         Base.metadata.create_all(bind=engine)
+        # Filtered view used by Commissioner SQL reads (SQLite dev; Postgres gets
+        # it from the attestation migration).
+        ensure_legacy_rounds_official_view(engine)
         logger.info("Database initialized successfully")
 
         # Test database connection

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -289,6 +289,9 @@ app.include_router(health.router)
 app.include_router(sheet_integration.router)
 app.include_router(tee_sheet.router)
 app.include_router(players.router)
+from .routers import member_rounds
+
+app.include_router(member_rounds.router)
 app.include_router(courses.router)
 
 # Import and include course data update router

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Float, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, UniqueConstraint, text
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import JSON
@@ -361,7 +361,19 @@ class LegacyRound(Base):
     """Historical round data synced from Google Sheets."""
 
     __tablename__ = "legacy_rounds"
-    __table_args__ = (Index("ix_legacy_rounds_date_group_member", "date", "group", "member"),)
+    __table_args__ = (
+        Index("ix_legacy_rounds_date_group_member", "date", "group", "member"),
+        # One member-posted round per (member, date). Partial index: only member
+        # self-posts are constrained; sheet rows can legitimately repeat.
+        Index(
+            "ux_member_round_per_day",
+            "member",
+            "date",
+            unique=True,
+            sqlite_where=text("source = 'member'"),
+            postgresql_where=text("source = 'member'"),
+        ),
+    )
     id = Column(Integer, primary_key=True, index=True)
     date = Column(String, index=True)  # e.g. "2026-04-06"
     group = Column(String)  # e.g. "A"
@@ -369,12 +381,19 @@ class LegacyRound(Base):
     score = Column(Integer)  # quarters won/lost
     location = Column(String)  # course name
     duration = Column(String, nullable=True)  # e.g. "02:15:00"
-    source = Column(String, default="sheet")  # "primary_sheet" or "writable_sheet"
+    source = Column(String, default="sheet")  # "primary_sheet" | "writable_sheet" | "member"
     synced_at = Column(String)  # ISO timestamp of last sync
     hole_scores = Column(JSON, default=dict)  # Hole-by-hole scores
     betting_history = Column(JSON, default=list)  # Detailed betting decisions
     performance_metrics = Column(JSON, default=dict)  # Advanced metrics
     created_at = Column(String)
+    # Member self-posting + peer attestation (member rows only; sheet/db rows
+    # default to "attested" so existing reads are unchanged).
+    player_profile_id = Column(Integer, ForeignKey("player_profiles.id"), nullable=True)
+    status = Column(String(16), nullable=False, default="attested", server_default="attested")
+    attested_by_profile_id = Column(Integer, ForeignKey("player_profiles.id"), nullable=True)
+    attested_at = Column(DateTime, nullable=True)
+    foursome = Column(JSON, nullable=True)  # canonical roster names eligible to attest
 
 
 class PlayerAchievement(Base):

--- a/backend/app/routers/commissioner.py
+++ b/backend/app/routers/commissioner.py
@@ -402,7 +402,11 @@ def _validate_sql(sql: str) -> bool:
     # unquoted base table name (handles quoting + schema qualification); we
     # normalize again via _base_name for defense in depth. Function calls do not
     # produce Table nodes, so they need no special handling.
-    table_refs = {_base_name(tbl.name) for tbl in tree.find_all(exp.Table)}
+    # Skip nodes whose normalized base name is empty: those are table-valued
+    # function output wrappers (e.g. CROSS JOIN json_array_elements(...)), not
+    # physical table references. The denied physical table always surfaces with
+    # a non-empty name, so this cannot reopen a leak.
+    table_refs = {name for tbl in tree.find_all(exp.Table) if (name := _base_name(tbl.name))}
 
     # Denylist takes PRECEDENCE over the allow-list: a physical table in
     # _DENIED_TABLES is unreachable even if a same-named CTE aliases it.

--- a/backend/app/routers/commissioner.py
+++ b/backend/app/routers/commissioner.py
@@ -306,6 +306,16 @@ _DENIED_COLUMNS = {
     "weaknesses",
 }
 
+_DENIED_TABLES = {
+    # Physical tables that must NEVER be referenced directly, regardless of
+    # quoting, schema-qualification, or CTE aliasing. `legacy_rounds` holds
+    # unattested member self-posts (status='pending'); only the filtered
+    # `legacy_rounds_official` view is sanctioned. This denylist takes
+    # precedence over the allow-list, so a CTE named `legacy_rounds` cannot
+    # whitelist the raw table.
+    "legacy_rounds",
+}
+
 _DANGEROUS_KEYWORDS = {
     "INSERT",
     "UPDATE",
@@ -354,9 +364,24 @@ def _validate_sql(sql: str) -> bool:
         if col in lower:
             return False
 
+    def _base_name(ident: str) -> str:
+        """Normalize an identifier to its unquoted, lowercase base table name.
+
+        Handles schema-qualified forms (schema.table, "schema"."table") by
+        taking the final segment, then strips surrounding double-quotes.
+        """
+        last_segment = re.split(r"\s*\.\s*", ident.strip())[-1].strip()
+        if last_segment.startswith('"') and last_segment.endswith('"'):
+            last_segment = last_segment[1:-1]
+        return last_segment.lower()
+
     # Extract CTE names (WITH name AS ...) so they're treated as valid aliases
     cte_names = {name.lower() for name in re.findall(r"\bWITH\s+(\w+)\s+AS\b", upper)}
     cte_names |= {name.lower() for name in re.findall(r",\s*(\w+)\s+AS\s*\(", upper)}
+    # A CTE may not be named after a denied physical table — that would
+    # whitelist the forbidden name. Denylist takes precedence over aliasing.
+    if any(_base_name(name) in _DENIED_TABLES for name in cte_names):
+        return False
     allowed = _ALLOWED_TABLES | cte_names
 
     # Table allowlist — every FROM / JOIN target must be allowed.
@@ -372,14 +397,16 @@ def _validate_sql(sql: str) -> bool:
         after = upper[m.end() :].lstrip()
         if after and after[0] == "(":
             continue  # function call, not a table
-        # Take the final segment (the table name) of a possibly-qualified ref,
-        # and strip surrounding double-quotes so quoting cannot bypass the check.
-        last_segment = re.split(r"\s*\.\s*", raw)[-1].strip()
-        if last_segment.startswith('"') and last_segment.endswith('"'):
-            last_segment = last_segment[1:-1]
-        table_refs.append(last_segment)
+        # Normalize to the unquoted base table name (handles quoting + schema
+        # qualification) so neither can bypass the allow/deny checks.
+        table_refs.append(_base_name(raw))
+    # Denylist takes PRECEDENCE over the allow-list: a physical table in
+    # _DENIED_TABLES is unreachable even if a same-named CTE aliases it.
     for tbl in table_refs:
-        if tbl.lower() not in allowed:
+        if tbl in _DENIED_TABLES:
+            return False
+    for tbl in table_refs:
+        if tbl not in allowed:
             return False
 
     return True

--- a/backend/app/routers/commissioner.py
+++ b/backend/app/routers/commissioner.py
@@ -13,10 +13,12 @@ import re
 from typing import Any
 
 import httpx
+import sqlglot
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
+from sqlglot import exp
 
 from ..database import get_db
 from ..utils.api_helpers import ApiResponse, handle_api_errors
@@ -330,6 +332,18 @@ _DANGEROUS_KEYWORDS = {
 }
 
 
+def _base_name(ident: str) -> str:
+    """Normalize an identifier to its unquoted, lowercase base table name.
+
+    Handles schema-qualified forms (schema.table, "schema"."table") by taking
+    the final segment, then strips surrounding double-quotes.
+    """
+    last_segment = re.split(r"\s*\.\s*", ident.strip())[-1].strip()
+    if last_segment.startswith('"') and last_segment.endswith('"'):
+        last_segment = last_segment[1:-1]
+    return last_segment.lower()
+
+
 def _validate_sql(sql: str) -> bool:
     """Return True if *sql* is a safe, read-only SELECT against allowed tables."""
     # Strip single-line comments
@@ -364,42 +378,32 @@ def _validate_sql(sql: str) -> bool:
         if col in lower:
             return False
 
-    def _base_name(ident: str) -> str:
-        """Normalize an identifier to its unquoted, lowercase base table name.
+    # Enumerate table references and CTE names with a real SQL parser rather
+    # than regex. sqlglot walks the entire AST, so comma/implicit joins,
+    # explicit JOINs, subqueries, CTE bodies, set operations (UNION/…), and
+    # nested CTEs are all covered — closing the regex whack-a-mole bypasses.
+    # Parse with the Postgres dialect (prod), and FAIL CLOSED if it can't parse.
+    try:
+        tree = sqlglot.parse_one(cleaned, dialect="postgres")
+    except Exception:
+        return False
+    if tree is None:
+        return False
 
-        Handles schema-qualified forms (schema.table, "schema"."table") by
-        taking the final segment, then strips surrounding double-quotes.
-        """
-        last_segment = re.split(r"\s*\.\s*", ident.strip())[-1].strip()
-        if last_segment.startswith('"') and last_segment.endswith('"'):
-            last_segment = last_segment[1:-1]
-        return last_segment.lower()
-
-    # Extract CTE names (WITH name AS ...) so they're treated as valid aliases
-    cte_names = {name.lower() for name in re.findall(r"\bWITH\s+(\w+)\s+AS\b", upper)}
-    cte_names |= {name.lower() for name in re.findall(r",\s*(\w+)\s+AS\s*\(", upper)}
+    # CTE names declared in the query are valid aliases for FROM/JOIN targets.
+    cte_names = {_base_name(cte.alias) for cte in tree.find_all(exp.CTE)}
     # A CTE may not be named after a denied physical table — that would
     # whitelist the forbidden name. Denylist takes precedence over aliasing.
-    if any(_base_name(name) in _DENIED_TABLES for name in cte_names):
+    if any(name in _DENIED_TABLES for name in cte_names):
         return False
     allowed = _ALLOWED_TABLES | cte_names
 
-    # Table allowlist — every FROM / JOIN target must be allowed.
-    # Identifiers may be unquoted (\w+), double-quoted ("name"), and/or
-    # schema-qualified (schema.table, "schema"."table", public."legacy_rounds").
-    # Match all such forms so quoting cannot evade the allow-list. Each part of a
-    # qualified name is either a bare word or a double-quoted segment.
-    _ident = r'(?:"[^"]+"|\w+)'
-    _qualified = rf"{_ident}(?:\s*\.\s*{_ident})*"
-    table_refs = []
-    for m in re.finditer(rf"\b(?:FROM|JOIN)\s+({_qualified})", upper):
-        raw = m.group(1)
-        after = upper[m.end() :].lstrip()
-        if after and after[0] == "(":
-            continue  # function call, not a table
-        # Normalize to the unquoted base table name (handles quoting + schema
-        # qualification) so neither can bypass the allow/deny checks.
-        table_refs.append(_base_name(raw))
+    # Every real table reference anywhere in the tree. exp.Table.name yields the
+    # unquoted base table name (handles quoting + schema qualification); we
+    # normalize again via _base_name for defense in depth. Function calls do not
+    # produce Table nodes, so they need no special handling.
+    table_refs = {_base_name(tbl.name) for tbl in tree.find_all(exp.Table)}
+
     # Denylist takes PRECEDENCE over the allow-list: a physical table in
     # _DENIED_TABLES is unreachable even if a same-named CTE aliases it.
     for tbl in table_refs:

--- a/backend/app/routers/commissioner.py
+++ b/backend/app/routers/commissioner.py
@@ -136,6 +136,10 @@ def _build_data_context(db: Session) -> str:
                 func.sum(models.LegacyRound.score).label("quarters"),
                 func.count(models.LegacyRound.id).label("rounds"),
             )
+            # Exclude unattested member self-posts (status='pending') — they must
+            # not reach standings until a foursome peer attests. Matches the
+            # filter in unified_data_service / spreadsheet_sync read paths.
+            .filter(models.LegacyRound.status != "pending")
             .group_by(models.LegacyRound.member)
             .order_by(func.sum(models.LegacyRound.score).desc())
             .limit(20)
@@ -214,11 +218,14 @@ async def commissioner_chat(
 DATA_SCHEMA = """
 ## Queryable Tables
 
-### legacy_rounds
+### legacy_rounds_official
 Columns: id, date, "group", member, score, location, duration, source, synced_at
 IMPORTANT: `group` is a PostgreSQL reserved word — always quote it as "group" in queries.
 Note: Uses `member` (string name) not a foreign key. Player matching requires
 `player_profiles.name` or `player_profiles.legacy_name`.
+ALWAYS query `legacy_rounds_official` (NOT `legacy_rounds`) — it is the official
+view that excludes unattested member self-posts (status='pending'). The raw
+`legacy_rounds` table is not queryable.
 
 ### player_profiles
 Columns: id, name, legacy_name, email, handicap, ghin_id, ghin_last_updated,
@@ -276,7 +283,12 @@ revision_reason, scores_used_count, synced_at
 """.strip()
 
 _ALLOWED_TABLES = {
-    "legacy_rounds",
+    # `legacy_rounds_official` is a view that excludes unattested member
+    # self-posts (status='pending'). The raw `legacy_rounds` table is
+    # deliberately NOT allowed, so pending rounds can never surface through
+    # the Commissioner's read-only SQL path — even if the LLM names the raw
+    # table, _validate_sql rejects the query.
+    "legacy_rounds_official",
     "player_profiles",
     "player_statistics",
     "game_records",
@@ -419,10 +431,10 @@ If the question is purely about rules (not data), respond directly without SQL.
 If you're unsure which player is meant, use ILIKE with wildcards for fuzzy matching.
 
 Example queries:
-- "Who has the most quarters?" → SELECT member, SUM(score) as total_quarters FROM legacy_rounds GROUP BY member ORDER BY total_quarters DESC LIMIT 10
+- "Who has the most quarters?" → SELECT member, SUM(score) as total_quarters FROM legacy_rounds_official GROUP BY member ORDER BY total_quarters DESC LIMIT 10
 - "Stuart's handicap history" → SELECT effective_date, handicap_index FROM ghin_handicap_history gh JOIN player_profiles pp ON gh.player_profile_id = pp.id WHERE pp.name ILIKE '%Stuart%' ORDER BY effective_date
-- "How many rounds per player?" → SELECT member, COUNT(*) as rounds FROM legacy_rounds GROUP BY member ORDER BY rounds DESC
-- "Best single round ever?" → SELECT member, score, date, location FROM legacy_rounds ORDER BY score DESC LIMIT 5
+- "How many rounds per player?" → SELECT member, COUNT(*) as rounds FROM legacy_rounds_official GROUP BY member ORDER BY rounds DESC
+- "Best single round ever?" → SELECT member, score, date, location FROM legacy_rounds_official ORDER BY score DESC LIMIT 5
 - "Who goes solo the most?" → SELECT pp.name, ps.solo_attempts, ps.solo_wins FROM player_statistics ps JOIN player_profiles pp ON ps.player_id = pp.id WHERE ps.solo_attempts > 0 ORDER BY ps.solo_attempts DESC"""
 
     step1_text = await _llm_generate(request.question, system)

--- a/backend/app/routers/commissioner.py
+++ b/backend/app/routers/commissioner.py
@@ -359,15 +359,25 @@ def _validate_sql(sql: str) -> bool:
     cte_names |= {name.lower() for name in re.findall(r",\s*(\w+)\s+AS\s*\(", upper)}
     allowed = _ALLOWED_TABLES | cte_names
 
-    # Table allowlist — every FROM / JOIN target must be allowed
-    # Skip function calls (word immediately followed by '(') like jsonb_array_elements(...)
+    # Table allowlist — every FROM / JOIN target must be allowed.
+    # Identifiers may be unquoted (\w+), double-quoted ("name"), and/or
+    # schema-qualified (schema.table, "schema"."table", public."legacy_rounds").
+    # Match all such forms so quoting cannot evade the allow-list. Each part of a
+    # qualified name is either a bare word or a double-quoted segment.
+    _ident = r'(?:"[^"]+"|\w+)'
+    _qualified = rf"{_ident}(?:\s*\.\s*{_ident})*"
     table_refs = []
-    for m in re.finditer(r"\b(?:FROM|JOIN)\s+(\w+)", upper):
-        name = m.group(1)
-        after = upper[m.end() :]
+    for m in re.finditer(rf"\b(?:FROM|JOIN)\s+({_qualified})", upper):
+        raw = m.group(1)
+        after = upper[m.end() :].lstrip()
         if after and after[0] == "(":
             continue  # function call, not a table
-        table_refs.append(name)
+        # Take the final segment (the table name) of a possibly-qualified ref,
+        # and strip surrounding double-quotes so quoting cannot bypass the check.
+        last_segment = re.split(r"\s*\.\s*", raw)[-1].strip()
+        if last_segment.startswith('"') and last_segment.endswith('"'):
+            last_segment = last_segment[1:-1]
+        table_refs.append(last_segment)
     for tbl in table_refs:
         if tbl.lower() not in allowed:
             return False

--- a/backend/app/routers/member_rounds.py
+++ b/backend/app/routers/member_rounds.py
@@ -1,0 +1,248 @@
+"""Member round-posting + peer attestation.
+
+Members self-post their Wolf-Goat-Pig round result (quarters won/lost — the same
+quantity Jeff hand-enters into the Google Sheet), tied to their profile, one
+round per member per calendar day. A posted round is ``status='pending'`` and
+becomes authoritative (``status='attested'``) only after another member of the
+foursome attests it.
+
+These rows live in ``legacy_rounds`` with ``source='member'`` so they survive
+the restart-time sheet sync (which only wipes ``primary_sheet``/``writable_sheet``
+rows) and are excluded from leaderboards/standings/history until attested.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import LegacyRound, PlayerProfile
+from ..services.auth_service import get_current_user
+from ..services.email_service import get_email_service
+from ..services.legacy_player_service import get_canonical_name
+from ..utils.time import utc_now
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["member-rounds"])
+
+
+class PostRoundRequest(BaseModel):
+    """A member-posted round result (quarters won/lost)."""
+
+    date: str = Field(..., description="Date in YYYY-MM-DD format")
+    score: int = Field(..., description="Quarters won (positive) or lost (negative)")
+    location: str | None = Field(None, description="Course name")
+    group: str | None = Field(None, description="Group letter")
+    duration: str | None = Field(None, description="Duration, e.g. 02:15:00")
+    foursome: list[str] = Field(
+        ...,
+        description="1-3 OTHER players' canonical roster names eligible to attest (must not include yourself)",
+    )
+
+
+def _serialize(r: LegacyRound) -> dict[str, Any]:
+    """Render a round in the pinned response shape."""
+    return {
+        "id": r.id,
+        "date": r.date,
+        "score": r.score,
+        "member": r.member,
+        "status": r.status,
+        "foursome": r.foursome or [],
+        "attested_by": r.attested_by_profile_id,
+        "attested_at": r.attested_at.isoformat() if r.attested_at else None,
+    }
+
+
+def _notify_foursome(db: Session, round_row: LegacyRound, poster: PlayerProfile) -> None:
+    """Email each foursome member that has a PlayerProfile+email an attestation
+    request. Best-effort: any email failure must NOT fail the request."""
+    try:
+        email_service = get_email_service()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Could not get email service for attestation request: %s", e)
+        return
+
+    for name in round_row.foursome or []:
+        try:
+            profile = db.query(PlayerProfile).filter(func.lower(PlayerProfile.legacy_name) == name.lower()).first()
+            if profile and profile.email:
+                email_service.send_attestation_request(
+                    to_email=profile.email,
+                    attester_name=profile.name or name,
+                    poster_name=poster.legacy_name or poster.name or "A member",
+                    round_date=round_row.date,
+                    score=round_row.score,
+                )
+        except Exception as e:
+            logger.warning("Failed to send attestation request to '%s': %s", name, e)
+
+
+@router.post("/players/me/round", status_code=201)
+def post_my_round(
+    body: PostRoundRequest,
+    current_user: PlayerProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Post (or replace a still-pending) round result for the current member."""
+    if not current_user.legacy_name:
+        raise HTTPException(
+            status_code=400,
+            detail="Link your roster name first via PUT /players/me/legacy-name",
+        )
+
+    try:
+        datetime.strptime(body.date, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD.")
+
+    if not 1 <= len(body.foursome) <= 3:
+        raise HTTPException(
+            status_code=400,
+            detail="foursome must list 1-3 other players' canonical roster names",
+        )
+
+    # Validate + canonicalize each foursome name; reject the poster.
+    canonical_foursome: list[str] = []
+    for name in body.foursome:
+        canonical = get_canonical_name(name, db)
+        if not canonical:
+            raise HTTPException(
+                status_code=400,
+                detail=f"'{name}' is not a valid roster name. Use /players/legacy-players to see valid names.",
+            )
+        if canonical.lower() == current_user.legacy_name.lower():
+            raise HTTPException(status_code=400, detail="foursome must not include yourself")
+        if canonical not in canonical_foursome:
+            canonical_foursome.append(canonical)
+
+    now = utc_now()
+    existing = (
+        db.query(LegacyRound)
+        .filter(
+            LegacyRound.source == "member",
+            LegacyRound.member == current_user.legacy_name,
+            LegacyRound.date == body.date,
+        )
+        .first()
+    )
+
+    if existing is not None:
+        if existing.status == "attested":
+            raise HTTPException(
+                status_code=409,
+                detail="You already posted an attested round for that date",
+            )
+        # Still pending — allow replace before attestation.
+        existing.score = body.score
+        existing.location = body.location
+        existing.group = body.group
+        existing.duration = body.duration
+        existing.foursome = canonical_foursome
+        existing.player_profile_id = current_user.id
+        existing.status = "pending"
+        existing.synced_at = now.isoformat()
+        row = existing
+    else:
+        row = LegacyRound(
+            date=body.date,
+            group=body.group,
+            member=current_user.legacy_name,
+            score=body.score,
+            location=body.location,
+            duration=body.duration,
+            source="member",
+            status="pending",
+            synced_at=now.isoformat(),
+            created_at=now.isoformat(),
+            player_profile_id=current_user.id,
+            foursome=canonical_foursome,
+        )
+        db.add(row)
+
+    db.commit()
+    db.refresh(row)
+
+    _notify_foursome(db, row, current_user)
+
+    return _serialize(row)
+
+
+@router.get("/players/me/rounds")
+def get_my_rounds(
+    current_user: PlayerProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[dict[str, Any]]:
+    """List the current member's own posted rounds (pending and attested)."""
+    rows = (
+        db.query(LegacyRound)
+        .filter(
+            LegacyRound.source == "member",
+            LegacyRound.player_profile_id == current_user.id,
+        )
+        .order_by(LegacyRound.date.desc())
+        .all()
+    )
+    return [_serialize(r) for r in rows]
+
+
+@router.get("/rounds/pending-attestation")
+def get_pending_attestation(
+    current_user: PlayerProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[dict[str, Any]]:
+    """List pending rounds the current member is eligible to attest."""
+    if not current_user.legacy_name:
+        return []
+
+    rows = (
+        db.query(LegacyRound)
+        .filter(
+            LegacyRound.source == "member",
+            LegacyRound.status == "pending",
+            LegacyRound.member != current_user.legacy_name,
+        )
+        .order_by(LegacyRound.date.desc())
+        .all()
+    )
+
+    legacy = current_user.legacy_name.lower()
+    eligible = [r for r in rows if any(n.lower() == legacy for n in (r.foursome or []))]
+    return [_serialize(r) for r in eligible]
+
+
+@router.post("/rounds/{round_id}/attest")
+def attest_round(
+    round_id: int,
+    current_user: PlayerProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Attest a pending round posted by another foursome member."""
+    row = db.query(LegacyRound).filter(LegacyRound.id == round_id).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Round not found")
+
+    legacy = current_user.legacy_name
+    foursome = row.foursome or []
+    eligible = bool(legacy) and legacy != row.member and any(n.lower() == legacy.lower() for n in foursome)
+    if not eligible:
+        raise HTTPException(status_code=403, detail="You are not eligible to attest this round")
+
+    if row.status != "pending":
+        raise HTTPException(status_code=409, detail="Round is not pending attestation")
+
+    row.status = "attested"
+    row.attested_by_profile_id = current_user.id
+    row.attested_at = utc_now()
+    db.commit()
+    db.refresh(row)
+
+    return _serialize(row)

--- a/backend/app/routers/spreadsheet_sync.py
+++ b/backend/app/routers/spreadsheet_sync.py
@@ -67,10 +67,11 @@ class RoundResultResponse(BaseModel):
     """Response model for a round result."""
 
     date: str
-    group: str
+    # group/location are nullable: member-posted rounds may omit them.
+    group: str | None = None
     member: str
     score: int
-    location: str
+    location: str | None = None
     duration: str | None = None
 
 
@@ -83,6 +84,8 @@ def get_spreadsheet_leaderboard(db: Session = Depends(get_db)):
             func.sum(LegacyRound.score).label("quarters"),
             func.count(LegacyRound.id).label("rounds"),
         )
+        # Exclude pending member-posted rounds (not yet attested).
+        .filter(LegacyRound.status != "pending")
         .group_by(LegacyRound.member)
         .all()
     )
@@ -116,7 +119,13 @@ def get_all_rounds(
     db: Session = Depends(get_db),
 ) -> Any:
     """Get all round results from legacy_rounds DB (synced every 2h)."""
-    rows = db.query(LegacyRound).order_by(LegacyRound.date.desc(), LegacyRound.member).limit(limit).all()
+    rows = (
+        db.query(LegacyRound)
+        .filter(LegacyRound.status != "pending")  # exclude unattested member rounds
+        .order_by(LegacyRound.date.desc(), LegacyRound.member)
+        .limit(limit)
+        .all()
+    )
     return [
         RoundResultResponse(
             date=r.date,
@@ -136,7 +145,12 @@ def get_rounds_by_date(date: str, db: Session = Depends(get_db)) -> Any:
 
     Date format: YYYY-MM-DD (e.g., "2026-07-21").
     """
-    rows = db.query(LegacyRound).filter(LegacyRound.date == date).order_by(LegacyRound.group, LegacyRound.member).all()
+    rows = (
+        db.query(LegacyRound)
+        .filter(LegacyRound.date == date, LegacyRound.status != "pending")
+        .order_by(LegacyRound.group, LegacyRound.member)
+        .all()
+    )
 
     # Group into round summaries by (date, group, location, duration)
     summaries: dict[tuple, dict] = {}
@@ -162,7 +176,12 @@ def get_rounds_by_date(date: str, db: Session = Depends(get_db)) -> Any:
 @router.get("/player/{member_name}", response_model=list[RoundResultResponse])
 def get_player_history(member_name: str, db: Session = Depends(get_db)) -> Any:
     """Get all rounds for a specific player from legacy_rounds DB (synced every 2h)."""
-    rows = db.query(LegacyRound).filter(LegacyRound.member == member_name).order_by(LegacyRound.date.desc()).all()
+    rows = (
+        db.query(LegacyRound)
+        .filter(LegacyRound.member == member_name, LegacyRound.status != "pending")
+        .order_by(LegacyRound.date.desc())
+        .all()
+    )
     return [
         RoundResultResponse(
             date=r.date,

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -238,6 +238,50 @@ class EmailService:
             text_body=text_body,
         )
 
+    def send_attestation_request(
+        self,
+        to_email: str,
+        attester_name: str,
+        poster_name: str,
+        round_date: str,
+        score: int,
+    ) -> bool:
+        """Ask a foursome member to attest a round another member just posted.
+
+        Modeled on send_welcome_email: builds and sends a transactional email
+        (HTML + plaintext via the base template), no per-method opt-out gate.
+        The poster's round becomes authoritative only once a foursome member
+        attests it in the app.
+        """
+        quarters = f"+{score}" if score > 0 else str(score)
+        content = f"""
+        <h2>Confirm a Wolf Goat Pig round</h2>
+        <p>Hi {attester_name},</p>
+        <p><strong>{poster_name}</strong> posted a round for <strong>{round_date}</strong>
+        and listed you in the foursome.</p>
+        <p>Reported result: <strong>{quarters} quarters</strong>.</p>
+        <p>Open the app to confirm it. The round won't count toward standings
+        until a foursome member attests it.</p>
+        """
+        template = Template(self._get_base_template())
+        html_body = template.render(subject="Confirm a Wolf Goat Pig round", content=content)
+
+        text_body = (
+            "Confirm a Wolf Goat Pig round\n\n"
+            f"Hi {attester_name},\n\n"
+            f"{poster_name} posted a round for {round_date} and listed you in the foursome.\n"
+            f"Reported result: {quarters} quarters.\n\n"
+            "Open the app to confirm it. The round won't count toward standings "
+            "until a foursome member attests it.\n"
+        )
+
+        return self._send_email(
+            to_email=to_email,
+            subject=f"Confirm {poster_name}'s Wolf Goat Pig round ({round_date})",
+            html_body=html_body,
+            text_body=text_body,
+        )
+
     def send_new_player_notification(
         self,
         to_email: str,

--- a/backend/app/services/unified_data_service.py
+++ b/backend/app/services/unified_data_service.py
@@ -182,7 +182,10 @@ class UnifiedDataService:
             # Fast path: read from legacy_rounds DB cache
             try:
                 db = self._get_db()
-                for r in db.query(LegacyRound).all():
+                # Exclude pending member-posted rounds — they are not
+                # authoritative until a foursome member attests them. Sheet/db
+                # rows default to status='attested' so they are unaffected.
+                for r in db.query(LegacyRound).filter(LegacyRound.status != "pending").all():
                     unified = self._legacy_round_to_unified(r)
                     key = (unified.date_sortable, unified.group, unified.member, unified.score)
                     if key not in all_rounds:

--- a/backend/migrations/add_member_round_attestation_postgres.sql
+++ b/backend/migrations/add_member_round_attestation_postgres.sql
@@ -1,0 +1,15 @@
+-- Member round-posting + peer attestation on legacy_rounds.
+-- All additive/nullable so existing sheet rows are untouched. Existing rows get
+-- status='attested' via the column default, keeping current reads unchanged.
+-- Sorts after add_legacy_rounds*_postgres.sql, so the table already exists.
+
+ALTER TABLE legacy_rounds ADD COLUMN IF NOT EXISTS player_profile_id INTEGER REFERENCES player_profiles(id);
+ALTER TABLE legacy_rounds ADD COLUMN IF NOT EXISTS status VARCHAR(16) NOT NULL DEFAULT 'attested';
+ALTER TABLE legacy_rounds ADD COLUMN IF NOT EXISTS attested_by_profile_id INTEGER REFERENCES player_profiles(id);
+ALTER TABLE legacy_rounds ADD COLUMN IF NOT EXISTS attested_at TIMESTAMP NULL;
+ALTER TABLE legacy_rounds ADD COLUMN IF NOT EXISTS foursome JSON NULL;
+
+-- One member-posted round per member per calendar day (member self-posts only).
+CREATE UNIQUE INDEX IF NOT EXISTS ux_member_round_per_day
+    ON legacy_rounds (member, date)
+    WHERE source = 'member';

--- a/backend/migrations/add_member_round_attestation_postgres.sql
+++ b/backend/migrations/add_member_round_attestation_postgres.sql
@@ -13,3 +13,11 @@ ALTER TABLE legacy_rounds ADD COLUMN IF NOT EXISTS foursome JSON NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS ux_member_round_per_day
     ON legacy_rounds (member, date)
     WHERE source = 'member';
+
+-- Official rounds view: excludes unattested member self-posts (status='pending').
+-- All read paths that feed standings/stats — including the Commissioner's
+-- read-only SQL executor — query this view, so pending rounds never leak into
+-- leaderboards or stat answers until a foursome peer attests them. Created here
+-- (after the status column is added above) so ordering is correct on upgrade.
+CREATE OR REPLACE VIEW legacy_rounds_official AS
+    SELECT * FROM legacy_rounds WHERE status <> 'pending';

--- a/backend/requirements-local.txt
+++ b/backend/requirements-local.txt
@@ -9,6 +9,9 @@ httpx
 python-dotenv
 pydantic
 
+# SQL parsing for the Commissioner read-only SQL validator (mirrors prod).
+sqlglot>=25,<28
+
 # Type checking and linting
 mypy
 ruff

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,10 @@ requests>=2.31.0
 # Data validation and serialization
 pydantic>=2.6.0,<3.0
 
+# SQL parsing — Commissioner read-only SQL validator (_validate_sql) uses
+# sqlglot's AST to enumerate table refs, closing regex-based bypasses.
+sqlglot>=25,<28
+
 # Image processing (scorecard compression + circle detection preprocessing)
 Pillow>=12.2.0
 opencv-python-headless>=4.9.0,<5.0

--- a/backend/tests/unit/routers/test_commissioner_pending_filter.py
+++ b/backend/tests/unit/routers/test_commissioner_pending_filter.py
@@ -149,6 +149,59 @@ def test_legitimate_cte_over_official_view_excludes_pending(db_session):
     assert "Bob Jones" not in members  # pending → excluded
 
 
+def test_comma_separated_raw_legacy_rounds_refs_are_rejected():
+    """Implicit (comma) joins must not slip a raw-table ref past the validator."""
+    from app.routers.commissioner import _validate_sql
+
+    # (a) comma join, second table is raw legacy_rounds
+    assert _validate_sql("SELECT lr.member, lr.score FROM legacy_rounds_official o, legacy_rounds lr") is False
+    # (b) comma join with a quoted raw ref
+    assert _validate_sql('SELECT * FROM player_profiles p, "legacy_rounds" lr') is False
+    # (c) comma join with a schema-qualified quoted raw ref
+    assert _validate_sql('SELECT * FROM legacy_rounds_official o, public."legacy_rounds" lr') is False
+
+
+def test_prior_adversarial_cases_still_rejected():
+    """All previously-closed bypasses remain rejected under the AST validator."""
+    from app.routers.commissioner import _validate_sql
+
+    # bare / quoted / schema-qualified raw table
+    assert _validate_sql("SELECT * FROM legacy_rounds") is False
+    assert _validate_sql('SELECT * FROM "legacy_rounds"') is False
+    assert _validate_sql('SELECT * FROM public."legacy_rounds"') is False
+    assert _validate_sql('SELECT * FROM "public"."legacy_rounds"') is False
+    # raw ref inside a subquery
+    assert _validate_sql('SELECT * FROM (SELECT * FROM "legacy_rounds") x') is False
+    # CTE named after the denied table (alias collision)
+    assert _validate_sql('WITH legacy_rounds AS (SELECT * FROM "legacy_rounds") SELECT * FROM legacy_rounds') is False
+    # nested CTE whose inner body pulls from the raw table
+    assert (
+        _validate_sql(
+            "WITH outer_cte AS ("
+            "  WITH inner_cte AS (SELECT * FROM legacy_rounds) SELECT * FROM inner_cte"
+            ") SELECT * FROM outer_cte"
+        )
+        is False
+    )
+    # UNION pulling from the raw table on one side
+    assert _validate_sql("SELECT member FROM legacy_rounds_official UNION SELECT member FROM legacy_rounds") is False
+
+
+def test_fail_closed_on_unparseable_sql():
+    """If sqlglot cannot parse the statement, the validator must reject it."""
+    from app.routers.commissioner import _validate_sql
+
+    assert _validate_sql("SELECT * FROM legacy_rounds_official WHERE ((( ") is False
+    assert _validate_sql("not valid sql at all ~~~") is False
+
+
+def test_comma_join_over_allowed_tables_still_passes():
+    """An implicit join over only allowed tables must still validate."""
+    from app.routers.commissioner import _validate_sql
+
+    assert _validate_sql("SELECT * FROM legacy_rounds_official o, player_profiles p") is True
+
+
 def test_official_view_quoted_query_still_excludes_pending(db_session):
     """A valid quoted query against the official view passes and hides pending rows."""
     from app.routers.commissioner import _execute_readonly_sql, _validate_sql

--- a/backend/tests/unit/routers/test_commissioner_pending_filter.py
+++ b/backend/tests/unit/routers/test_commissioner_pending_filter.py
@@ -1,0 +1,115 @@
+"""Regression: unattested member rounds (status='pending') must never leak into
+Commissioner standings/stat answers.
+
+Two read paths are guarded here against a real SQLite session:
+  1. `_build_data_context()` — the leaderboard aggregation injected into the chat
+     system prompt.
+  2. `_execute_readonly_sql()` against the `legacy_rounds_official` view — the
+     data-chat SQL executor.
+
+Both must exclude a pending round while including an attested one for the same
+member.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, ensure_legacy_rounds_official_view
+from app.models import LegacyRound
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite with the full schema + the legacy_rounds_official view."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    # Same helper prod/dev use, so the view's filter is exercised identically.
+    ensure_legacy_rounds_official_view(engine)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestingSessionLocal()
+
+    # Attested round for Alice; pending self-post for Bob.
+    session.add_all(
+        [
+            LegacyRound(
+                date="2026-06-15",
+                member="Alice Park",
+                score=7,
+                source="primary_sheet",
+                status="attested",
+                synced_at="x",
+                created_at="x",
+            ),
+            LegacyRound(
+                date="2026-06-15",
+                member="Bob Jones",
+                score=99,
+                source="member",
+                status="pending",
+                synced_at="x",
+                created_at="x",
+            ),
+        ]
+    )
+    session.commit()
+
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_build_data_context_excludes_pending(db_session):
+    from app.routers.commissioner import _build_data_context
+
+    context = _build_data_context(db_session)
+    assert "Alice Park" in context  # attested → visible
+    assert "Bob Jones" not in context  # pending → hidden
+    assert "99" not in context  # pending score must not leak
+
+
+def test_official_view_excludes_pending_in_sql_executor(db_session):
+    from app.routers.commissioner import _execute_readonly_sql
+
+    results = _execute_readonly_sql(
+        db_session,
+        "SELECT member, SUM(score) AS quarters FROM legacy_rounds_official GROUP BY member ORDER BY quarters DESC",
+    )
+    assert "error" not in results, results
+    members = {row[0] for row in results["rows"]}
+    assert "Alice Park" in members  # attested → returned
+    assert "Bob Jones" not in members  # pending → excluded
+
+
+def test_raw_legacy_rounds_table_is_rejected_by_validator():
+    """Even if the LLM names the raw table, the query is refused (no pending leak)."""
+    from app.routers.commissioner import _validate_sql
+
+    assert _validate_sql("SELECT member, score FROM legacy_rounds_official") is True
+    assert _validate_sql("SELECT member, score FROM legacy_rounds") is False
+
+
+def test_pending_becomes_visible_after_attestation(db_session):
+    """Flipping pending→attested makes the round surface through both read paths."""
+    from app.routers.commissioner import _build_data_context, _execute_readonly_sql
+
+    row = db_session.query(LegacyRound).filter(LegacyRound.member == "Bob Jones").one()
+    row.status = "attested"
+    db_session.commit()
+
+    context = _build_data_context(db_session)
+    assert "Bob Jones" in context
+
+    results = _execute_readonly_sql(
+        db_session,
+        "SELECT member FROM legacy_rounds_official WHERE member = 'Bob Jones'",
+    )
+    assert "error" not in results, results
+    assert {row[0] for row in results["rows"]} == {"Bob Jones"}

--- a/backend/tests/unit/routers/test_commissioner_pending_filter.py
+++ b/backend/tests/unit/routers/test_commissioner_pending_filter.py
@@ -96,6 +96,41 @@ def test_raw_legacy_rounds_table_is_rejected_by_validator():
     assert _validate_sql("SELECT member, score FROM legacy_rounds") is False
 
 
+def test_quoted_and_qualified_raw_legacy_rounds_refs_are_rejected():
+    """Quoting / schema-qualification must not let the raw table evade the allow-list."""
+    from app.routers.commissioner import _validate_sql
+
+    # (a) plain double-quoted raw table
+    assert _validate_sql('SELECT * FROM "legacy_rounds"') is False
+    # (b) quoted raw-table ref inside a subquery
+    assert _validate_sql('SELECT * FROM (SELECT * FROM "legacy_rounds") x') is False
+    # (b') quoted raw-table ref inside a CTE
+    assert _validate_sql('WITH leaked AS (SELECT * FROM "legacy_rounds") SELECT * FROM leaked') is False
+    # (c) schema-qualified quoted refs
+    assert _validate_sql('SELECT * FROM public."legacy_rounds"') is False
+    assert _validate_sql('SELECT * FROM "public"."legacy_rounds"') is False
+    # JOIN target quoted raw table is also rejected
+    assert (
+        _validate_sql('SELECT * FROM legacy_rounds_official o JOIN "legacy_rounds" r ON o.member = r.member') is False
+    )
+    # Sanity: the genuinely-allowed view still passes, even quoted/qualified.
+    assert _validate_sql('SELECT member FROM "legacy_rounds_official"') is True
+    assert _validate_sql('SELECT member FROM public."legacy_rounds_official"') is True
+
+
+def test_official_view_quoted_query_still_excludes_pending(db_session):
+    """A valid quoted query against the official view passes and hides pending rows."""
+    from app.routers.commissioner import _execute_readonly_sql, _validate_sql
+
+    sql = 'SELECT member FROM "legacy_rounds_official"'
+    assert _validate_sql(sql) is True
+    results = _execute_readonly_sql(db_session, sql)
+    assert "error" not in results, results
+    members = {row[0] for row in results["rows"]}
+    assert "Alice Park" in members  # attested → returned
+    assert "Bob Jones" not in members  # pending → excluded
+
+
 def test_pending_becomes_visible_after_attestation(db_session):
     """Flipping pending→attested makes the round surface through both read paths."""
     from app.routers.commissioner import _build_data_context, _execute_readonly_sql

--- a/backend/tests/unit/routers/test_commissioner_pending_filter.py
+++ b/backend/tests/unit/routers/test_commissioner_pending_filter.py
@@ -187,6 +187,32 @@ def test_prior_adversarial_cases_still_rejected():
     assert _validate_sql("SELECT member FROM legacy_rounds_official UNION SELECT member FROM legacy_rounds") is False
 
 
+def test_documented_table_valued_function_pattern_passes():
+    """The documented CROSS JOIN json_array_elements(...) pattern must validate.
+
+    sqlglot models the TVF output as an exp.Table with an empty name; those
+    wrappers must be skipped, not rejected (DATA_SCHEMA ~commissioner.py:265).
+    """
+    from app.routers.commissioner import _validate_sql
+
+    sql = (
+        "SELECT gpr.player_name, (h->>'hole')::int AS hole, "
+        "(h->>'quarters')::numeric AS quarters "
+        "FROM game_player_results gpr "
+        "CROSS JOIN json_array_elements(gpr.hole_scores) AS h "
+        "WHERE gpr.player_name ILIKE '%Stuart%' "
+        "ORDER BY (h->>'hole')::int"
+    )
+    assert _validate_sql(sql) is True
+
+
+def test_tvf_wrapped_attempt_to_reach_raw_table_still_rejected():
+    """Skipping empty-name TVF wrappers must not let a real raw ref slip through."""
+    from app.routers.commissioner import _validate_sql
+
+    assert _validate_sql("SELECT * FROM json_array_elements((SELECT 1)) x, legacy_rounds lr") is False
+
+
 def test_fail_closed_on_unparseable_sql():
     """If sqlglot cannot parse the statement, the validator must reject it."""
     from app.routers.commissioner import _validate_sql

--- a/backend/tests/unit/routers/test_commissioner_pending_filter.py
+++ b/backend/tests/unit/routers/test_commissioner_pending_filter.py
@@ -118,6 +118,37 @@ def test_quoted_and_qualified_raw_legacy_rounds_refs_are_rejected():
     assert _validate_sql('SELECT member FROM public."legacy_rounds_official"') is True
 
 
+def test_cte_alias_named_after_denied_table_is_rejected():
+    """A CTE named like the forbidden raw table cannot whitelist it (denylist wins)."""
+    from app.routers.commissioner import _validate_sql
+
+    # (a) CTE named legacy_rounds, quoted raw-table body
+    assert _validate_sql('WITH legacy_rounds AS (SELECT * FROM "legacy_rounds") SELECT * FROM legacy_rounds') is False
+    # (b) same idea, unquoted raw-table body
+    assert _validate_sql("WITH legacy_rounds AS (SELECT * FROM legacy_rounds) SELECT * FROM legacy_rounds") is False
+    # (c) CTE named legacy_rounds whose body selects from the raw table via a
+    #     schema-qualified quoted ref
+    assert (
+        _validate_sql('WITH legacy_rounds AS (SELECT * FROM public."legacy_rounds") SELECT * FROM legacy_rounds')
+        is False
+    )
+    # A legitimate CTE over the sanctioned view still passes.
+    assert _validate_sql("WITH r AS (SELECT * FROM legacy_rounds_official) SELECT * FROM r") is True
+
+
+def test_legitimate_cte_over_official_view_excludes_pending(db_session):
+    """A valid CTE over the official view passes and still hides pending rows."""
+    from app.routers.commissioner import _execute_readonly_sql, _validate_sql
+
+    sql = "WITH r AS (SELECT * FROM legacy_rounds_official) SELECT member FROM r"
+    assert _validate_sql(sql) is True
+    results = _execute_readonly_sql(db_session, sql)
+    assert "error" not in results, results
+    members = {row[0] for row in results["rows"]}
+    assert "Alice Park" in members  # attested → returned
+    assert "Bob Jones" not in members  # pending → excluded
+
+
 def test_official_view_quoted_query_still_excludes_pending(db_session):
     """A valid quoted query against the official view passes and hides pending rows."""
     from app.routers.commissioner import _execute_readonly_sql, _validate_sql

--- a/backend/tests/unit/routers/test_member_rounds_router.py
+++ b/backend/tests/unit/routers/test_member_rounds_router.py
@@ -1,0 +1,410 @@
+"""Unit tests for member round-posting + peer attestation.
+
+Covers the pinned contract: post → pending; overwrite-while-pending; 409 when
+already attested; attest flips pending→attested; self/non-foursome attest 403;
+attest-non-pending 409; pending excluded from leaderboard reads (both the
+spreadsheet_sync router AND unified_data_service); missing legacy_name 400; and
+the one-per-day partial unique index.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.routers.member_rounds as member_rounds_module
+from app.database import Base, get_db
+from app.main import app
+from app.models import LegacyRosterPlayer, PlayerProfile
+from app.services.auth_service import get_current_user
+from app.utils.admin_auth import require_admin
+
+ROSTER = ["Stuart Gano", "Jeff Smith", "Bob Jones", "Alice Park"]
+
+
+@pytest.fixture
+def db_session():
+    """A fresh in-memory SQLite DB with the full schema (incl. new columns)."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestingSessionLocal()
+
+    # Seed canonical roster + profiles (with emails so attestation emails resolve).
+    for i, name in enumerate(ROSTER, start=1):
+        session.add(LegacyRosterPlayer(name=name, source="seed", added_at="2026-01-01T00:00:00"))
+        session.add(
+            PlayerProfile(
+                id=i,
+                name=name,
+                legacy_name=name,
+                email=f"{name.split()[0].lower()}@example.com",
+                created_at="2026-01-01T00:00:00",
+            )
+        )
+    session.commit()
+
+    yield session, TestingSessionLocal
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def client(db_session, monkeypatch):
+    """TestClient wired to the temp DB with no real emails sent."""
+    session, TestingSessionLocal = db_session
+
+    def _override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[require_admin] = lambda: None
+
+    # No real emails.
+    fake_email = MagicMock()
+    fake_email.send_attestation_request.return_value = True
+    monkeypatch.setattr(member_rounds_module, "get_email_service", lambda: fake_email)
+
+    test_client = TestClient(app)
+    test_client.fake_email = fake_email  # type: ignore[attr-defined]
+    yield test_client
+
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(require_admin, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _login(player_id: int, legacy_name: str | None):
+    """Override get_current_user with a minimal profile."""
+    user = MagicMock(spec=PlayerProfile)
+    user.id = player_id
+    user.legacy_name = legacy_name
+    user.name = legacy_name
+    app.dependency_overrides[get_current_user] = lambda: user
+    return user
+
+
+# Profile ids per ROSTER seeding order.
+STUART, JEFF, BOB, ALICE = 1, 2, 3, 4
+
+
+# ── POST /players/me/round ───────────────────────────────────────────────────
+
+
+def test_post_creates_pending_round(client):
+    _login(STUART, "Stuart Gano")
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith", "Bob Jones"]},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["status"] == "pending"
+    assert data["member"] == "Stuart Gano"
+    assert data["score"] == 5
+    assert data["foursome"] == ["Jeff Smith", "Bob Jones"]
+    assert data["attested_by"] is None
+    assert data["attested_at"] is None
+    client.fake_email.send_attestation_request.assert_called()
+
+
+def test_post_without_legacy_name_returns_400(client):
+    _login(STUART, None)
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 1, "foursome": ["Jeff Smith"]},
+    )
+    assert resp.status_code == 400
+    assert "roster name" in resp.json()["detail"].lower()
+
+
+def test_post_negative_score_allowed(client):
+    _login(STUART, "Stuart Gano")
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": -7, "foursome": ["Jeff Smith"]},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["score"] == -7
+
+
+def test_post_foursome_including_self_returns_400(client):
+    _login(STUART, "Stuart Gano")
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 1, "foursome": ["stuart gano"]},
+    )
+    assert resp.status_code == 400
+    assert "yourself" in resp.json()["detail"].lower()
+
+
+def test_post_invalid_foursome_name_returns_400(client):
+    _login(STUART, "Stuart Gano")
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 1, "foursome": ["Nobody McGhost"]},
+    )
+    assert resp.status_code == 400
+
+
+def test_post_empty_foursome_returns_400(client):
+    _login(STUART, "Stuart Gano")
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 1, "foursome": []},
+    )
+    assert resp.status_code == 400
+
+
+def test_post_bad_date_returns_400(client):
+    _login(STUART, "Stuart Gano")
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "06/15/2026", "score": 1, "foursome": ["Jeff Smith"]},
+    )
+    assert resp.status_code == 400
+
+
+def test_second_post_same_day_while_pending_overwrites(client):
+    _login(STUART, "Stuart Gano")
+    first = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    )
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    second = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 9, "foursome": ["Bob Jones"]},
+    )
+    assert second.status_code == 201
+    body = second.json()
+    assert body["id"] == first_id  # same row, overwritten
+    assert body["score"] == 9
+    assert body["foursome"] == ["Bob Jones"]
+
+    # Only one member row exists for that day.
+    mine = client.get("/players/me/rounds").json()
+    assert len([r for r in mine if r["date"] == "2026-06-15"]) == 1
+
+
+def test_second_post_when_attested_returns_409(client):
+    _login(STUART, "Stuart Gano")
+    posted = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    ).json()
+
+    _login(JEFF, "Jeff Smith")
+    attest = client.post(f"/rounds/{posted['id']}/attest")
+    assert attest.status_code == 200
+
+    _login(STUART, "Stuart Gano")
+    resp = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 99, "foursome": ["Bob Jones"]},
+    )
+    assert resp.status_code == 409
+
+
+# ── POST /rounds/{id}/attest ─────────────────────────────────────────────────
+
+
+def test_attest_by_foursome_member_flips_to_attested(client):
+    _login(STUART, "Stuart Gano")
+    posted = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith", "Bob Jones"]},
+    ).json()
+
+    _login(BOB, "Bob Jones")
+    resp = client.post(f"/rounds/{posted['id']}/attest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "attested"
+    assert data["attested_by"] == BOB
+    assert data["attested_at"] is not None
+
+
+def test_self_attest_returns_403(client):
+    _login(STUART, "Stuart Gano")
+    posted = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    ).json()
+    resp = client.post(f"/rounds/{posted['id']}/attest")  # still Stuart
+    assert resp.status_code == 403
+
+
+def test_non_foursome_attest_returns_403(client):
+    _login(STUART, "Stuart Gano")
+    posted = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    ).json()
+
+    _login(ALICE, "Alice Park")  # not in foursome
+    resp = client.post(f"/rounds/{posted['id']}/attest")
+    assert resp.status_code == 403
+
+
+def test_attest_nonexistent_returns_404(client):
+    _login(JEFF, "Jeff Smith")
+    resp = client.post("/rounds/999999/attest")
+    assert resp.status_code == 404
+
+
+def test_attest_already_attested_returns_409(client):
+    _login(STUART, "Stuart Gano")
+    posted = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    ).json()
+
+    _login(JEFF, "Jeff Smith")
+    assert client.post(f"/rounds/{posted['id']}/attest").status_code == 200
+    # Second attest of a non-pending round.
+    resp = client.post(f"/rounds/{posted['id']}/attest")
+    assert resp.status_code == 409
+
+
+# ── GET /rounds/pending-attestation ──────────────────────────────────────────
+
+
+def test_pending_attestation_lists_for_foursome_member_only(client):
+    _login(STUART, "Stuart Gano")
+    client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    )
+
+    _login(JEFF, "Jeff Smith")  # in foursome → sees it
+    assert len(client.get("/rounds/pending-attestation").json()) == 1
+
+    _login(ALICE, "Alice Park")  # not in foursome → empty
+    assert client.get("/rounds/pending-attestation").json() == []
+
+    _login(STUART, "Stuart Gano")  # poster never attests own round
+    assert client.get("/rounds/pending-attestation").json() == []
+
+
+# ── Read-path: pending excluded, attested included ───────────────────────────
+
+
+def test_pending_excluded_from_spreadsheet_leaderboard_then_included(client):
+    _login(STUART, "Stuart Gano")
+    posted = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    ).json()
+
+    # While pending, Stuart absent from the leaderboard.
+    board = client.get("/admin/spreadsheet/leaderboard").json()
+    assert "Stuart Gano" not in {e["member"] for e in board}
+    assert client.get("/admin/spreadsheet/rounds").json() == []
+
+    # After attestation, Stuart appears.
+    _login(JEFF, "Jeff Smith")
+    client.post(f"/rounds/{posted['id']}/attest")
+
+    board = client.get("/admin/spreadsheet/leaderboard").json()
+    stuart = next((e for e in board if e["member"] == "Stuart Gano"), None)
+    assert stuart is not None and stuart["quarters"] == 5
+    assert len(client.get("/admin/spreadsheet/rounds").json()) == 1
+
+
+def test_pending_excluded_from_unified_get_all_rounds(client, db_session):
+    session, _ = db_session
+    from app.services.unified_data_service import UnifiedDataService
+
+    _login(STUART, "Stuart Gano")
+    posted = client.post(
+        "/players/me/round",
+        json={"date": "2026-06-15", "score": 5, "foursome": ["Jeff Smith"]},
+    ).json()
+
+    service = UnifiedDataService(db=session)
+    pending_rounds = service.get_all_rounds(include_database=False)
+    assert all(r.member != "Stuart Gano" for r in pending_rounds)
+
+    _login(JEFF, "Jeff Smith")
+    client.post(f"/rounds/{posted['id']}/attest")
+
+    attested_rounds = service.get_all_rounds(include_database=False)
+    assert any(r.member == "Stuart Gano" and r.score == 5 for r in attested_rounds)
+
+
+# ── One-per-day partial unique index ─────────────────────────────────────────
+
+
+def test_one_member_round_per_day_unique_index(db_session):
+    session, _ = db_session
+    from app.models import LegacyRound
+
+    session.add(
+        LegacyRound(
+            date="2026-06-15",
+            member="Stuart Gano",
+            score=1,
+            source="member",
+            status="pending",
+            synced_at="2026-06-15T00:00:00",
+            created_at="2026-06-15T00:00:00",
+        )
+    )
+    session.commit()
+
+    session.add(
+        LegacyRound(
+            date="2026-06-15",
+            member="Stuart Gano",
+            score=2,
+            source="member",
+            status="pending",
+            synced_at="2026-06-15T00:00:00",
+            created_at="2026-06-15T00:00:00",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+
+    # Sheet rows (different source) are NOT constrained — duplicates allowed.
+    session.add_all(
+        [
+            LegacyRound(
+                date="2026-06-15",
+                member="Stuart Gano",
+                score=3,
+                source="primary_sheet",
+                status="attested",
+                synced_at="x",
+                created_at="x",
+            ),
+            LegacyRound(
+                date="2026-06-15",
+                member="Stuart Gano",
+                score=4,
+                source="primary_sheet",
+                status="attested",
+                synced_at="x",
+                created_at="x",
+            ),
+        ]
+    )
+    session.commit()  # no error


### PR DESCRIPTION
## What

Backend for members self-posting their **Wolf-Goat-Pig round result (quarters won/lost)** — the value the organizer currently hand-enters into the Google Sheet — tied to their `PlayerProfile`, **one per member per calendar day**, authoritative only after another **foursome member attests** it. The DB (`legacy_rounds`) becomes the source of truth; sheet write-back is intentionally out of scope.

The per-hole scoring path is untouched — this is a standalone **totals** path.

## Schema (additive, idempotent `ADD COLUMN IF NOT EXISTS`)

Extends `legacy_rounds`:
- `player_profile_id`, `status` (NOT NULL default `attested`), `attested_by_profile_id`, `attested_at`, `foursome` (JSON)
- Member posts use `source='member'`, `status='pending'`
- Partial unique index `ux_member_round_per_day (member, date) WHERE source='member'` → enforces one-per-day
- All additive/nullable so existing + sheet rows stay authoritative (default `attested`)

## Endpoints (all `Depends(get_current_user)`)

- `POST /players/me/round` — 400 if no `legacy_name`; canonicalizes the 1–3-name foursome via `get_canonical_name`, rejects the poster; overwrites a still-`pending` same-day row, 409 if already attested; emails each foursome member with a profile (best-effort, never fails the request)
- `GET /players/me/rounds`
- `GET /rounds/pending-attestation` — the attester's queue
- `POST /rounds/{id}/attest` — 404→403 (not a named foursome member / is the poster)→409 (not pending) ordering; flips to `attested`

## Read-path correctness

`pending` rounds are excluded from standings until attested:
- `unified_data_service.get_all_rounds()` and all four `spreadsheet_sync.py` queries filter `status != 'pending'`
- Confirmed `source='member'` rows survive the restart-time sheet wipe (which only deletes `primary_sheet`/`writable_sheet` rows)

## Email

New `EmailService.send_attestation_request` modeled on `send_welcome_email`.

## Tests

`tests/unit/routers/test_member_rounds_router.py` — 18 tests covering every contract case (post/replace-while-pending/409-when-attested, attest happy path, self-attest 403, non-foursome 403, attest-non-pending 409, pending-excluded-from-both-read-paths, missing-legacy-name 400, unique-index backstop).

**Gate:** `ruff check` + `ruff format --check` clean; `pytest` → **1492 passed** (the single `startup_test.py::test_server` failure is the documented Mac-only SOCKS-proxy issue, passes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — orchestrated by polly; opposite-vendor cross-review to follow before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Members can now post their own golf round results with score, date, and foursome participants.
  * Peer attestation workflow allows eligible members to verify and attest posted rounds.
  * Email notifications automatically notify foursome members to attest pending rounds.
  * Members can view their posted rounds and pending attestations awaiting their action.

* **Changes**
  * Pending member-posted rounds are excluded from leaderboards until attested by peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->