### PR TITLE
fix: trigger nightly sheet write-back drain (cron + startup) and correct sheet-id docstring

### DIFF
--- a/.github/workflows/sheet-sync-drain.yml
+++ b/.github/workflows/sheet-sync-drain.yml
@@ -1,0 +1,35 @@
+name: Nightly Sheet Sync Drain
+
+# Flushes the pending sheet-sync queue to the writable WGP Dashboard copy
+# (19AabC...). Driven here (not the in-process scheduler, which is a no-op shim
+# in prod) — same pattern as the GHIN sync and headcount callout crons.
+on:
+  schedule:
+    - cron: '0 8 * * *'  # 08:00 UTC (~1am PT) nightly — after weekend games
+  workflow_dispatch:       # Allow manual trigger
+
+jobs:
+  drain:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Drain pending sheet syncs
+      run: |
+        echo "📤 Draining pending sheet syncs..."
+        RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+          "https://wolf-goat-pig.onrender.com/spreadsheet/drain-pending-syncs" \
+          -H "Content-Type: application/json" \
+          --max-time 120)
+
+        HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+        BODY=$(echo "$RESPONSE" | head -n -1)
+
+        echo "Status: $HTTP_CODE"
+        echo "Response: $BODY"
+
+        if [ "$HTTP_CODE" != "200" ]; then
+          echo "❌ Drain failed with status $HTTP_CODE"
+          exit 1
+        fi
+
+        echo "✅ Sheet sync drain complete"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -162,6 +162,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception as e:
         logger.warning(f"Legacy rounds startup sync failed to launch: {e}")
 
+    # Also drain any queued sheet write-backs on startup (secondary robustness;
+    # the primary trigger is the nightly sheet-sync-drain GitHub Actions cron).
+    try:
+        import threading
+
+        from .services.email_scheduler import email_scheduler as _sched
+
+        t = threading.Thread(target=_sched._process_pending_sheet_syncs, daemon=True)
+        t.start()
+        logger.info("📤 Pending sheet-sync drain started in background")
+    except Exception as e:
+        logger.warning(f"Pending sheet-sync startup drain failed to launch: {e}")
+
     logger.info("🚀 Wolf Goat Pig API startup completed successfully!")
 
     yield  # Application runs here
@@ -278,6 +291,12 @@ app.include_router(migrations_router)
 from .routers import spreadsheet_sync
 
 app.include_router(spreadsheet_sync.router)
+
+# Cron-driven spreadsheet ops (nightly pending-sync drain — unauthenticated, like
+# /ghin/sync-handicaps and /callouts/run; the in-process scheduler is a no-op in prod)
+from .routers import spreadsheet_ops
+
+app.include_router(spreadsheet_ops.router)
 
 # Include unified data routes (merges all data sources)
 from .routers import unified_data

--- a/backend/app/routers/spreadsheet_ops.py
+++ b/backend/app/routers/spreadsheet_ops.py
@@ -1,0 +1,41 @@
+"""Spreadsheet sync ops endpoint — driven by an external scheduler (GitHub Actions cron).
+
+The in-process email scheduler is a no-op in production (a vendored `schedule`
+shim never fires jobs), so the nightly drain of the pending sheet-sync queue runs
+as a GitHub Actions cron that POSTs here — the same pattern as GHIN sync
+(POST /ghin/sync-handicaps) and the headcount callout (POST /callouts/run).
+
+Completed app games are enqueued (POST /admin/spreadsheet/sync-round) into the
+pending_sheet_syncs table; this endpoint flushes that queue, writing new/updated
+rounds to the WRITABLE copy (19AabC...). Idempotent: dedup against legacy_rounds
+means a re-run writes nothing already present.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from ..services.email_scheduler import email_scheduler
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/spreadsheet", tags=["spreadsheet"])
+
+
+@router.post("/drain-pending-syncs")
+def drain_pending_sheet_syncs():
+    """Flush the pending sheet-sync queue to the writable Google Sheet.
+
+    Runs the same drain the (no-op-in-prod) in-process scheduler was meant to run
+    nightly. Intended to be called by the sheet-sync-drain GitHub Actions cron.
+    Returns a small summary (pending/written/duplicates/failed) of what was flushed.
+
+    A plain (non-async) handler so FastAPI runs the blocking Sheets I/O in a
+    threadpool rather than stalling the event loop.
+    """
+    try:
+        summary = email_scheduler._process_pending_sheet_syncs()
+        return {"message": "Pending sheet syncs drained", "summary": summary}
+    except Exception as e:
+        logger.error(f"Error draining pending sheet syncs: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to drain pending sheet syncs: {e!s}")

--- a/backend/app/services/email_scheduler.py
+++ b/backend/app/services/email_scheduler.py
@@ -367,7 +367,7 @@ class EmailScheduler:
         finally:
             db.close()
 
-    def _process_pending_sheet_syncs(self):
+    def _process_pending_sheet_syncs(self) -> dict[str, int]:
         """Drain the pending_sheet_syncs queue.
 
         For each pending row:
