### PR TITLE
feat(scorecard): tiled adaptive scanning guided by pre-picked players

### DIFF
--- a/backend/app/routers/scorecard.py
+++ b/backend/app/routers/scorecard.py
@@ -4,10 +4,11 @@ Scorecard Router
 Scorecard photo scanning via Gemini Vision.
 """
 
+import json as _json
 import logging
 from typing import Any
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
 logger = logging.getLogger("app.routers.scorecard")
 
@@ -15,11 +16,19 @@ router = APIRouter(prefix="/scorecard", tags=["scorecard"])
 
 
 @router.post("/scan")
-async def scan_scorecard_photo(file: UploadFile = File(...)) -> dict[str, Any]:
+async def scan_scorecard_photo(
+    file: UploadFile = File(...),
+    players: str | None = Form(None),
+) -> dict[str, Any]:
     """
     Upload a scorecard photo and extract running quarter totals via Gemini Vision.
     Returns extracted running totals and computed per-hole quarter deltas.
     Phase 1: no image persistence, process and return immediately.
+
+    Optional form field:
+    - players: JSON array of player name strings (e.g. '["CK","SS","SG"]').
+      When provided, passed to the scan service as expected_players to guide
+      tiled/guided scanning.
     """
     from ..services.scorecard_scan_service import scan_scorecard
 
@@ -38,8 +47,17 @@ async def scan_scorecard_photo(file: UploadFile = File(...)) -> dict[str, Any]:
     # that fits Groq's ~4MB request budget (see _fit_image_to_budget) right before
     # the call — so the model gets maximum legible detail instead of a pre-shrunk 2048px.
 
+    expected_players = None
+    if players:
+        try:
+            parsed = _json.loads(players)
+            if isinstance(parsed, list) and parsed:
+                expected_players = [str(p) for p in parsed]
+        except (ValueError, TypeError):
+            expected_players = None
+
     try:
-        result = await scan_scorecard(image_bytes, content_type)
+        result = await scan_scorecard(image_bytes, content_type, expected_players=expected_players)
         return result
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/backend/app/services/scorecard_scan_service.py
+++ b/backend/app/services/scorecard_scan_service.py
@@ -392,65 +392,66 @@ def _shape_extraction(extracted: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-async def scan_scorecard(image_bytes: bytes, content_type: str) -> dict[str, Any]:
-    """
-    Send scorecard image to Groq Vision and return extracted running totals
-    plus computed per-hole quarter deltas. Retries once if the first attempt
-    returns malformed JSON or violates the zero-sum invariant — these are
-    the dominant failure modes in practice and a stricter retry catches
-    most of them without doubling latency on the happy path.
-
-    Preprocessing pipeline (each step degrades gracefully — failures fall
-    through to the previous step's bytes):
-      1. deskew_to_card: detect the card frame and perspective-warp to a
-         rectangle so the model sees a clean top-down view.
-      2. crop_to_grid: detect grid lines and tighten the frame to just the
-         table region, dropping branding/title/footer.
-      3. annotate_circles: classical Hough detection draws red rectangles
-         around hand-drawn circles to make the negative/positive sign call
-         a rectangle-spotting task instead of a circle-recognition task.
-    The annotated bytes are reused for both the initial call and the strict
-    retry.
-    """
-    # Downscale to a sane working size first — the CV preprocessing below runs
-    # at full resolution and is prohibitively slow on a raw ~4000px phone pic.
+async def scan_scorecard(
+    image_bytes: bytes, content_type: str, expected_players: list[str] | None = None
+) -> dict[str, Any]:
+    """Single guided Groq call; if it fails zero-sum or is missing an expected
+    player, fall back to a tiled (left=holes 1-9 / right=holes 10-18) scan and
+    merge by player. Returns the usual shape plus result["method"]."""
+    # Cap working size before the (full-res) CV preprocessing — see _PREPROCESS_MAX_DIM.
     image_bytes, content_type = _fit_image_to_budget(
         image_bytes, content_type, max_dim=_PREPROCESS_MAX_DIM, max_b64_chars=10**12
     )
     deskewed_bytes, deskewed_ct, deskew_diag = deskew_to_card(image_bytes, content_type)
     cropped_bytes, cropped_ct, grid_diag = crop_to_grid(deskewed_bytes, deskewed_ct)
     annotated_bytes, annotated_ct, circle_diag = annotate_circles(cropped_bytes, cropped_ct)
-    preprocessing_diag = {
-        "deskew": deskew_diag,
-        "grid_crop": grid_diag,
-        "circles": circle_diag,
-    }
+    preprocessing_diag = {"deskew": deskew_diag, "grid_crop": grid_diag, "circles": circle_diag}
 
-    parse_error: Exception | None = None
+    def _finalize(raw: dict, method: str) -> dict:
+        out = _shape_extraction(raw)
+        out["validation"] = _validate_zero_sum(out["per_hole_quarters"])
+        out["preprocessing"] = preprocessing_diag
+        out["method"] = method
+        return out
+
+    # ---- single guided attempt (with one strict retry on bad JSON) ----
     try:
-        extracted = await _call_groq_vision(annotated_bytes, annotated_ct, strict=False)
-    except json.JSONDecodeError as e:
-        logger.warning("First scan returned non-JSON, retrying strict: %s", e)
-        parse_error = e
-        extracted = None
+        single_raw = await _call_groq_vision(
+            annotated_bytes, annotated_ct, strict=False, expected_players=expected_players
+        )
+    except json.JSONDecodeError:
+        try:
+            single_raw = await _call_groq_vision(
+                annotated_bytes, annotated_ct, strict=True, expected_players=expected_players
+            )
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse vision response: {e}")
 
-    if extracted is not None:
-        result = _shape_extraction(extracted)
-        validation = _validate_zero_sum(result["per_hole_quarters"])
-        if validation["valid"]:
-            result["validation"] = validation
-            result["preprocessing"] = preprocessing_diag
-            return result
-        logger.warning("Zero-sum violated on first scan: %s — retrying strict", validation["bad_holes"])
+    single = _finalize(single_raw, "single")
+    if single["validation"]["valid"] and not _missing_expected(single_raw, expected_players):
+        return single
 
+    # ---- tiled fallback ----
+    halves = _split_horizontal_halves(deskewed_bytes, deskewed_ct)
+    if not halves:
+        return single  # can't tile — return best single attempt
+    (left_b, left_ct), (right_b, right_ct) = halves
     try:
-        extracted = await _call_groq_vision(annotated_bytes, annotated_ct, strict=True)
-    except json.JSONDecodeError as e:
-        if parse_error is not None:
-            logger.error("Both scan attempts returned non-JSON")
-        raise ValueError(f"Failed to parse vision response: {e}")
+        left_b, left_ct, _ = annotate_circles(left_b, left_ct)
+        right_b, right_ct, _ = annotate_circles(right_b, right_ct)
+        left_raw = await _call_groq_vision(
+            left_b, left_ct, expected_players=expected_players, hole_range=(1, 9)
+        )
+        right_raw = await _call_groq_vision(
+            right_b, right_ct, expected_players=expected_players, hole_range=(10, 18)
+        )
+    except Exception as e:
+        logger.warning("Tiled scan failed (%s); using single-call result", e)
+        return single
 
-    result = _shape_extraction(extracted)
-    result["validation"] = _validate_zero_sum(result["per_hole_quarters"])
-    result["preprocessing"] = preprocessing_diag
-    return result
+    merged_raw = _merge_tile_results(expected_players or [], left_raw, right_raw)
+    tiled = _finalize(merged_raw, "tiled")
+    # Keep whichever attempt is balanced; prefer tiled when both/neither are.
+    if tiled["validation"]["valid"] or not single["validation"]["valid"]:
+        return tiled
+    return single

--- a/backend/app/services/scorecard_scan_service.py
+++ b/backend/app/services/scorecard_scan_service.py
@@ -9,6 +9,7 @@ import base64
 import json
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,29 @@ _GROQ_VISION_MODEL = os.getenv("GROQ_VISION_MODEL", "meta-llama/llama-4-scout-17
 
 # Path to reference scorecard examples for few-shot prompting
 _EXAMPLES_DIR = Path(__file__).parent.parent / "data" / "scorecard_examples"
+
+
+def _norm_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", (name or "").lower())
+
+
+def _expected_players_suffix(expected_players: list[str] | None) -> str:
+    if not expected_players:
+        return ""
+    names = ", ".join(expected_players)
+    return (
+        f"\n\nThe scorers are KNOWN: expect exactly {len(expected_players)} players "
+        f"named: {names}. Use these exact names (one row each). Some players may be "
+        f"written in a lower band below the Par row — include them. Ignore any "
+        f"golf-score rows and handwritten notes; only read the quarter running totals."
+    )
+
+
+def _missing_expected(result: dict, expected_players: list[str] | None) -> list[str]:
+    if not expected_players:
+        return []
+    found = {_norm_name(p.get("name", "")) for p in result.get("players", [])}
+    return [n for n in expected_players if _norm_name(n) not in found]
 
 
 def _load_reference_examples() -> list[tuple[bytes, str, str]]:
@@ -192,6 +216,8 @@ async def _call_groq_vision(
     content_type: str,
     *,
     strict: bool = False,
+    expected_players: list[str] | None = None,
+    hole_range: tuple[int, int] | None = None,
 ) -> dict[str, Any]:
     """One round-trip to Groq Vision. Strict mode tightens the prompt and lowers temp."""
     api_key = os.getenv("GROQ_API_KEY")
@@ -222,6 +248,14 @@ async def _call_groq_vision(
         prompt = "\n\n".join(gt_blocks) + "\n\n---\n\nNow extract the NEW scorecard below:\n" + EXTRACTION_PROMPT
     else:
         prompt = EXTRACTION_PROMPT
+    prompt += _expected_players_suffix(expected_players)
+    if hole_range:
+        lo, hi = hole_range
+        half = "FRONT nine" if lo == 1 else "BACK nine"
+        prompt += (
+            f"\n\nThis image is the {half} only. Read running totals for holes "
+            f"{lo} through {hi} only; do not invent other holes."
+        )
     if strict:
         prompt += _STRICT_SUFFIX
 

--- a/backend/app/services/scorecard_scan_service.py
+++ b/backend/app/services/scorecard_scan_service.py
@@ -431,6 +431,13 @@ async def scan_scorecard(
     if single["validation"]["valid"] and not _missing_expected(single_raw, expected_players):
         return single
 
+    # When no expected players are provided there is nothing to guide the tile
+    # merge — return the single-call result directly so a zero-sum-invalid card
+    # is still shown to the user on the review screen rather than silently
+    # replaced by an empty tiled result.
+    if not expected_players:
+        return single
+
     # ---- tiled fallback ----
     halves = _split_horizontal_halves(deskewed_bytes, deskewed_ct)
     if not halves:

--- a/backend/app/services/scorecard_scan_service.py
+++ b/backend/app/services/scorecard_scan_service.py
@@ -338,6 +338,31 @@ async def _call_groq_vision(
     return json.loads(raw_text)
 
 
+def _merge_tile_results(expected_players: list[str], left_raw: dict, right_raw: dict) -> dict:
+    """Combine left (holes 1-9) and right (holes 10-18) raw extractions into one
+    raw extraction keyed by the player's position in expected_players."""
+    exp_index = {_norm_name(n): i for i, n in enumerate(expected_players)}
+    unified = [{"name": n, "confidence": 1.0} for n in expected_players]
+    merged: list[dict] = []
+    for raw, lo, hi in ((left_raw, 1, 9), (right_raw, 10, 18)):
+        tile_players = raw.get("players", []) if raw else []
+        idx_map: dict[int, int] = {}
+        for ti, tp in enumerate(tile_players):
+            ei = exp_index.get(_norm_name(tp.get("name", "")))
+            if ei is None and ti < len(expected_players):
+                ei = ti  # positional fallback
+            if ei is not None:
+                idx_map[ti] = ei
+        for rt in (raw.get("running_totals", []) if raw else []):
+            if not (lo <= rt.get("hole", 0) <= hi):
+                continue
+            ei = idx_map.get(rt.get("player_index"))
+            if ei is None:
+                continue
+            merged.append({**rt, "player_index": ei})
+    return {"players": unified, "running_totals": merged}
+
+
 def _shape_extraction(extracted: dict[str, Any]) -> dict[str, Any]:
     """Apply circle=negative, group by player, compute per-hole deltas."""
     players = extracted.get("players", [])

--- a/backend/app/services/scorecard_scan_service.py
+++ b/backend/app/services/scorecard_scan_service.py
@@ -353,7 +353,7 @@ def _merge_tile_results(expected_players: list[str], left_raw: dict, right_raw: 
                 ei = ti  # positional fallback
             if ei is not None:
                 idx_map[ti] = ei
-        for rt in (raw.get("running_totals", []) if raw else []):
+        for rt in raw.get("running_totals", []) if raw else []:
             if not (lo <= rt.get("hole", 0) <= hi):
                 continue
             ei = idx_map.get(rt.get("player_index"))
@@ -439,12 +439,8 @@ async def scan_scorecard(
     try:
         left_b, left_ct, _ = annotate_circles(left_b, left_ct)
         right_b, right_ct, _ = annotate_circles(right_b, right_ct)
-        left_raw = await _call_groq_vision(
-            left_b, left_ct, expected_players=expected_players, hole_range=(1, 9)
-        )
-        right_raw = await _call_groq_vision(
-            right_b, right_ct, expected_players=expected_players, hole_range=(10, 18)
-        )
+        left_raw = await _call_groq_vision(left_b, left_ct, expected_players=expected_players, hole_range=(1, 9))
+        right_raw = await _call_groq_vision(right_b, right_ct, expected_players=expected_players, hole_range=(10, 18))
         merged_raw = _merge_tile_results(expected_players or [], left_raw, right_raw)
         tiled = _finalize(merged_raw, "tiled")
     except Exception as e:

--- a/backend/app/services/scorecard_scan_service.py
+++ b/backend/app/services/scorecard_scan_service.py
@@ -211,6 +211,29 @@ def _fit_image_to_budget(
         return image_bytes, content_type
 
 
+def _split_horizontal_halves(
+    image_bytes: bytes, content_type: str
+) -> tuple[tuple[bytes, str], tuple[bytes, str]] | None:
+    """Split an image at width/2 into (left, right) JPEGs. None if unreadable."""
+    try:
+        from io import BytesIO
+
+        from PIL import Image
+
+        img = Image.open(BytesIO(image_bytes)).convert("RGB")
+        w, h = img.size
+        mid = w // 2
+
+        def _enc(box):
+            buf = BytesIO()
+            img.crop(box).save(buf, format="JPEG", quality=85)
+            return buf.getvalue()
+
+        return (_enc((0, 0, mid, h)), "image/jpeg"), (_enc((mid, 0, w, h)), "image/jpeg")
+    except Exception:
+        return None
+
+
 async def _call_groq_vision(
     image_bytes: bytes,
     content_type: str,

--- a/backend/app/services/scorecard_scan_service.py
+++ b/backend/app/services/scorecard_scan_service.py
@@ -445,12 +445,12 @@ async def scan_scorecard(
         right_raw = await _call_groq_vision(
             right_b, right_ct, expected_players=expected_players, hole_range=(10, 18)
         )
+        merged_raw = _merge_tile_results(expected_players or [], left_raw, right_raw)
+        tiled = _finalize(merged_raw, "tiled")
     except Exception as e:
         logger.warning("Tiled scan failed (%s); using single-call result", e)
         return single
 
-    merged_raw = _merge_tile_results(expected_players or [], left_raw, right_raw)
-    tiled = _finalize(merged_raw, "tiled")
     # Keep whichever attempt is balanced; prefer tiled when both/neither are.
     if tiled["validation"]["valid"] or not single["validation"]["valid"]:
         return tiled

--- a/backend/tests/live/test_scorecard_accuracy_live.py
+++ b/backend/tests/live/test_scorecard_accuracy_live.py
@@ -27,8 +27,9 @@ _IMAGE = _DATA / "scorecard_5man_001.jpeg"
 _GROUND_TRUTH = _DATA / "scorecard_5man_001_ground_truth.json"
 
 # Conservative front-nine cell-accuracy floor for this hard, low-res 5-man card.
-# Tighten once real numbers are observed; the printed diff is the primary value.
-_ACCURACY_FLOOR = 0.5
+# Raised to 0.7 after tiled scanning — tiling should clear it; adjust down only
+# with comment if real numbers say otherwise. The printed diff is the primary value.
+_ACCURACY_FLOOR = 0.7
 
 
 def _norm(name: str) -> str:
@@ -45,10 +46,15 @@ def test_scorecard_scan_front_nine_accuracy():
     ground_truth = json.loads(_GROUND_TRUTH.read_text())
     image_bytes = _IMAGE.read_bytes()
 
-    result = asyncio.run(scan_scorecard(image_bytes, "image/jpeg"))
+    expected = [p["name"] for p in ground_truth["players"]]  # CK, SS, KG, BH, SG
+    result = asyncio.run(scan_scorecard(image_bytes, "image/jpeg", expected_players=expected))
 
     scan_names = {i: _norm(p.get("name", "")) for i, p in enumerate(result.get("players", []))}
     scan_signed = {(e["player_index"], e["hole"]): _signed(e) for e in result.get("running_totals", [])}
+
+    # All five players must now be found (tiled scan should pick up all, including SG)
+    found = {_norm(p.get("name", "")) for p in result.get("players", [])}
+    assert all(_norm(n) in found for n in expected), f"missing players; method={result.get('method')}"
 
     gt_names = {i: _norm(p["name"]) for i, p in enumerate(ground_truth["players"])}
     gt_signed = {(e["player_index"], e["hole"]): _signed(e) for e in ground_truth["running_totals"]}

--- a/backend/tests/unit/routers/test_scorecard_router.py
+++ b/backend/tests/unit/routers/test_scorecard_router.py
@@ -155,3 +155,25 @@ class TestScanScorecard:
             files={"file": ("card.jpg", image_data, "image/jpeg")},
         )
         assert resp.json() == expected
+
+
+# ── players form field ─────────────────────────────────────────────────────
+
+
+def test_scan_passes_players_to_service(monkeypatch):
+    import app.services.scorecard_scan_service as svc_mod
+
+    captured = {}
+
+    async def fake_scan(image_bytes, content_type, expected_players=None):
+        captured["players"] = expected_players
+        return {"players": [], "running_totals": [], "per_hole_quarters": [], "validation": {"valid": True}}
+
+    monkeypatch.setattr(svc_mod, "scan_scorecard", fake_scan)
+    resp = client.post(
+        "/scorecard/scan",
+        files={"file": ("c.png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 64, "image/png")},
+        data={"players": '["CK","SS","SG"]'},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["players"] == ["CK", "SS", "SG"]

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -372,7 +372,7 @@ class TestScanScorecardCallsPreprocessing:
             assert image_bytes == b"GRID_CROPPED", "annotate must receive grid-cropped bytes"
             return b"ANNOTATED", "image/jpeg", {"preprocessing_applied": True, "circles_detected": 7}
 
-        async def fake_call_groq(image_bytes, content_type, *, strict=False):
+        async def fake_call_groq(image_bytes, content_type, *, strict=False, expected_players=None, hole_range=None):
             assert image_bytes == b"ANNOTATED", "vision must receive annotated bytes"
             return {
                 "players": [{"name": "P1", "confidence": 1.0}, {"name": "P2", "confidence": 1.0}],
@@ -490,6 +490,65 @@ class TestGuidedPlayers:
         # CK matches "C.K." normalized; SG is absent
         assert _missing_expected(result, ["CK", "SS", "SG"]) == ["SG"]
         assert _missing_expected(result, None) == []
+
+
+class TestAdaptiveScan:
+    def _valid_raw(self, players, holes_per_player):
+        # players: list[str]; holes_per_player: dict[name]-> {hole: (value, circled)}
+        pls = [{"name": n, "confidence": 1.0} for n in players]
+        rts = []
+        for i, n in enumerate(players):
+            for h, (v, c) in holes_per_player[n].items():
+                rts.append({"player_index": i, "hole": h, "value": v, "is_circled": c, "confidence": 1.0})
+        return {"players": pls, "running_totals": rts}
+
+    def test_valid_single_call_does_not_tile(self, monkeypatch):
+        import app.services.scorecard_scan_service as svc
+
+        # zero-sum balanced 2-player single result for all 18 holes
+        single = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(1, 19)}, "B": {h: (2, True) for h in range(1, 19)}},
+        )
+        calls = {"n": 0}
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            calls["n"] += 1
+            return single
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
+        assert result["method"] == "single"
+        assert calls["n"] == 1  # no tiling
+
+    def test_missing_player_triggers_tiling(self, monkeypatch):
+        import app.services.scorecard_scan_service as svc
+
+        single = self._valid_raw(  # only 1 of 2 expected players -> missing -> tile
+            ["A"], {"A": {h: (0, False) for h in range(1, 19)}}
+        )
+        left = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(1, 10)}, "B": {h: (2, True) for h in range(1, 10)}},
+        )
+        right = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(10, 19)}, "B": {h: (2, True) for h in range(10, 19)}},
+        )
+        seq = [single, left, right]
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            return seq.pop(0)
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(
+            svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg"))
+        )
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
+        assert result["method"] == "tiled"
+        assert {p["name"] for p in result["players"]} == {"A", "B"}
+        assert result["validation"]["valid"] is True
 
 
 class TestMergeTiles:

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -626,6 +626,28 @@ class TestAdaptiveScan:
         assert result["method"] == "single"
         assert result["validation"]["valid"] is True
 
+    def test_tiled_merge_exception_falls_back_to_single(self, monkeypatch):
+        import app.services.scorecard_scan_service as svc
+
+        # single is zero-sum invalid (both players +2 every hole) -> triggers tiling
+        single = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(1, 19)}, "B": {h: (2, False) for h in range(1, 19)}},
+        )
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            return single
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "crop_to_grid", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "annotate_circles", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg")))
+        monkeypatch.setattr(svc, "_merge_tile_results", lambda *a: (_ for _ in ()).throw(KeyError("bad")))
+
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
+        assert result["method"] == "single"  # fell back, did not raise
+
 
 class TestMergeTiles:
     def test_merges_left_front_right_back_by_name(self):

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -542,9 +542,7 @@ class TestAdaptiveScan:
 
         monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
         monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
-        monkeypatch.setattr(
-            svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg"))
-        )
+        monkeypatch.setattr(svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg")))
         result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
         assert result["method"] == "tiled"
         assert {p["name"] for p in result["players"]} == {"A", "B"}
@@ -581,9 +579,7 @@ class TestAdaptiveScan:
         monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
         monkeypatch.setattr(svc, "crop_to_grid", lambda b, ct: (b, ct, {}))
         monkeypatch.setattr(svc, "annotate_circles", lambda b, ct: (b, ct, {}))
-        monkeypatch.setattr(
-            svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg"))
-        )
+        monkeypatch.setattr(svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg")))
 
         result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
         assert result["method"] == "tiled"
@@ -596,9 +592,7 @@ class TestAdaptiveScan:
 
         # Single: only player A present → missing B → triggers tiling.
         # But single itself is valid (zero-sum for a 1-player degenerate case).
-        single = self._valid_raw(
-            ["A"], {"A": {h: (0, False) for h in range(1, 19)}}
-        )
+        single = self._valid_raw(["A"], {"A": {h: (0, False) for h in range(1, 19)}})
         # Tile halves: both A and B are positive every hole → merged not zero-sum.
         left_unbalanced = self._valid_raw(
             ["A", "B"],
@@ -617,9 +611,7 @@ class TestAdaptiveScan:
         monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
         monkeypatch.setattr(svc, "crop_to_grid", lambda b, ct: (b, ct, {}))
         monkeypatch.setattr(svc, "annotate_circles", lambda b, ct: (b, ct, {}))
-        monkeypatch.setattr(
-            svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg"))
-        )
+        monkeypatch.setattr(svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg")))
 
         result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
         # single is valid (zero-sum), tiled is not → keep single

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -618,6 +618,31 @@ class TestAdaptiveScan:
         assert result["method"] == "single"
         assert result["validation"]["valid"] is True
 
+    def test_no_expected_players_zero_sum_invalid_returns_single_not_empty(self, monkeypatch):
+        """When expected_players is None and the single call is zero-sum invalid,
+        the service must return that single result (non-empty) rather than
+        silently discarding it by running _merge_tile_results([], ...) which
+        produces an empty players list."""
+        import app.services.scorecard_scan_service as svc
+
+        # Both players +2 every hole → zero-sum invalid (per-hole sum = +4, not 0).
+        both_up = dict.fromkeys(range(1, 19), (2, False))
+        single = self._valid_raw(["A", "B"], {"A": both_up, "B": both_up})
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            return single
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "crop_to_grid", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "annotate_circles", lambda b, ct: (b, ct, {}))
+
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=None))
+        assert result["method"] == "single", "single-call result must be returned, not a tiled empty"
+        assert result["players"], "players must not be empty — single result was discarded"
+        assert result["running_totals"], "running_totals must not be empty — single result was discarded"
+        assert result["validation"]["valid"] is False, "zero-sum violation should still be reported"
+
     def test_tiled_merge_exception_falls_back_to_single(self, monkeypatch):
         import app.services.scorecard_scan_service as svc
 

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -508,7 +508,7 @@ class TestAdaptiveScan:
         # zero-sum balanced 2-player single result for all 18 holes
         single = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(1, 19)}, "B": {h: (2, True) for h in range(1, 19)}},