@@ -380,6 +380,10 @@ class EmailScheduler:
 
         The app records per-hole scores; the legacy sheet stores only round totals.
         player_scores in the queue are expected to be the summed totals.
+
+        Returns a summary dict (pending/written/duplicates/failed counts) so the
+        HTTP drain endpoint can report what it flushed. The in-process scheduler
+        and the startup thread ignore the return value.
         """
         from datetime import UTC
         from datetime import datetime as dt
@@ -387,6 +391,7 @@ class EmailScheduler:
         from ..models import PendingSheetSync
         from .spreadsheet_sync_service import get_spreadsheet_sync_service
 
+        summary = {"pending": 0, "written": 0, "duplicates": 0, "failed": 0}
         db = self._get_db()
         try:
             pending = (
@@ -396,8 +401,9 @@ class EmailScheduler:
                 .all()
             )
             if not pending:
-                return
+                return summary
 
+            summary["pending"] = len(pending)
             logger.info("Processing %d pending sheet sync(s)", len(pending))
             wrote_any = False
 
@@ -411,6 +417,7 @@ class EmailScheduler:
 
                     if action == "duplicate":
                         logger.info("Skipping duplicate round %s group=%s", job.date, job.group)
+                        summary["duplicates"] += 1
                     else:
                         logger.info(
                             "Writing %s round %s group=%s to sheet",
@@ -430,6 +437,7 @@ class EmailScheduler:
                         if not success:
                             raise RuntimeError("sync_completed_game returned False")
                         wrote_any = True
+                        summary["written"] += 1
 
                     job.status = "done"
                     job.processed_at = dt.now(UTC).isoformat()
@@ -441,6 +449,7 @@ class EmailScheduler:
                     job.error = str(exc)
                     job.processed_at = dt.now(UTC).isoformat()
                     db.commit()
+                    summary["failed"] += 1
 
             if wrote_any:
                 logger.info("Sheet writes completed — refreshing legacy_rounds cache")
@@ -450,6 +459,8 @@ class EmailScheduler:
             logger.error("_process_pending_sheet_syncs failed: %s", exc)
         finally:
             db.close()
+
+        return summary
 
     def _dedup_action(self, db, job) -> str:
         """Return 'duplicate', 'update', or 'new' for a PendingSheetSync job.

--- a/backend/app/services/spreadsheet_sync_service.py
+++ b/backend/app/services/spreadsheet_sync_service.py
@@ -2,8 +2,14 @@
 
 This service provides two-way sync between the Wolf Goat Pig app and the
 legacy Google Sheets dashboard at:
-- Primary (read-only): https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
-- Writable copy: https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM
+- PRIMARY (canonical, read source): Jeff Green's master sheet —
+  https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM
+- WRITABLE (app write target): Stuart's "Copy of WGP Dashboard" —
+  https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
+
+Completed app games are written to the WRITABLE copy (19AabC...); the PRIMARY
+master (1PWhi5...) is the canonical read source. See PRIMARY_SHEET_ID /
+WRITABLE_SHEET_ID below.
 
 Sheet Structure:
 - Dashboard: Leaderboard summary (auto-calculated from Details)