+            {"A": dict.fromkeys(range(1, 19), (2, False)), "B": dict.fromkeys(range(1, 19), (2, True))},
         )
         calls = {"n": 0}
 
@@ -525,15 +525,15 @@ class TestAdaptiveScan:
         import app.services.scorecard_scan_service as svc
 
         single = self._valid_raw(  # only 1 of 2 expected players -> missing -> tile
-            ["A"], {"A": {h: (0, False) for h in range(1, 19)}}
+            ["A"], {"A": dict.fromkeys(range(1, 19), (0, False))}
         )
         left = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(1, 10)}, "B": {h: (2, True) for h in range(1, 10)}},
+            {"A": dict.fromkeys(range(1, 10), (2, False)), "B": dict.fromkeys(range(1, 10), (2, True))},
         )
         right = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(10, 19)}, "B": {h: (2, True) for h in range(10, 19)}},
+            {"A": dict.fromkeys(range(10, 19), (2, False)), "B": dict.fromkeys(range(10, 19), (2, True))},
         )
         seq = [single, left, right]
 
@@ -557,18 +557,18 @@ class TestAdaptiveScan:
         single = self._valid_raw(
             ["A", "B"],
             {
-                "A": {h: (2, False) for h in range(1, 19)},
-                "B": {h: (2, False) for h in range(1, 19)},  # both positive → zero-sum broken
+                "A": dict.fromkeys(range(1, 19), (2, False)),
+                "B": dict.fromkeys(range(1, 19), (2, False)),  # both positive → zero-sum broken
             },
         )
         # Tiled halves: A is +2, B is -2 per hole → balanced.
         left = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(1, 10)}, "B": {h: (2, True) for h in range(1, 10)}},
+            {"A": dict.fromkeys(range(1, 10), (2, False)), "B": dict.fromkeys(range(1, 10), (2, True))},
         )
         right = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(10, 19)}, "B": {h: (2, True) for h in range(10, 19)}},
+            {"A": dict.fromkeys(range(10, 19), (2, False)), "B": dict.fromkeys(range(10, 19), (2, True))},
         )
         seq = [single, left, right]
 
@@ -592,15 +592,15 @@ class TestAdaptiveScan:
 
         # Single: only player A present → missing B → triggers tiling.
         # But single itself is valid (zero-sum for a 1-player degenerate case).
-        single = self._valid_raw(["A"], {"A": {h: (0, False) for h in range(1, 19)}})
+        single = self._valid_raw(["A"], {"A": dict.fromkeys(range(1, 19), (0, False))})
         # Tile halves: both A and B are positive every hole → merged not zero-sum.
         left_unbalanced = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(1, 10)}, "B": {h: (2, False) for h in range(1, 10)}},
+            {"A": dict.fromkeys(range(1, 10), (2, False)), "B": dict.fromkeys(range(1, 10), (2, False))},
         )
         right_unbalanced = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(10, 19)}, "B": {h: (2, False) for h in range(10, 19)}},
+            {"A": dict.fromkeys(range(10, 19), (2, False)), "B": dict.fromkeys(range(10, 19), (2, False))},
         )
         seq = [single, left_unbalanced, right_unbalanced]
 
@@ -649,7 +649,7 @@ class TestAdaptiveScan:
         # single is zero-sum invalid (both players +2 every hole) -> triggers tiling
         single = self._valid_raw(
             ["A", "B"],
-            {"A": {h: (2, False) for h in range(1, 19)}, "B": {h: (2, False) for h in range(1, 19)}},
+            {"A": dict.fromkeys(range(1, 19), (2, False)), "B": dict.fromkeys(range(1, 19), (2, False))},
         )
 
         async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -550,6 +550,82 @@ class TestAdaptiveScan:
         assert {p["name"] for p in result["players"]} == {"A", "B"}
         assert result["validation"]["valid"] is True
 
+    def test_zero_sum_invalid_single_triggers_tiling(self, monkeypatch):
+        """If the single result is NOT zero-sum balanced, tiling is triggered and
+        a valid tiled result is returned."""
+        import app.services.scorecard_scan_service as svc
+
+        # Single: both players +2 every hole → per-hole sum is +4 (not 0), invalid.
+        single = self._valid_raw(
+            ["A", "B"],
+            {
+                "A": {h: (2, False) for h in range(1, 19)},
+                "B": {h: (2, False) for h in range(1, 19)},  # both positive → zero-sum broken
+            },
+        )
+        # Tiled halves: A is +2, B is -2 per hole → balanced.
+        left = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(1, 10)}, "B": {h: (2, True) for h in range(1, 10)}},
+        )
+        right = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(10, 19)}, "B": {h: (2, True) for h in range(10, 19)}},
+        )
+        seq = [single, left, right]
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            return seq.pop(0)
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "crop_to_grid", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "annotate_circles", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(
+            svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg"))
+        )
+
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
+        assert result["method"] == "tiled"
+        assert result["validation"]["valid"] is True
+
+    def test_single_valid_tiled_invalid_keeps_single(self, monkeypatch):
+        """When single is valid+complete BUT tiling is triggered (missing player) and
+        the merged tile result is NOT balanced, the function returns the single result."""
+        import app.services.scorecard_scan_service as svc
+
+        # Single: only player A present → missing B → triggers tiling.
+        # But single itself is valid (zero-sum for a 1-player degenerate case).
+        single = self._valid_raw(
+            ["A"], {"A": {h: (0, False) for h in range(1, 19)}}
+        )
+        # Tile halves: both A and B are positive every hole → merged not zero-sum.
+        left_unbalanced = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(1, 10)}, "B": {h: (2, False) for h in range(1, 10)}},
+        )
+        right_unbalanced = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(10, 19)}, "B": {h: (2, False) for h in range(10, 19)}},
+        )
+        seq = [single, left_unbalanced, right_unbalanced]
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            return seq.pop(0)
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "crop_to_grid", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(svc, "annotate_circles", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(
+            svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg"))
+        )
+
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
+        # single is valid (zero-sum), tiled is not → keep single
+        assert result["method"] == "single"
+        assert result["validation"]["valid"] is True
+
 
 class TestMergeTiles:
     def test_merges_left_front_right_back_by_name(self):

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -440,3 +440,21 @@ class TestFitImageToBudget:
         out, ct = _fit_image_to_budget(b"not an image", "image/jpeg", max_dim=4096, max_b64_chars=10)
         assert out == b"not an image"
         assert ct == "image/jpeg"
+
+
+class TestGuidedPlayers:
+    def test_suffix_names_players(self):
+        from app.services.scorecard_scan_service import _expected_players_suffix
+
+        s = _expected_players_suffix(["CK", "SS", "SG"])
+        assert "CK" in s and "SS" in s and "SG" in s
+        assert "exactly 3" in s
+        assert _expected_players_suffix(None) == ""
+
+    def test_missing_expected_normalized(self):
+        from app.services.scorecard_scan_service import _missing_expected
+
+        result = {"players": [{"name": "C.K."}, {"name": "ss"}]}
+        # CK matches "C.K." normalized; SG is absent
+        assert _missing_expected(result, ["CK", "SS", "SG"]) == ["SG"]
+        assert _missing_expected(result, None) == []

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -442,6 +442,38 @@ class TestFitImageToBudget:
         assert ct == "image/jpeg"
 
 
+class TestSplitHalves:
+    @staticmethod
+    def _jpeg(w, h):
+        from io import BytesIO
+
+        from PIL import Image
+
+        buf = BytesIO()
+        Image.new("RGB", (w, h), "white").save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def test_splits_into_two_halves(self):
+        from io import BytesIO
+
+        from PIL import Image
+
+        from app.services.scorecard_scan_service import _split_horizontal_halves
+
+        out = _split_horizontal_halves(self._jpeg(2000, 1000), "image/jpeg")
+        assert out is not None
+        (left_b, left_ct), (right_b, right_ct) = out
+        lw = Image.open(BytesIO(left_b)).size[0]
+        rw = Image.open(BytesIO(right_b)).size[0]
+        assert 950 <= lw <= 1050 and 950 <= rw <= 1050  # ~half of 2000
+        assert left_ct == "image/jpeg" and right_ct == "image/jpeg"
+
+    def test_returns_none_on_non_image(self):
+        from app.services.scorecard_scan_service import _split_horizontal_halves
+
+        assert _split_horizontal_halves(b"nope", "image/jpeg") is None
+
+
 class TestGuidedPlayers:
     def test_suffix_names_players(self):
         from app.services.scorecard_scan_service import _expected_players_suffix

--- a/backend/tests/unit/services/test_scorecard_scan_service.py
+++ b/backend/tests/unit/services/test_scorecard_scan_service.py
@@ -490,3 +490,31 @@ class TestGuidedPlayers:
         # CK matches "C.K." normalized; SG is absent
         assert _missing_expected(result, ["CK", "SS", "SG"]) == ["SG"]
         assert _missing_expected(result, None) == []
+
+
+class TestMergeTiles:
+    def test_merges_left_front_right_back_by_name(self):
+        from app.services.scorecard_scan_service import _merge_tile_results
+
+        left = {
+            "players": [{"name": "SS"}, {"name": "CK"}],  # note: different order than expected
+            "running_totals": [
+                {"player_index": 0, "hole": 1, "value": 4, "is_circled": False, "confidence": 1.0},
+                {"player_index": 1, "hole": 1, "value": 6, "is_circled": False, "confidence": 1.0},
+                {"player_index": 0, "hole": 99, "value": 0, "is_circled": False},  # out of range -> dropped
+            ],
+        }
+        right = {
+            "players": [{"name": "CK"}, {"name": "SS"}],
+            "running_totals": [
+                {"player_index": 0, "hole": 10, "value": 130, "is_circled": True, "confidence": 1.0},
+                {"player_index": 1, "hole": 10, "value": 70, "is_circled": False, "confidence": 1.0},
+            ],
+        }
+        merged = _merge_tile_results(["CK", "SS"], left, right)
+        assert [p["name"] for p in merged["players"]] == ["CK", "SS"]
+        # CK is expected index 0
+        ck = [r for r in merged["running_totals"] if r["player_index"] == 0]
+        assert {(r["hole"], r["value"]) for r in ck} == {(1, 6), (10, 130)}
+        ss = [r for r in merged["running_totals"] if r["player_index"] == 1]
+        assert {(r["hole"], r["value"]) for r in ss} == {(1, 4), (10, 70)}

--- a/docs/superpowers/plans/2026-06-19-tiled-scorecard-scan.md
+++ b/docs/superpowers/plans/2026-06-19-tiled-scorecard-scan.md
@@ -1,0 +1,745 @@
+# Tiled Adaptive Scorecard Scanning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the scorecard scanner reliably read dense multi-man phone cards by guiding it with pre-picked roster players and falling back to a tiled (left/right half) per-region scan when a cheap single call fails.
+
+**Architecture:** `scan_scorecard` gains an optional `expected_players` list. It tries one guided whole-card call; if the result fails zero-sum OR is missing an expected player, it deskews and splits the card into left (holes 1–9) and right (holes 10–18) halves, scans each guided by the player list, and merges by player. The endpoint accepts a `players` form field; the frontend pre-picks players from the roster before capture.
+
+**Tech Stack:** FastAPI + Pillow (backend), Groq Vision (existing), React + Vitest (frontend).
+
+## Global Constraints
+
+- Players per round: 4, 5, or 6.
+- Preprocessing/working image is capped at 2048px longest side (`_PREPROCESS_MAX_DIM`); never feed full-res phone pics to the OpenCV preprocessing.
+- Tiling adds at most 2 Groq calls (total 3 on a hard card). Single-call stays the happy path.
+- `is_circled` ⇒ negative; per-hole deltas must sum to zero across players (`_validate_zero_sum`).
+- Each tile/step degrades gracefully — a failed tile or non-image bytes must never raise out of `scan_scorecard`; fall back to the single-call result.
+- Pre-push gate: `frontend: npm run typecheck && npx vitest run && npm run build`; `backend: venv/bin/python -m ruff check app/ tests/ && venv/bin/python -m ruff format --check app/ tests/ && venv/bin/python -m pytest tests/ --ignore=tests/manual --ignore=tests/_diagnostic`.
+
+---
+
+## File Structure
+
+**Backend**
+- Modify `backend/app/services/scorecard_scan_service.py` — guided prompt, expected-player check, `_split_horizontal_halves`, `_merge_tile_results`, adaptive orchestration in `scan_scorecard`, `method` in result.
+- Modify `backend/app/routers/scorecard.py` — optional `players` form field → `expected_players`.
+- Modify `backend/tests/unit/services/test_scorecard_scan_service.py` — unit tests for the new helpers + adaptive flow.
+- Modify `backend/tests/live/test_scorecard_accuracy_live.py` — pass known players, assert tiled improvement.
+
+**Frontend**
+- Modify `frontend/src/pages/ScorecardScanPage.jsx` — pre-pick players step (new-round mode).
+- Modify `frontend/src/components/game/ScorecardPhoto.jsx` — send `players` to `/scorecard/scan`; accept `pickedPlayers`.
+- Modify `frontend/src/components/game/ScorecardReview.jsx` — when players are known, render fixed rows (no mapping dropdowns).
+- Create `frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx`.
+
+---
+
+## Task 1: Guided prompt + expected-player completeness check
+
+**Files:**
+- Modify: `backend/app/services/scorecard_scan_service.py`
+- Test: `backend/tests/unit/services/test_scorecard_scan_service.py`
+
+**Interfaces:**
+- Produces:
+  - `_expected_players_suffix(expected_players: list[str] | None) -> str` — prompt text naming the exact players, or `""`.
+  - `_missing_expected(result: dict, expected_players: list[str] | None) -> list[str]` — expected names not present in `result["players"]` (normalized match); `[]` when none expected.
+  - `_call_groq_vision(..., expected_players=None, hole_range=None)` gains two kwargs (used in later tasks); when given, the prompt is prefixed with the suffix and (if `hole_range`) the hole instruction.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to backend/tests/unit/services/test_scorecard_scan_service.py
+class TestGuidedPlayers:
+    def test_suffix_names_players(self):
+        from app.services.scorecard_scan_service import _expected_players_suffix
+
+        s = _expected_players_suffix(["CK", "SS", "SG"])
+        assert "CK" in s and "SS" in s and "SG" in s
+        assert "exactly 3" in s
+        assert _expected_players_suffix(None) == ""
+
+    def test_missing_expected_normalized(self):
+        from app.services.scorecard_scan_service import _missing_expected
+
+        result = {"players": [{"name": "C.K."}, {"name": "ss"}]}
+        # CK matches "C.K." normalized; SG is absent
+        assert _missing_expected(result, ["CK", "SS", "SG"]) == ["SG"]
+        assert _missing_expected(result, None) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py::TestGuidedPlayers -v`
+Expected: FAIL with ImportError (functions not defined).
+
+- [ ] **Step 3: Implement the helpers**
+
+Add near the top of `scorecard_scan_service.py` (after the existing imports add `import re` if missing):
+
+```python
+import re  # if not already imported
+
+
+def _norm_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", (name or "").lower())
+
+
+def _expected_players_suffix(expected_players: list[str] | None) -> str:
+    if not expected_players:
+        return ""
+    names = ", ".join(expected_players)
+    return (
+        f"\n\nThe scorers are KNOWN: expect exactly {len(expected_players)} players "
+        f"named: {names}. Use these exact names (one row each). Some players may be "
+        f"written in a lower band below the Par row — include them. Ignore any "
+        f"golf-score rows and handwritten notes; only read the quarter running totals."
+    )
+
+
+def _missing_expected(result: dict, expected_players: list[str] | None) -> list[str]:
+    if not expected_players:
+        return []
+    found = {_norm_name(p.get("name", "")) for p in result.get("players", [])}
+    return [n for n in expected_players if _norm_name(n) not in found]
+```
+
+Then thread the kwargs into `_call_groq_vision`. Change its signature to:
+
+```python
+async def _call_groq_vision(
+    image_bytes: bytes,
+    content_type: str,
+    *,
+    strict: bool = False,
+    expected_players: list[str] | None = None,
+    hole_range: tuple[int, int] | None = None,
+) -> dict[str, Any]:
+```
+
+Inside, right after `prompt` is built (the `if references: ... else: prompt = EXTRACTION_PROMPT` block) and before `if strict:`, insert:
+
+```python
+    prompt += _expected_players_suffix(expected_players)
+    if hole_range:
+        lo, hi = hole_range
+        half = "FRONT nine" if lo == 1 else "BACK nine"
+        prompt += (
+            f"\n\nThis image is the {half} only. Read running totals for holes "
+            f"{lo} through {hi} only; do not invent other holes."
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py::TestGuidedPlayers -v`
+Expected: PASS
+
+- [ ] **Step 5: Verify existing scan tests still pass (signature change)**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py -q`
+Expected: PASS (the new kwargs are optional; existing callers unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/scorecard_scan_service.py backend/tests/unit/services/test_scorecard_scan_service.py
+git commit -m "feat(scorecard): guided prompt + expected-player completeness check"
+```
+
+---
+
+## Task 2: Horizontal split helper
+
+**Files:**
+- Modify: `backend/app/services/scorecard_scan_service.py`
+- Test: `backend/tests/unit/services/test_scorecard_scan_service.py`
+
+**Interfaces:**
+- Produces: `_split_horizontal_halves(image_bytes: bytes, content_type: str) -> tuple[tuple[bytes, str], tuple[bytes, str]] | None` — returns `((left_bytes,"image/jpeg"), (right_bytes,"image/jpeg"))` split at width/2, or `None` if the image can't be read (caller falls back).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestSplitHalves:
+    @staticmethod
+    def _jpeg(w, h):
+        from io import BytesIO
+
+        from PIL import Image
+
+        buf = BytesIO()
+        Image.new("RGB", (w, h), "white").save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def test_splits_into_two_halves(self):
+        from io import BytesIO
+
+        from PIL import Image
+
+        from app.services.scorecard_scan_service import _split_horizontal_halves
+
+        out = _split_horizontal_halves(self._jpeg(2000, 1000), "image/jpeg")
+        assert out is not None
+        (left_b, left_ct), (right_b, right_ct) = out
+        lw = Image.open(BytesIO(left_b)).size[0]
+        rw = Image.open(BytesIO(right_b)).size[0]
+        assert 950 <= lw <= 1050 and 950 <= rw <= 1050  # ~half of 2000
+        assert left_ct == "image/jpeg" and right_ct == "image/jpeg"
+
+    def test_returns_none_on_non_image(self):
+        from app.services.scorecard_scan_service import _split_horizontal_halves
+
+        assert _split_horizontal_halves(b"nope", "image/jpeg") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py::TestSplitHalves -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _split_horizontal_halves(
+    image_bytes: bytes, content_type: str
+) -> tuple[tuple[bytes, str], tuple[bytes, str]] | None:
+    """Split an image at width/2 into (left, right) JPEGs. None if unreadable."""
+    try:
+        from io import BytesIO
+
+        from PIL import Image
+
+        img = Image.open(BytesIO(image_bytes)).convert("RGB")
+        w, h = img.size
+        mid = w // 2
+
+        def _enc(box):
+            buf = BytesIO()
+            img.crop(box).save(buf, format="JPEG", quality=85)
+            return buf.getvalue()
+
+        return (_enc((0, 0, mid, h)), "image/jpeg"), (_enc((mid, 0, w, h)), "image/jpeg")
+    except Exception:
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py::TestSplitHalves -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/scorecard_scan_service.py backend/tests/unit/services/test_scorecard_scan_service.py
+git commit -m "feat(scorecard): horizontal split helper for tiled scanning"
+```
+
+---
+
+## Task 3: Merge two tile results by player
+
+**Files:**
+- Modify: `backend/app/services/scorecard_scan_service.py`
+- Test: `backend/tests/unit/services/test_scorecard_scan_service.py`
+
+**Interfaces:**
+- Consumes: `_norm_name` (Task 1).
+- Produces: `_merge_tile_results(expected_players: list[str], left_raw: dict, right_raw: dict) -> dict` — returns a RAW extraction `{"players":[{"name","confidence"}], "running_totals":[...]}` with `player_index` remapped to the position of each player in `expected_players`, left contributing holes 1–9 and right holes 10–18. Caller runs `_shape_extraction` on it.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestMergeTiles:
+    def test_merges_left_front_right_back_by_name(self):
+        from app.services.scorecard_scan_service import _merge_tile_results
+
+        left = {
+            "players": [{"name": "SS"}, {"name": "CK"}],  # note: different order than expected
+            "running_totals": [
+                {"player_index": 0, "hole": 1, "value": 4, "is_circled": False, "confidence": 1.0},
+                {"player_index": 1, "hole": 1, "value": 6, "is_circled": False, "confidence": 1.0},
+                {"player_index": 0, "hole": 99, "value": 0, "is_circled": False},  # out of range -> dropped
+            ],
+        }
+        right = {
+            "players": [{"name": "CK"}, {"name": "SS"}],
+            "running_totals": [
+                {"player_index": 0, "hole": 10, "value": 130, "is_circled": True, "confidence": 1.0},
+                {"player_index": 1, "hole": 10, "value": 70, "is_circled": False, "confidence": 1.0},
+            ],
+        }
+        merged = _merge_tile_results(["CK", "SS"], left, right)
+        assert [p["name"] for p in merged["players"]] == ["CK", "SS"]
+        # CK is expected index 0
+        ck = [r for r in merged["running_totals"] if r["player_index"] == 0]
+        assert {(r["hole"], r["value"]) for r in ck} == {(1, 6), (10, 130)}
+        ss = [r for r in merged["running_totals"] if r["player_index"] == 1]
+        assert {(r["hole"], r["value"]) for r in ss} == {(1, 4), (10, 70)}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py::TestMergeTiles -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _merge_tile_results(expected_players: list[str], left_raw: dict, right_raw: dict) -> dict:
+    """Combine left (holes 1-9) and right (holes 10-18) raw extractions into one
+    raw extraction keyed by the player's position in expected_players."""
+    exp_index = {_norm_name(n): i for i, n in enumerate(expected_players)}
+    unified = [{"name": n, "confidence": 1.0} for n in expected_players]
+    merged: list[dict] = []
+    for raw, lo, hi in ((left_raw, 1, 9), (right_raw, 10, 18)):
+        tile_players = raw.get("players", []) if raw else []
+        idx_map: dict[int, int] = {}
+        for ti, tp in enumerate(tile_players):
+            ei = exp_index.get(_norm_name(tp.get("name", "")))
+            if ei is None and ti < len(expected_players):
+                ei = ti  # positional fallback
+            if ei is not None:
+                idx_map[ti] = ei
+        for rt in (raw.get("running_totals", []) if raw else []):
+            if not (lo <= rt.get("hole", 0) <= hi):
+                continue
+            ei = idx_map.get(rt.get("player_index"))
+            if ei is None:
+                continue
+            merged.append({**rt, "player_index": ei})
+    return {"players": unified, "running_totals": merged}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py::TestMergeTiles -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/scorecard_scan_service.py backend/tests/unit/services/test_scorecard_scan_service.py
+git commit -m "feat(scorecard): merge left/right tile results by player"
+```
+
+---
+
+## Task 4: Adaptive orchestration in `scan_scorecard`
+
+**Files:**
+- Modify: `backend/app/services/scorecard_scan_service.py` (`scan_scorecard`)
+- Test: `backend/tests/unit/services/test_scorecard_scan_service.py`
+
+**Interfaces:**
+- Consumes: `_call_groq_vision(..., expected_players, hole_range)`, `_split_horizontal_halves`, `_merge_tile_results`, `_missing_expected`, existing `_shape_extraction`, `_validate_zero_sum`, `deskew_to_card`.
+- Produces: `scan_scorecard(image_bytes, content_type, expected_players: list[str] | None = None) -> dict` — same result dict plus `result["method"]` ∈ {`"single"`, `"tiled"`}.
+
+**Behavior:** run the existing single-call pipeline guided by `expected_players`. If the single result is valid (zero-sum AND no missing expected players) → return it with `method="single"`. Otherwise deskew the working-size image, split into halves, call each guided (`expected_players`, `hole_range`), merge, shape, validate → return with `method="tiled"`. If splitting/merging can't run, return the single result (graceful).
+
+- [ ] **Step 1: Write the failing test (mock `_call_groq_vision` per call)**
+
+```python
+class TestAdaptiveScan:
+    def _valid_raw(self, players, holes_per_player):
+        # players: list[str]; holes_per_player: dict[name]-> {hole: (value, circled)}
+        pls = [{"name": n, "confidence": 1.0} for n in players]
+        rts = []
+        for i, n in enumerate(players):
+            for h, (v, c) in holes_per_player[n].items():
+                rts.append({"player_index": i, "hole": h, "value": v, "is_circled": c, "confidence": 1.0})
+        return {"players": pls, "running_totals": rts}
+
+    def test_valid_single_call_does_not_tile(self, monkeypatch):
+        import app.services.scorecard_scan_service as svc
+
+        # zero-sum balanced 2-player single result for all 18 holes
+        single = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(1, 19)}, "B": {h: (2, True) for h in range(1, 19)}},
+        )
+        calls = {"n": 0}
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            calls["n"] += 1
+            return single
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
+        assert result["method"] == "single"
+        assert calls["n"] == 1  # no tiling
+
+    def test_missing_player_triggers_tiling(self, monkeypatch):
+        import app.services.scorecard_scan_service as svc
+
+        single = self._valid_raw(  # only 1 of 2 expected players -> missing -> tile
+            ["A"], {"A": {h: (0, False) for h in range(1, 19)}}
+        )
+        left = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(1, 10)}, "B": {h: (2, True) for h in range(1, 10)}},
+        )
+        right = self._valid_raw(
+            ["A", "B"],
+            {"A": {h: (2, False) for h in range(10, 19)}, "B": {h: (2, True) for h in range(10, 19)}},
+        )
+        seq = [single, left, right]
+
+        async def fake_call(image_bytes, ct, *, strict=False, expected_players=None, hole_range=None):
+            return seq.pop(0)
+
+        monkeypatch.setattr(svc, "_call_groq_vision", fake_call)
+        monkeypatch.setattr(svc, "deskew_to_card", lambda b, ct: (b, ct, {}))
+        monkeypatch.setattr(
+            svc, "_split_horizontal_halves", lambda b, ct: ((b, "image/jpeg"), (b, "image/jpeg"))
+        )
+        result = asyncio.run(svc.scan_scorecard(b"img", "image/jpeg", expected_players=["A", "B"]))
+        assert result["method"] == "tiled"
+        assert {p["name"] for p in result["players"]} == {"A", "B"}
+        assert result["validation"]["valid"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py::TestAdaptiveScan -v`
+Expected: FAIL (`scan_scorecard` has no `expected_players` / no `method`).
+
+- [ ] **Step 3: Rewrite `scan_scorecard`**
+
+Replace the body of `scan_scorecard` (keep the preprocessing-cap line from the current code) with:
+
+```python
+async def scan_scorecard(
+    image_bytes: bytes, content_type: str, expected_players: list[str] | None = None
+) -> dict[str, Any]:
+    """Single guided Groq call; if it fails zero-sum or is missing an expected
+    player, fall back to a tiled (left=holes 1-9 / right=holes 10-18) scan and
+    merge by player. Returns the usual shape plus result["method"]."""
+    # Cap working size before the (full-res) CV preprocessing — see _PREPROCESS_MAX_DIM.
+    image_bytes, content_type = _fit_image_to_budget(
+        image_bytes, content_type, max_dim=_PREPROCESS_MAX_DIM, max_b64_chars=10**12
+    )
+    deskewed_bytes, deskewed_ct, deskew_diag = deskew_to_card(image_bytes, content_type)
+    cropped_bytes, cropped_ct, grid_diag = crop_to_grid(deskewed_bytes, deskewed_ct)
+    annotated_bytes, annotated_ct, circle_diag = annotate_circles(cropped_bytes, cropped_ct)
+    preprocessing_diag = {"deskew": deskew_diag, "grid_crop": grid_diag, "circles": circle_diag}
+
+    def _finalize(raw: dict, method: str) -> dict:
+        out = _shape_extraction(raw)
+        out["validation"] = _validate_zero_sum(out["per_hole_quarters"])
+        out["preprocessing"] = preprocessing_diag
+        out["method"] = method
+        return out
+
+    # ---- single guided attempt (with one strict retry on bad JSON) ----
+    try:
+        single_raw = await _call_groq_vision(
+            annotated_bytes, annotated_ct, strict=False, expected_players=expected_players
+        )
+    except json.JSONDecodeError:
+        try:
+            single_raw = await _call_groq_vision(
+                annotated_bytes, annotated_ct, strict=True, expected_players=expected_players
+            )
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse vision response: {e}")
+
+    single = _finalize(single_raw, "single")
+    if single["validation"]["valid"] and not _missing_expected(single_raw, expected_players):
+        return single
+
+    # ---- tiled fallback ----
+    halves = _split_horizontal_halves(deskewed_bytes, deskewed_ct)
+    if not halves:
+        return single  # can't tile — return best single attempt
+    (left_b, left_ct), (right_b, right_ct) = halves
+    try:
+        left_b, left_ct, _ = annotate_circles(left_b, left_ct)
+        right_b, right_ct, _ = annotate_circles(right_b, right_ct)
+        left_raw = await _call_groq_vision(
+            left_b, left_ct, expected_players=expected_players, hole_range=(1, 9)
+        )
+        right_raw = await _call_groq_vision(
+            right_b, right_ct, expected_players=expected_players, hole_range=(10, 18)
+        )
+    except Exception as e:
+        logger.warning("Tiled scan failed (%s); using single-call result", e)
+        return single
+
+    merged_raw = _merge_tile_results(expected_players or [], left_raw, right_raw)
+    tiled = _finalize(merged_raw, "tiled")
+    # Keep whichever attempt is balanced; prefer tiled when both/neither are.
+    if tiled["validation"]["valid"] or not single["validation"]["valid"]:
+        return tiled
+    return single
+```
+
+Note: this replaces the old retry-on-zero-sum-only logic with the adaptive single→tiled flow. The strict retry is preserved only for the JSON-parse failure case.
+
+- [ ] **Step 4: Run the new tests + the full scan-service suite**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/services/test_scorecard_scan_service.py -v`
+Expected: PASS (new adaptive tests + all existing tests). If an existing test asserted the old double-call retry behavior on zero-sum, update it to the new `method`-aware flow (the b"fake" parsing tests are unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/scorecard_scan_service.py backend/tests/unit/services/test_scorecard_scan_service.py
+git commit -m "feat(scorecard): adaptive single->tiled scan guided by expected players"
+```
+
+---
+
+## Task 5: Endpoint `players` form field
+
+**Files:**
+- Modify: `backend/app/routers/scorecard.py`
+- Test: `backend/tests/unit/routers/test_scorecard_router.py`
+
+**Interfaces:**
+- Consumes: `scan_scorecard(image_bytes, content_type, expected_players)`.
+- Produces: `POST /scorecard/scan` accepts optional `players` form field (JSON array string); parsed to `expected_players` and passed through.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# in backend/tests/unit/routers/test_scorecard_router.py
+def test_scan_passes_players_to_service(monkeypatch):
+    import app.routers.scorecard as router_mod
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    captured = {}
+
+    async def fake_scan(image_bytes, content_type, expected_players=None):
+        captured["players"] = expected_players
+        return {"players": [], "running_totals": [], "per_hole_quarters": [], "validation": {"valid": True}}
+
+    monkeypatch.setattr(router_mod, "scan_scorecard", fake_scan, raising=False)
+    client = TestClient(app)
+    resp = client.post(
+        "/scorecard/scan",
+        files={"file": ("c.png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 64, "image/png")},
+        data={"players": '["CK","SS","SG"]'},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["players"] == ["CK", "SS", "SG"]
+```
+
+> If `scan_scorecard` is imported inside the handler (`from ..services... import scan_scorecard`), patch it where the handler looks it up. The current handler does `from ..services.scorecard_scan_service import scan_scorecard` inside the function — so patch `app.services.scorecard_scan_service.scan_scorecard` instead of `router_mod`. Use that target in `monkeypatch.setattr`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/routers/test_scorecard_router.py::test_scan_passes_players_to_service -v`
+Expected: FAIL (players not parsed/passed).
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/routers/scorecard.py`, change the handler signature and pass-through:
+
+```python
+import json as _json
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+
+@router.post("/scan")
+async def scan_scorecard_photo(
+    file: UploadFile = File(...),
+    players: str | None = Form(None),
+) -> dict[str, Any]:
+    ...
+    expected_players = None
+    if players:
+        try:
+            parsed = _json.loads(players)
+            if isinstance(parsed, list) and parsed:
+                expected_players = [str(p) for p in parsed]
+        except (ValueError, TypeError):
+            expected_players = None
+    ...
+    result = await scan_scorecard(image_bytes, content_type, expected_players=expected_players)
+    return result
+```
+
+Keep the existing 20MB guard and the (now comment-only) no-downscale note. Pass `expected_players` into the `scan_scorecard` call (replace the existing `result = await scan_scorecard(image_bytes, content_type)`).
+
+- [ ] **Step 4: Run test + router suite**
+
+Run: `cd backend && venv/bin/python -m pytest tests/unit/routers/test_scorecard_router.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routers/scorecard.py backend/tests/unit/routers/test_scorecard_router.py
+git commit -m "feat(scorecard): accept optional players form field on /scorecard/scan"
+```
+
+---
+
+## Task 6: Frontend — pre-pick players + send to scan + known-player review
+
+**Files:**
+- Modify: `frontend/src/pages/ScorecardScanPage.jsx`
+- Modify: `frontend/src/components/game/ScorecardPhoto.jsx`
+- Modify: `frontend/src/components/game/ScorecardReview.jsx`
+- Test: `frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx`
+
+**Interfaces:**
+- `ScorecardPhoto` new prop `pickedPlayers: string[]` (names). When non-empty: sent as `players` in the scan form data, and passed to `ScorecardReview` so it renders fixed rows (no mapping).
+- `ScorecardScanPage` new-round mode renders a roster multiselect before `ScorecardPhoto`; chosen names become `pickedPlayers`.
+
+- [ ] **Step 1: Write the failing test (ScorecardPhoto sends players)**
+
+```jsx
+// frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx
+import React from 'react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import ScorecardPhoto from '../ScorecardPhoto';
+
+vi.mock('../ScorecardCapture', () => ({
+  default: ({ onCapture }) => <button onClick={() => onCapture(new File(['x'], 'c.jpg', { type: 'image/jpeg' }))}>capture</button>,
+}));
+vi.mock('../ScorecardReview', () => ({ default: () => <div data-testid="review" /> }));
+vi.mock('../../../utils/scorecardImage', () => ({ preprocessScorecardImage: async (f) => f }));
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ players: [], running_totals: [], per_hole_quarters: [], method: 'single' }),
+  }));
+});
+
+test('new-round scan posts the picked players as a form field', async () => {
+  render(
+    <ScorecardPhoto mode="new-round" pickedPlayers={['CK', 'SS', 'SG']} rosterNames={[]} players={[]} onSaved={() => {}} onCancel={() => {}} />,
+  );
+  screen.getByText('capture').click();
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  const body = global.fetch.mock.calls[0][1].body; // FormData
+  expect(body.get('players')).toBe('["CK","SS","SG"]');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/game/__tests__/ScorecardPhoto.players.test.jsx`
+Expected: FAIL (no `players` field on the form data).
+
+- [ ] **Step 3: Implement ScorecardPhoto**
+
+In `ScorecardPhoto.jsx`, accept `pickedPlayers = []`, and in `handleCapture` after building `formData`:
+
+```jsx
+const ScorecardPhoto = ({ gameId, players, onSaved, onCancel, mode = 'attach', rosterNames = [], pickedPlayers = [], initialStage, initialExtraction }) => {
+  ...
+  const formData = new FormData();
+  formData.append('file', prepped);
+  if (pickedPlayers.length > 0) {
+    formData.append('players', JSON.stringify(pickedPlayers));
+  }
+  ...
+```
+
+And pass `pickedPlayers` to `ScorecardReview`:
+
+```jsx
+<ScorecardReview extraction={extraction} players={players} mode={mode}
+  rosterNames={rosterNames} pickedPlayers={pickedPlayers}
+  onConfirm={handleConfirm} onCancel={onCancel} />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/game/__tests__/ScorecardPhoto.players.test.jsx`
+Expected: PASS
+
+- [ ] **Step 5: ScorecardReview — fixed rows when players known**
+
+In `ScorecardReview.jsx`, accept `pickedPlayers = []`. When `pickedPlayers.length > 0` (new-round with known players), the per-player rows use `pickedPlayers[pi]` as the name and render the name as plain text (no `<select>`); `handleConfirm`'s new-round branch sends `{ name: pickedPlayers[pi], player_profile_id: null }` (no `unlinked`, since these are real roster picks). Keep the existing mapping-dropdown path only when `pickedPlayers` is empty. Initialize `mapping` to `pickedPlayers` when present.
+
+```jsx
+const knownPlayers = pickedPlayers.length > 0;
+// in the players.map row: render `{knownPlayers ? (pickedPlayers[pi] ?? ep.name) : <select .../>}`
+// in handleConfirm new-round branch:
+//   name: knownPlayers ? (pickedPlayers[pi] ?? ep.name) : (mapping[pi] === '__unlinked__' ? ep.name : mapping[pi])
+```
+
+- [ ] **Step 6: ScorecardScanPage — pre-pick step**
+
+In `ScorecardScanPage.jsx` new-round mode (`mode === 'new-round'`), before rendering `<ScorecardPhoto>`, gate on a `pickedPlayers` state: if empty, render a roster multiselect (checkboxes over `rosterNames`, enforce 4–6 selected) with a "Continue" button that sets `pickedPlayers`; once set, render `<ScorecardPhoto mode="new-round" pickedPlayers={pickedPlayers} rosterNames={rosterNames} .../>`. Add `const [pickedPlayers, setPickedPlayers] = useState([]);` and reset it in `onCancel`.
+
+- [ ] **Step 7: Frontend gate**
+
+Run: `cd frontend && npm run typecheck && npx vitest run && npm run build`
+Expected: all pass (existing ScorecardReview/ScorecardScanPage tests still green; new test passes).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/pages/ScorecardScanPage.jsx frontend/src/components/game/ScorecardPhoto.jsx frontend/src/components/game/ScorecardReview.jsx frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx
+git commit -m "feat(scorecard): pre-pick roster players, send to scan, fixed-row review"
+```
+
+---
+
+## Task 7: Live accuracy eval with known players + full gate
+
+**Files:**
+- Modify: `backend/tests/live/test_scorecard_accuracy_live.py`
+
+**Interfaces:**
+- Consumes: `scan_scorecard(image_bytes, content_type, expected_players)`.
+
+- [ ] **Step 1: Update the eval to pass known players and assert the tiled win**
+
+Change the scan call to pass the 5 known players and assert all are found + accuracy beats the single-call baseline:
+
+```python
+    expected = [p["name"] for p in ground_truth["players"]]  # CK, SS, KG, BH, SG
+    result = asyncio.run(scan_scorecard(image_bytes, "image/jpeg", expected_players=expected))
+    # all five players must now be found (the single-call path missed SG)
+    found = {_norm(p.get("name", "")) for p in result.get("players", [])}
+    assert all(_norm(n) in found for n in expected), f"missing players; method={result.get('method')}"
+```
+
+Keep the existing per-cell scoring + printed diff. Raise `_ACCURACY_FLOOR` from `0.5` to `0.7` (tiling should clear it; adjust down only with a comment if real numbers say otherwise).
+
+- [ ] **Step 2: Verify it still skips without a key**
+
+Run: `cd backend && venv/bin/python -m pytest tests/live/test_scorecard_accuracy_live.py -m live -v`
+Expected: SKIPPED (missing GROQ_API_KEY).
+
+- [ ] **Step 3: Full backend + frontend gate**
+
+Run:
+```
+cd backend && venv/bin/python -m ruff check app/ tests/ && venv/bin/python -m ruff format --check app/ tests/ && venv/bin/python -m pytest tests/ --ignore=tests/manual --ignore=tests/_diagnostic -q
+cd ../frontend && npm run typecheck && npx vitest run && npm run build
+```
+Expected: green except the documented Mac-only `tests/infra/startup_test.py::test_server` SOCKS failure.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/live/test_scorecard_accuracy_live.py
+git commit -m "test(scorecard): live eval passes known players, asserts all found + higher floor"
+```
+
+- [ ] **Step 5: Real-world validation (manual, after deploy)**
+
+With `GROQ_API_KEY` set, run the eval against the 5-man fixture and confirm `method == "tiled"`, all 5 players found, and accuracy ≫ the 16% single-call baseline:
+`cd backend && GROQ_API_KEY=<key> venv/bin/python -m pytest tests/live/test_scorecard_accuracy_live.py -m live -s`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** adaptive trigger (T4) ✓; pre-pick players (T6) ✓; Approach A tiling — deskew→split→guided halves→merge (T2/T3/T4) ✓; `players` form field (T5) ✓; review drops mapping when known (T6) ✓; width/2 split (T2) ✓; `method` observability (T4) ✓; graceful degradation (T2 None, T4 try/except → single) ✓; live eval measures vs 16% (T7) ✓.
+- **Type consistency:** `_norm_name` (T1) reused in T3; `_call_groq_vision(..., expected_players, hole_range)` defined T1, called T4; `_split_horizontal_halves -> ((bytes,str),(bytes,str))|None` (T2) consumed T4; `_merge_tile_results(list, dict, dict) -> raw dict` (T3) consumed T4 then `_shape_extraction`; `scan_scorecard(..., expected_players)` (T4) consumed by router (T5) and eval (T7); `pickedPlayers` prop threaded ScorecardScanPage→ScorecardPhoto→ScorecardReview (T6).
+- **Placeholders:** none — every code step has concrete code; the one prose-only step (T6 Step 6) describes exact state + gating in a known file.
+- **Risk noted:** T5 patch target — patch `scan_scorecard` where the handler imports it (inside the function), called out in the test note. T1 — confirm `import re`/`json` already present before re-adding.

--- a/docs/superpowers/specs/2026-06-19-tiled-scorecard-scan-design.md
+++ b/docs/superpowers/specs/2026-06-19-tiled-scorecard-scan-design.md
@@ -1,0 +1,134 @@
+# Tiled Adaptive Scorecard Scanning — Design
+
+- **Date:** 2026-06-19
+- **Status:** Approved (design)
+- **Builds on:** the existing Groq Vision scorecard scanner (`scorecard_scan_service.py`) and the "scan a finished round" flow.
+
+## Problem
+
+A live scan of a real, dense **5-man** phone scorecard scored **16%** front-nine
+cell accuracy and **missed the 5th player entirely** (written in the lower band
+below Par). The single whole-card call can't resolve the tiny handwritten cells,
+and full-resolution preprocessing is too slow on free-tier infra — so a bigger
+whole-card image isn't the answer. Reading the card by region (cropping it into
+halves) *did* work by hand.
+
+## Goal
+
+Make the scanner reliably read dense multi-man cards by (a) telling it exactly
+which players to find (pre-picked from the roster) and (b) falling back to a
+**tiled** per-region scan when a cheap single call fails — without paying for
+tiling on easy cards.
+
+## Decisions (locked)
+
+1. **Adaptive trigger:** one whole-card call first; tile only if it fails.
+2. **Pre-pick players from the roster before capture** — the scan knows the
+   exact names + count up front (both scan paths have known players).
+3. **Tiling = Approach A:** 2 tiles, left/right page halves, full height.
+4. `players` is an **optional form field** on the existing `POST /scorecard/scan`
+   (no new endpoint).
+5. The review screen **drops name-mapping** when players are pre-picked (mapping
+   stays only as a manual override).
+6. Tiling split is a **plain width/2** of the deskewed image (no fold detection).
+
+## Flow
+
+**New-round path** (`/scorecard-scan` → "Scan a finished round"):
+pre-pick players (roster multiselect) → capture → adaptive scan (sends names) →
+review/confirm quarters → save.
+
+**Attach-to-game path:** unchanged except it passes the game's players to the
+scan and skips review name-mapping.
+
+## Backend
+
+### Endpoint
+
+`POST /scorecard/scan` gains an optional form field `players` — a JSON array of
+expected player names, e.g. `["CK","SS","KG","BH","SG"]`. Absent → current
+behavior (auto-detect; tile on zero-sum failure only).
+
+### `scan_scorecard(image_bytes, content_type, expected_players=None)`
+
+1. Downscale to the 2048px preprocessing working size; run deskew → crop → annotate
+   (existing pipeline) for the single-call attempt.
+2. **Single guided call** — when `expected_players` is given, the prompt states:
+   *"Expect exactly these N players: [names]. Read each player's 18-hole running
+   totals."* (When absent, the current generic prompt.)
+3. **Validate** the result:
+   - per-hole zero-sum holds (existing `_validate_zero_sum`), AND
+   - every expected player is present (matched by normalized name).
+4. **Valid → return** (`method="single"`). Cheap path = 1 Groq call.
+5. **Invalid → tile** (see below), `method="tiled"`.
+6. Return the existing shape (`players`, `running_totals`, `per_hole_quarters`,
+   `validation`) plus `method` for observability.
+
+### Tiling (Approach A)
+
+- `deskew_to_card` once on the working-size image; **do not** tight-crop (the
+  lower-band 5th player must survive).
+- Split the deskewed image at **width/2**: left = front nine, right = back nine,
+  each **full height**.
+- `annotate_circles` on each half (cheap at half size).
+- One **guided call per half**: *"This is the [front|back] nine. Read holes
+  [1–9|10–18] running totals for these players: [names]. Ignore golf-score rows
+  and notes."*
+- **Merge by player:** for each expected player, take holes 1–9 from the left
+  result and holes 10–18 from the right; align extracted rows to expected names
+  (normalized match, fall back to row order). Build combined `running_totals` →
+  `per_hole_quarters` → `_validate_zero_sum`.
+- Tiling adds 2 Groq calls (total 3 on a hard card; ~60–80s worst case).
+
+### Trigger summary
+
+| expected_players | tile when |
+|---|---|
+| provided | zero-sum invalid OR any expected player missing |
+| absent | zero-sum invalid |
+
+## Frontend
+
+- **Pre-pick step** (new-round mode): a roster multiselect (`/legacy-players`)
+  before `ScorecardCapture`. Picked names flow to the scan and to review.
+- `ScorecardPhoto`: send `players` (picked names, or the game's players in attach
+  mode) in the `/scorecard/scan` form data.
+- `ScorecardReview`: when players are known, render fixed player rows (no mapping
+  dropdowns); keep mapping only as a manual override if the scan can't align.
+
+## Error handling
+
+- Each tile call degrades gracefully (a failed/garbled tile falls back to the
+  single-call result for those holes rather than erroring the whole scan).
+- If tiling also fails zero-sum, return the better of the two attempts with
+  `validation.valid=false` — the review/correct screen remains the safety net.
+- Non-image bytes / preprocessing failures: existing graceful fallthrough.
+
+## Testing
+
+**Backend unit:**
+- Guided prompt includes the expected player names when provided.
+- Adaptive: a valid single result does NOT tile; an invalid one DOES (mock
+  `_call_groq_vision`).
+- Merge: left holes 1–9 + right holes 10–18 → correct combined `running_totals`
+  and `per_hole_quarters`.
+- Split helper produces two sub-images from a deskewed frame.
+- `method` is `"single"` vs `"tiled"` accordingly.
+
+**Live eval (on-demand, `GROQ_API_KEY`):** extend the existing held-out accuracy
+test to pass the 5 known players and assert the tiled path beats the 16%
+single-call baseline (and finds all 5 players).
+
+**Frontend:** pre-pick step renders and gates capture; scan posts `players`;
+review uses known players (no mapping dropdowns).
+
+## Scope (YAGNI)
+
+2 tiles only; proportional width/2 split (no fold/band detection); keep the
+single-call path; simple normalized-name alignment. No 3rd lower-band tile.
+
+## Rollout
+
+Frontend + backend deploy together (push to main). No DB migration. Pre-push
+gate: frontend typecheck+vitest+build; backend ruff+pytest. Note: the live eval
+is the real accuracy check and needs `GROQ_API_KEY` (not in CI).

--- a/frontend/src/components/game/ScorecardPhoto.jsx
+++ b/frontend/src/components/game/ScorecardPhoto.jsx
@@ -35,6 +35,7 @@ const ScorecardPhoto = ({
   onCancel,
   mode = 'attach',
   rosterNames = [],
+  pickedPlayers = [],
   initialStage,
   initialExtraction,
 }) => {
@@ -60,6 +61,9 @@ const ScorecardPhoto = ({
 
     const formData = new FormData();
     formData.append('file', prepped);
+    if (pickedPlayers.length > 0) {
+      formData.append('players', JSON.stringify(pickedPlayers));
+    }
 
     try {
       const res = await fetch(`${API_URL}/scorecard/scan`, {
@@ -156,6 +160,7 @@ const ScorecardPhoto = ({
         players={players}
         mode={mode}
         rosterNames={rosterNames}
+        pickedPlayers={pickedPlayers}
         onConfirm={handleConfirm}
         onCancel={onCancel}
       />

--- a/frontend/src/components/game/ScorecardReview.jsx
+++ b/frontend/src/components/game/ScorecardReview.jsx
@@ -44,12 +44,23 @@ const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'att
       const match = scanPlayers.find(sp => norm(sp.name) === normPicked);
       return match ?? scanPlayers[i] ?? { name: picked, confidence: null };
     });
-    // Build index map: old scan index → new picked index
+    // Build index map: old scan index → new picked index.
+    // First pass: exact name matches (always win over positional fallbacks).
+    // Second pass: positional fallback for unmatched picked players — mirrors
+    // the scanPlayers[i] fallback used by reorderedPlayers above so that a
+    // garbled OCR name still picks up that scan row's running_totals.
     const oldToNew = {};
     pickedPlayers.forEach((picked, newIdx) => {
       const normPicked = norm(picked);
       const oldIdx = extraction.players.findIndex(sp => norm(sp.name) === normPicked);
       if (oldIdx !== -1) oldToNew[oldIdx] = newIdx;
+    });
+    pickedPlayers.forEach((picked, newIdx) => {
+      const normPicked = norm(picked);
+      const oldIdx = extraction.players.findIndex(sp => norm(sp.name) === normPicked);
+      if (oldIdx === -1 && newIdx < scanPlayers.length && !(newIdx in oldToNew)) {
+        oldToNew[newIdx] = newIdx;
+      }
     });
     const reorderedTotals = extraction.running_totals
       .filter(t => t.player_index in oldToNew)

--- a/frontend/src/components/game/ScorecardReview.jsx
+++ b/frontend/src/components/game/ScorecardReview.jsx
@@ -28,10 +28,34 @@ const computeDeltas = (runningTotals) => {
   return deltas;
 };
 
+const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
 const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'attach', rosterNames = [], pickedPlayers = [] }) => {
-  const { players: extractedPlayers, running_totals: rawTotals } = extraction;
   const isNewRound = mode === 'new-round';
   const knownPlayers = pickedPlayers.length > 0;
+
+  // When pickedPlayers are known, reorder extraction so index i = pickedPlayers[i].
+  // This prevents the single-scan path from attributing one player's scores to another's name.
+  const { players: extractedPlayers, running_totals: rawTotals } = (() => {
+    if (!knownPlayers) return extraction;
+    const scanPlayers = extraction.players;
+    const reorderedPlayers = pickedPlayers.map((picked, i) => {
+      const normPicked = norm(picked);
+      const match = scanPlayers.find(sp => norm(sp.name) === normPicked);
+      return match ?? scanPlayers[i] ?? { name: picked, confidence: null };
+    });
+    // Build index map: old scan index → new picked index
+    const oldToNew = {};
+    pickedPlayers.forEach((picked, newIdx) => {
+      const normPicked = norm(picked);
+      const oldIdx = extraction.players.findIndex(sp => norm(sp.name) === normPicked);
+      if (oldIdx !== -1) oldToNew[oldIdx] = newIdx;
+    });
+    const reorderedTotals = extraction.running_totals
+      .filter(t => t.player_index in oldToNew)
+      .map(t => ({ ...t, player_index: oldToNew[t.player_index] }));
+    return { players: reorderedPlayers, running_totals: reorderedTotals };
+  })();
 
   const bestRosterMatch = (name) => {
     const lower = (name || '').trim().toLowerCase();

--- a/frontend/src/components/game/ScorecardReview.jsx
+++ b/frontend/src/components/game/ScorecardReview.jsx
@@ -28,9 +28,10 @@ const computeDeltas = (runningTotals) => {
   return deltas;
 };
 
-const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'attach', rosterNames = [] }) => {
+const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'attach', rosterNames = [], pickedPlayers = [] }) => {
   const { players: extractedPlayers, running_totals: rawTotals } = extraction;
   const isNewRound = mode === 'new-round';
+  const knownPlayers = pickedPlayers.length > 0;
 
   const bestRosterMatch = (name) => {
     const lower = (name || '').trim().toLowerCase();
@@ -45,7 +46,9 @@ const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'att
     );
   };
   const [mapping, setMapping] = useState(() =>
-    extractedPlayers.map(ep => bestRosterMatch(ep.name)),
+    knownPlayers
+      ? pickedPlayers
+      : extractedPlayers.map(ep => bestRosterMatch(ep.name)),
   );
   const [playedAt, setPlayedAt] = useState(() => new Date().toISOString().slice(0, 10));
 
@@ -129,10 +132,12 @@ const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'att
       }
       onConfirm({
         players: extractedPlayers.map((ep, pi) =>
-          mapping[pi] === '__unlinked__'
-            // explicit "keep as typed" — backend must NOT auto-link by name
-            ? { name: ep.name, player_profile_id: null, unlinked: true }
-            : { name: mapping[pi], player_profile_id: null }),
+          knownPlayers
+            ? { name: pickedPlayers[pi] ?? ep.name, player_profile_id: null }
+            : (mapping[pi] === '__unlinked__'
+                // explicit "keep as typed" — backend must NOT auto-link by name
+                ? { name: ep.name, player_profile_id: null, unlinked: true }
+                : { name: mapping[pi], player_profile_id: null })),
         per_hole_quarters: perHole,
         played_at: playedAt,
       });
@@ -167,21 +172,31 @@ const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'att
       {isNewRound && (
         <div className="flex flex-col gap-3 bg-gray-50 border border-gray-200 rounded-lg p-3">
           <div className="flex flex-col gap-2">
-            <span className="text-sm font-semibold text-gray-700">Map scanned players to roster</span>
+            <span className="text-sm font-semibold text-gray-700">
+              {knownPlayers ? 'Players' : 'Map scanned players to roster'}
+            </span>
             {extractedPlayers.map((ep, pi) => (
               <div key={pi} className="flex items-center gap-2">
-                <span className="text-sm text-gray-600 min-w-[90px]">{ep.name || `Player ${pi + 1}`}</span>
-                <span className="text-gray-400">→</span>
-                <select
-                  value={mapping[pi]}
-                  onChange={e => setMapping(prev => prev.map((m, i) => (i === pi ? e.target.value : m)))}
-                  className="text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
-                >
-                  {rosterNames.map(r => (
-                    <option key={r} value={r}>{r}</option>
-                  ))}
-                  <option value="__unlinked__">Keep as typed (unlinked)</option>
-                </select>
+                {knownPlayers ? (
+                  <span className="text-sm text-gray-800 font-medium">
+                    {(pickedPlayers[pi] ?? ep.name) || `Player ${pi + 1}`}
+                  </span>
+                ) : (
+                  <>
+                    <span className="text-sm text-gray-600 min-w-[90px]">{ep.name || `Player ${pi + 1}`}</span>
+                    <span className="text-gray-400">→</span>
+                    <select
+                      value={mapping[pi]}
+                      onChange={e => setMapping(prev => prev.map((m, i) => (i === pi ? e.target.value : m)))}
+                      className="text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                    >
+                      {rosterNames.map(r => (
+                        <option key={r} value={r}>{r}</option>
+                      ))}
+                      <option value="__unlinked__">Keep as typed (unlinked)</option>
+                    </select>
+                  </>
+                )}
               </div>
             ))}
           </div>

--- a/frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx
+++ b/frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import ScorecardPhoto from '../ScorecardPhoto';
+
+vi.mock('../ScorecardCapture', () => ({
+  default: ({ onCapture }) => <button onClick={() => onCapture(new File(['x'], 'c.jpg', { type: 'image/jpeg' }))}>capture</button>,
+}));
+vi.mock('../ScorecardReview', () => ({ default: () => <div data-testid="review" /> }));
+vi.mock('../../../utils/scorecardImage', () => ({ preprocessScorecardImage: async (f) => f }));
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ players: [], running_totals: [], per_hole_quarters: [], method: 'single' }),
+  }));
+});
+
+test('new-round scan posts the picked players as a form field', async () => {
+  render(
+    <ScorecardPhoto mode="new-round" pickedPlayers={['CK', 'SS', 'SG']} rosterNames={[]} players={[]} onSaved={() => {}} onCancel={() => {}} />,
+  );
+  screen.getByText('capture').click();
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  const body = global.fetch.mock.calls[0][1].body; // FormData
+  expect(body.get('players')).toBe('["CK","SS","SG"]');
+});