--- a/backend/tests/unit/routers/test_spreadsheet_ops_router.py
+++ b/backend/tests/unit/routers/test_spreadsheet_ops_router.py
@@ -1,0 +1,47 @@
+"""Unit tests for the spreadsheet ops router.
+
+The endpoint is the external-cron entry point for the nightly drain of the
+pending sheet-sync queue. These tests cover the HTTP wiring — that the endpoint
+invokes the drain and echoes its summary — with the scheduler's drain stubbed
+(its own logic is covered in the email_scheduler tests).
+"""
+
+from fastapi.testclient import TestClient
+
+from app import routers
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_drain_invokes_scheduler_and_returns_summary(monkeypatch):
+    calls = {"count": 0}
+    fake_summary = {"pending": 3, "written": 2, "duplicates": 1, "failed": 0}
+
+    class FakeScheduler:
+        def _process_pending_sheet_syncs(self):
+            calls["count"] += 1
+            return fake_summary
+
+    monkeypatch.setattr(routers.spreadsheet_ops, "email_scheduler", FakeScheduler())
+
+    resp = client.post("/spreadsheet/drain-pending-syncs")
+
+    assert resp.status_code == 200
+    assert calls["count"] == 1
+    body = resp.json()
+    assert body["summary"] == fake_summary
+    assert body["message"] == "Pending sheet syncs drained"
+
+
+def test_drain_returns_500_when_scheduler_raises(monkeypatch):
+    class BoomScheduler:
+        def _process_pending_sheet_syncs(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(routers.spreadsheet_ops, "email_scheduler", BoomScheduler())
+
+    resp = client.post("/spreadsheet/drain-pending-syncs")
+
+    assert resp.status_code == 500
+    assert "Failed to drain" in resp.json()["detail"]


### PR DESCRIPTION
## Problem

Completed app games are enqueued into the `pending_sheet_syncs` table (`POST /admin/spreadsheet/sync-round` only **enqueues**), then drained by `_process_pending_sheet_syncs`, which writes them to the writable WGP Dashboard copy. But that drain **never fired in production**: it was registered only on the in-process `schedule` lib, which resolves to a no-op shim in prod (`backend/schedule.py`), and — unlike the rounds sync — had **no GitHub Actions cron and no startup trigger**. Queued rows therefore never flushed to the sheet.

## Fix

The drain now fires **nightly** via `.github/workflows/sheet-sync-drain.yml` (cron `0 8 * * *`, ~1am PT) hitting the new endpoint **`POST /spreadsheet/drain-pending-syncs`**, plus a startup background-thread drain on each deploy for secondary robustness.

- **New endpoint** `POST /spreadsheet/drain-pending-syncs` (`backend/app/routers/spreadsheet_ops.py`) — unauthenticated, mirroring the auth/style of the crons' existing targets `/ghin/sync-handicaps` and `/callouts/run`. Runs the drain and returns a small JSON summary: `{pending, written, duplicates, failed}`. Plain `def` handler so blocking Sheets I/O runs in FastAPI's threadpool.
- **New workflow** `.github/workflows/sheet-sync-drain.yml` — nightly cron modeled exactly on `ghin-sync.yml` (`workflow_dispatch` included). Cron `0 8 * * *` is clear of GHIN (`0 14`) and callouts (`0 15`/`0 22`).
- **Startup flush** in `backend/app/main.py`, mirroring the existing legacy-rounds-sync startup thread.
- `_process_pending_sheet_syncs` now returns a summary dict on every exit path; the no-op scheduler and the startup thread ignore the return value.
- **Docstring correction** in `backend/app/services/spreadsheet_sync_service.py`: the top-of-file labels were backwards. Corrected to reality — `19AabC...` = the app's **WRITABLE** copy / write target (Stuart's "Copy of WGP Dashboard"); `1PWhi5...` = **PRIMARY** canonical **READ** source (Jeff's master).

## Write target unchanged

`WRITABLE_SHEET_ID` stays `19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA` and `PRIMARY_SHEET_ID` stays `1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM`. **Only the docstring was wrong, not the constants** — their values/assignments are byte-identical. Writes still go to `19AabC...`.

## Secrets

**No new secret required.** Like `ghin-sync.yml`, the new workflow hardcodes `https://wolf-goat-pig.onrender.com` and uses no auth header.

## Tests / gates

- `backend/tests/unit/routers/test_spreadsheet_ops_router.py` — asserts the endpoint invokes the drain and echoes its summary, and returns 500 on failure.
- `ruff check` ✅ · `ruff format --check` ✅ · `pytest tests/ --ignore=tests/manual --ignore=tests/_diagnostic` → **1508 passed, 1 failed**. The single failure is the documented local-only `tests/infra/startup_test.py` SOCKS-proxy `ImportError` (passes in CI). Workflow YAML validated as well-formed.

## Note (non-blocking, out of scope)

There are now three drain trigger paths (startup, cron, manual). The drain's dedup checks the persisted `legacy_rounds` mirror, not the live sheet, so two concurrent runs (e.g. a deploy landing during the cron) could in theory double-append a pending row before `legacy_rounds` refreshes. Low probability and a pre-existing dedup characteristic; adding locking is out of scope here.