--- a/frontend/src/components/game/__tests__/ScorecardReview.newround.test.jsx
+++ b/frontend/src/components/game/__tests__/ScorecardReview.newround.test.jsx
@@ -40,6 +40,50 @@ test('new-round mode maps names to roster and confirms profile-less payload', ()
   expect(arg.played_at).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 });
 
+test('pickedPlayers: scanned order reversed from picked order aligns scores by name, not index', () => {
+  const onConfirm = vi.fn();
+  // Scan returned players in OPPOSITE order: SS first, CK second
+  // CK's scores: hole 1 = 10 (delta = 10), hole 2 = 20 (delta = 10)
+  // SS's scores: hole 1 = 1 (delta = 1), hole 2 = 2 (delta = 1)
+  const reversedExtraction = {
+    players: [{ name: 'SS', confidence: 0.9 }, { name: 'CK', confidence: 0.9 }],
+    running_totals: (() => {
+      const t = [];
+      // SS is at scan index 0, CK is at scan index 1
+      for (let h = 1; h <= 18; h++) {
+        t.push({ player_index: 0, hole: h, value: h * 1, confidence: 1 });      // SS: 1,2,...18
+        t.push({ player_index: 1, hole: h, value: h * 10, confidence: 1 });     // CK: 10,20,...180
+      }
+      return t;
+    })(),
+  };
+
+  render(
+    <ScorecardReview
+      extraction={reversedExtraction}
+      players={[]}
+      mode="new-round"
+      pickedPlayers={['CK', 'SS']}
+      onConfirm={onConfirm}
+      onCancel={() => {}}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+  expect(onConfirm).toHaveBeenCalledTimes(1);
+  const arg = onConfirm.mock.calls[0][0];
+
+  // pickedPlayers[0] = 'CK' → must have CK's scores (delta=10 per hole)
+  expect(arg.players[0]).toEqual({ name: 'CK', player_profile_id: null });
+  const ckHole1 = arg.per_hole_quarters.find(q => q.player_index === 0 && q.hole === 1);
+  expect(ckHole1.quarters).toBe(10);
+
+  // pickedPlayers[1] = 'SS' → must have SS's scores (delta=1 per hole)
+  expect(arg.players[1]).toEqual({ name: 'SS', player_profile_id: null });
+  const ssHole1 = arg.per_hole_quarters.find(q => q.player_index === 1 && q.hole === 1);
+  expect(ssHole1.quarters).toBe(1);
+});
+
 test('choosing "keep as typed (unlinked)" sends unlinked:true with the typed name', () => {
   const onConfirm = vi.fn();
   render(

--- a/frontend/src/components/game/__tests__/ScorecardReview.newround.test.jsx
+++ b/frontend/src/components/game/__tests__/ScorecardReview.newround.test.jsx
@@ -84,6 +84,49 @@ test('pickedPlayers: scanned order reversed from picked order aligns scores by n
   expect(ssHole1.quarters).toBe(1);
 });
 
+test('pickedPlayers: garbled OCR name uses positional fallback so scores are NOT dropped', () => {
+  const onConfirm = vi.fn();
+  // Scan garbled "CK" → "CKgarbled"; "SS" scanned correctly.
+  // CKgarbled is at scan index 0: hole values 100, 200, ... (delta = 100 per hole)
+  // SS is at scan index 1: hole values 10, 20, ...   (delta = 10 per hole)
+  const garbledExtraction = {
+    players: [{ name: 'CKgarbled', confidence: 0.4 }, { name: 'SS', confidence: 0.9 }],
+    running_totals: (() => {
+      const t = [];
+      for (let h = 1; h <= 18; h++) {
+        t.push({ player_index: 0, hole: h, value: h * 100, confidence: 1 }); // CKgarbled scan index 0
+        t.push({ player_index: 1, hole: h, value: h * 10, confidence: 1 });  // SS scan index 1
+      }
+      return t;
+    })(),
+  };
+
+  render(
+    <ScorecardReview
+      extraction={garbledExtraction}
+      players={[]}
+      mode="new-round"
+      pickedPlayers={['CK', 'SS']}
+      onConfirm={onConfirm}
+      onCancel={() => {}}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+  expect(onConfirm).toHaveBeenCalledTimes(1);
+  const arg = onConfirm.mock.calls[0][0];
+
+  // 'CK' had no name match → positional fallback: scan index 0 (CKgarbled row, delta=100)
+  expect(arg.players[0]).toEqual({ name: 'CK', player_profile_id: null });
+  const ckHole1 = arg.per_hole_quarters.find(q => q.player_index === 0 && q.hole === 1);
+  expect(ckHole1.quarters).toBe(100); // NOT zero/dropped
+
+  // 'SS' matched by name: scan index 1 (delta=10)
+  expect(arg.players[1]).toEqual({ name: 'SS', player_profile_id: null });
+  const ssHole1 = arg.per_hole_quarters.find(q => q.player_index === 1 && q.hole === 1);
+  expect(ssHole1.quarters).toBe(10);
+});
+
 test('choosing "keep as typed (unlinked)" sends unlinked:true with the typed name', () => {
   const onConfirm = vi.fn();
   render(

--- a/frontend/src/pages/ScorecardScanPage.jsx
+++ b/frontend/src/pages/ScorecardScanPage.jsx
@@ -5,6 +5,114 @@ import { apiConfig } from '../config/api.config';
 
 const API_URL = apiConfig.baseUrl;
 
+/**
+ * PlayerPickStep — roster multiselect shown before the camera in new-round mode.
+ * Enforces 4–6 players selected before allowing Continue.
+ */
+const PlayerPickStep = ({ rosterNames, onConfirm, onCancel }) => {
+  const [selected, setSelected] = useState([]);
+
+  const toggle = (name) => {
+    setSelected(prev =>
+      prev.includes(name) ? prev.filter(n => n !== name) : [...prev, name],
+    );
+  };
+
+  const canContinue = selected.length >= 4 && selected.length <= 6;
+
+  return (
+    <div style={{ minHeight: '100vh', background: '#F9FAFB', padding: '16px' }}>
+      <div style={{ maxWidth: '500px', margin: '0 auto' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px', paddingTop: '8px' }}>
+          <button
+            onClick={onCancel}
+            style={{ background: 'none', border: 'none', fontSize: '20px', cursor: 'pointer', padding: '4px', color: '#6B7280' }}
+          >
+            ←
+          </button>
+          <div>
+            <h1 style={{ margin: 0, fontSize: '1.4rem', fontWeight: 'bold', color: '#111827' }}>
+              📷 Scan Scorecard
+            </h1>
+            <p style={{ margin: 0, fontSize: '13px', color: '#6B7280' }}>
+              Select the players in this round (4–6)
+            </p>
+          </div>
+        </div>
+
+        <div style={{
+          background: 'white',
+          borderRadius: '16px',
+          padding: '20px',
+          boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+        }}>
+          <h2 style={{ margin: '0 0 16px', fontSize: '1rem', fontWeight: '600', color: '#374151' }}>
+            Who played? ({selected.length} selected)
+          </h2>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '20px' }}>
+            {rosterNames.map(name => {
+              const isSelected = selected.includes(name);
+              return (
+                <label
+                  key={name}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '10px',
+                    padding: '10px 14px',
+                    background: isSelected ? '#ECFDF5' : '#F9FAFB',
+                    border: `2px solid ${isSelected ? '#047857' : '#E5E7EB'}`,
+                    borderRadius: '10px',
+                    cursor: 'pointer',
+                    fontWeight: isSelected ? '600' : '400',
+                    color: '#111827',
+                    transition: 'all 0.15s',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggle(name)}
+                    style={{ accentColor: '#047857', width: '16px', height: '16px' }}
+                  />
+                  {name}
+                </label>
+              );
+            })}
+          </div>
+
+          {!canContinue && selected.length > 0 && (
+            <p style={{ fontSize: '13px', color: '#6B7280', marginBottom: '12px', textAlign: 'center' }}>
+              {selected.length < 4
+                ? `Select at least ${4 - selected.length} more player${4 - selected.length > 1 ? 's' : ''}`
+                : 'Maximum 6 players allowed'}
+            </p>
+          )}
+
+          <button
+            onClick={() => onConfirm(selected)}
+            disabled={!canContinue}
+            style={{
+              width: '100%',
+              padding: '14px',
+              background: canContinue ? '#047857' : '#D1D5DB',
+              color: canContinue ? 'white' : '#9CA3AF',
+              border: 'none',
+              borderRadius: '10px',
+              fontWeight: '600',
+              fontSize: '15px',
+              cursor: canContinue ? 'pointer' : 'not-allowed',
+            }}
+          >
+            Continue →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const ScorecardScanPage = () => {
   const navigate = useNavigate();
   const [games, setGames] = useState([]);
@@ -13,6 +121,7 @@ const ScorecardScanPage = () => {
   const [saved, setSaved] = useState(false);
   const [mode, setMode] = useState(null); // null = landing, 'new-round', 'attach'
   const [rosterNames, setRosterNames] = useState([]);
+  const [pickedPlayers, setPickedPlayers] = useState([]);
   const [savedGameId, setSavedGameId] = useState(null);
 
   useEffect(() => {
@@ -94,6 +203,16 @@ const ScorecardScanPage = () => {
   }
 
   if (mode === 'new-round') {
+    // Pre-pick step: gate on player selection before showing the camera
+    if (pickedPlayers.length === 0) {
+      return (
+        <PlayerPickStep
+          rosterNames={rosterNames}
+          onConfirm={setPickedPlayers}
+          onCancel={() => setMode(null)}
+        />
+      );
+    }
     return (
       <div style={{ minHeight: '100vh', background: '#F9FAFB', padding: '16px' }}>
         <div style={{ maxWidth: '600px', margin: '0 auto' }}>
@@ -106,9 +225,10 @@ const ScorecardScanPage = () => {
             <ScorecardPhoto
               mode="new-round"
               rosterNames={rosterNames}
+              pickedPlayers={pickedPlayers}
               players={[]}
               onSaved={(result) => { setSavedGameId(result?.game_id || null); setSaved(true); }}
-              onCancel={() => setMode(null)}
+              onCancel={() => { setPickedPlayers([]); setMode(null); }}
             />
           </div>
         </div>

--- a/frontend/src/pages/ScorecardScanPage.jsx
+++ b/frontend/src/pages/ScorecardScanPage.jsx
@@ -238,6 +238,7 @@ const ScorecardScanPage = () => {
 
   if (mode === 'attach' && selectedGame) {
     const players = selectedGame.players || [];
+    const attachPickedPlayers = players.map(p => p.name).filter(Boolean);
     return (
       <div style={{ minHeight: '100vh', background: '#F9FAFB', padding: '16px' }}>
         <div style={{ maxWidth: '600px', margin: '0 auto' }}>
@@ -250,6 +251,7 @@ const ScorecardScanPage = () => {
             <ScorecardPhoto
               gameId={selectedGame.game_id}
               players={players}
+              pickedPlayers={attachPickedPlayers}
               onSaved={() => setSaved(true)}
               onCancel={() => setSelectedGame(null)}
             />

--- a/frontend/src/pages/__tests__/ScorecardScanPage.test.jsx
+++ b/frontend/src/pages/__tests__/ScorecardScanPage.test.jsx
@@ -6,25 +6,46 @@ import ScorecardScanPage from '../ScorecardScanPage';
 
 // Mock the heavy photo flow — we only assert the landing routes into it.
 vi.mock('../../components/game/ScorecardPhoto', () => ({
-  default: ({ mode }) => <div data-testid="scorecard-photo">mode:{mode}</div>,
+  default: ({ mode, pickedPlayers }) => (
+    <div data-testid="scorecard-photo">
+      mode:{mode}
+      {pickedPlayers && pickedPlayers.length > 0 && (
+        <span data-testid="picked-count">{pickedPlayers.length}</span>
+      )}
+    </div>
+  ),
 }));
+
+const ROSTER = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve', 'Frank'];
 
 beforeEach(() => {
   global.fetch = vi.fn(async (url) => ({
     ok: true,
-    json: async () => (String(url).includes('/legacy-players') ? { players: [] } : []),
+    json: async () => (String(url).includes('/legacy-players') ? { players: ROSTER } : []),
   }));
 });
 
 describe('ScorecardScanPage landing', () => {
-  test("'Scan a finished round' enters new-round mode without selecting a game", async () => {
+  test("'Scan a finished round' shows player picker then photo flow after selecting 4 players", async () => {
     render(
       <MemoryRouter>
         <ScorecardScanPage />
       </MemoryRouter>,
     );
+    // Enter new-round mode — should show player picker, not photo yet
     fireEvent.click(await screen.findByText(/Scan a finished round/i));
+    expect(screen.queryByTestId('scorecard-photo')).toBeNull();
+    expect(await screen.findByText(/Who played/i)).toBeInTheDocument();
+
+    // Select 4 players
+    for (const name of ROSTER.slice(0, 4)) {
+      fireEvent.click(screen.getByLabelText(name));
+    }
+
+    // Continue should now be enabled
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(screen.getByTestId('scorecard-photo')).toHaveTextContent('mode:new-round');
+    expect(screen.getByTestId('picked-count')).toHaveTextContent('4');
   });
 
   test("'Add to an active game' does NOT immediately enter the photo flow (shows game picker)", async () => {

--- a/frontend/src/pages/__tests__/ScorecardScanPage.test.jsx
+++ b/frontend/src/pages/__tests__/ScorecardScanPage.test.jsx
@@ -57,4 +57,29 @@ describe('ScorecardScanPage landing', () => {
     fireEvent.click(await screen.findByText(/Add to an active game/i));
     expect(screen.queryByTestId('scorecard-photo')).toBeNull();
   });
+
+  test("attach mode passes the game's player names as pickedPlayers to ScorecardPhoto", async () => {
+    // Override fetch to return a game with two named players.
+    global.fetch = vi.fn(async (url) => ({
+      ok: true,
+      json: async () => {
+        if (String(url).includes('/legacy-players')) return { players: ROSTER };
+        // /games/active
+        return [{ game_id: 'g1', players: [{ name: 'Alice' }, { name: 'Bob' }], created_at: null }];
+      },
+    }));
+
+    render(
+      <MemoryRouter>
+        <ScorecardScanPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByText(/Add to an active game/i));
+    // Select the game from the picker.
+    fireEvent.click(await screen.findByText('Alice, Bob'));
+    // ScorecardPhoto should now be visible with pickedPlayers wired.
+    expect(screen.getByTestId('scorecard-photo')).toBeInTheDocument();
+    expect(screen.getByTestId('picked-count')).toHaveTextContent('2');
+  });
 });


### PR DESCRIPTION
## Tiled adaptive scorecard scanning, guided by pre-picked players

A live Groq scan of a real 5-man phone scorecard scored **16%** front-nine cell accuracy and **missed the 5th player** (written in the lower band). The single whole-card call can't resolve the dense handwritten cells, and full-res preprocessing is too slow on free-tier infra. Reading the card by region (cropping into halves) works.

### What this does
- **Pre-pick players** from the roster before capture, so the scan knows the exact names + count (both scan paths now pass players: new-round picks them; attach mode passes the game's players).
- **Adaptive scan:** one guided whole-card Groq call first; if it fails zero-sum **or** is missing an expected player, fall back to a **tiled** scan — deskew, split into left (holes 1–9) / right (holes 10–18) halves at full height (so the lower-band 5th player survives), scan each guided by the player list, and **merge by player**. `result.method` is `"single"` or `"tiled"`.
- **Review** renders fixed player rows aligned to the picked roster **by name** (positional fallback), dropping the name-mapping dropdowns when players are known.

### Key files
- `backend/app/services/scorecard_scan_service.py` — guided prompt, `_split_horizontal_halves`, `_merge_tile_results`, adaptive orchestration, budget-aware sizing.
- `backend/app/routers/scorecard.py` — optional `players` form field on `POST /scorecard/scan`.
- `frontend/src/pages/ScorecardScanPage.jsx`, `components/game/ScorecardPhoto.jsx`, `ScorecardReview.jsx`.

### Testing
- Backend: unit tests for the guided prompt, split, merge, and the full adaptive flow (single-valid → no tile; missing-player/zero-sum-invalid → tile; tile/merge exception → graceful fallback to single; empty-players → return single, never an empty result). Full suite green (only the documented Mac-local SOCKS test fails locally; passes in CI).
- Frontend: pre-pick step, `players` posted to scan, name-aligned review (incl. opposite-order and garbled-OCR cases). typecheck + 523 tests + build green.
- A held-out **live accuracy eval** (`tests/live/test_scorecard_accuracy_live.py`, skips without `GROQ_API_KEY`) measures the tiled result against the 5-man ground truth — run it to confirm the gain over the 16% baseline:
  `cd backend && GROQ_API_KEY=<key> venv/bin/python -m pytest tests/live/test_scorecard_accuracy_live.py -m live -s`

### Built via
Brainstorm → spec → plan → subagent-driven implementation (7 tasks, per-task spec+quality review, then an opus whole-branch review that caught and fixed a Critical empty-merge regression).

### Deferred follow-ups (logged, non-blocking)
duplicate-normalized-name collision edge (backend merge + frontend remap); `PlayerPickStep` empty-roster dead-end; cosmetic naming/docstring/style nits; the tile-boundary cumulative-running-total assumption (exercised by the live eval).

This pull request and its description were written by Isaac.
