### PR TITLE
feat(scorecard): persist scan photo + backfill per-hole later (Part B)

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,16 @@
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import JSON

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, UniqueConstraint, text
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import JSON
@@ -167,6 +167,7 @@ class GameStateModel(Base):
     # changes are tracked; NESTED mutation (state["players"][i]["x"] = ...) is NOT,
     # so nested writes must reassign the top-level key (state["players"] = new_list).
     state = Column(MutableDict.as_mutable(JSON))
+    scorecard_image = Column(Text, nullable=True)  # downscaled JPEG as base64/data-URL for later per-hole backfill
     created_at = Column(String)
     updated_at = Column(String)
 

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -1144,6 +1144,11 @@ async def backfill_scorecard(
     if record:
         db.query(models.GamePlayerResult).filter(models.GamePlayerResult.game_record_id == record.id).delete()
         db.flush()
+        # Update the GameRecord summary so final_scores / total_holes_played are
+        # not stale after the backfill (persist_completed_game only sets these on
+        # initial creation, never on update).
+        record.final_scores = standings
+        record.total_holes_played = len(hole_history)
     persist_completed_game(db, game)
     db.commit()
     return {"game_id": game_id, "standings": standings}

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -1,10 +1,11 @@
 """Game lifecycle routes — create, join, lobby, start, list, delete, complete, state, action, history, details."""
 
+import base64
 import logging
 import traceback
 from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
@@ -1104,3 +1105,23 @@ async def get_game_details(game_id: str, db: Session = Depends(database.get_db))
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error retrieving game details: {e!s}")
+
+
+@router.get("/{game_id}/scorecard-photo")
+async def get_scorecard_photo(game_id: str, db: Session = Depends(database.get_db)) -> Response:
+    """Return the stored scorecard photo for a scanned round (for later per-hole backfill)."""
+    game = db.query(models.GameStateModel).filter(models.GameStateModel.game_id == game_id).first()
+    if not game or not game.scorecard_image:
+        raise HTTPException(status_code=404, detail="No scorecard photo for this round")
+    raw = game.scorecard_image
+    media_type = "image/jpeg"
+    if raw.startswith("data:"):
+        header, _, b64 = raw.partition(",")
+        media_type = header[5:].split(";", 1)[0] or media_type
+    else:
+        b64 = raw
+    try:
+        content = base64.b64decode(b64)
+    except Exception:
+        raise HTTPException(status_code=404, detail="Stored photo is unreadable")
+    return Response(content=content, media_type=media_type)

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -233,6 +233,7 @@ class ScorecardRoundRequest(BaseModel):
     per_hole_quarters: list[ScorecardRoundHoleQuarter]
     course_name: str | None = None
     played_at: str | None = None
+    image_base64: str | None = None
 
 
 @router.post("/from-scorecard")
@@ -309,6 +310,9 @@ async def create_round_from_scorecard(
             created_at=created_at,
             updated_at=now,
         )
+        # Attach the photo for later per-hole backfill (best-effort; oversize ignored).
+        if body.image_base64 and len(body.image_base64) <= 2_000_000:
+            game.scorecard_image = body.image_base64
         db.add(game)
         db.flush()
         persist_completed_game(db, game)

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -1107,6 +1107,48 @@ async def get_game_details(game_id: str, db: Session = Depends(database.get_db))
         raise HTTPException(status_code=500, detail=f"Error retrieving game details: {e!s}")
 
 
+class ScorecardBackfillRequest(BaseModel):
+    per_hole_quarters: list[ScorecardRoundHoleQuarter]
+
+
+@router.patch("/{game_id}/scorecard")
+async def backfill_scorecard(
+    game_id: str,
+    body: ScorecardBackfillRequest,
+    db: Session = Depends(database.get_db),
+) -> dict[str, Any]:
+    """Backfill the per-hole quarters of a scanned round and recompute standings.
+    Standings come out as the sum of the submitted per-hole (settle-up identity)."""
+    from ..services.completed_game_service import build_hole_history, persist_completed_game
+
+    game = db.query(models.GameStateModel).filter(models.GameStateModel.game_id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=404, detail="Round not found")
+    state = dict(game.state or {})
+    players = state.get("players", [])
+    n = len(players)
+    for q in body.per_hole_quarters:
+        if not (0 <= q.player_index < n) or not (1 <= q.hole <= 18):
+            raise HTTPException(status_code=400, detail="Invalid per_hole_quarters entry")
+
+    per_hole = [q.model_dump() for q in body.per_hole_quarters]
+    hole_history, standings = build_hole_history(players, per_hole)
+    state["hole_history"] = hole_history
+    state["hole_quarters"] = {str(e["hole"]): e["points_delta"] for e in hole_history}
+    state["standings"] = standings
+    game.state = state  # reassign top-level so MutableDict marks dirty
+    game.updated_at = utc_now().isoformat()
+
+    # Rebuild GamePlayerResult rows for this round so /details reflects the backfill.
+    record = db.query(models.GameRecord).filter(models.GameRecord.game_id == game_id).first()
+    if record:
+        db.query(models.GamePlayerResult).filter(models.GamePlayerResult.game_record_id == record.id).delete()
+        db.flush()
+    persist_completed_game(db, game)
+    db.commit()
+    return {"game_id": game_id, "standings": standings}
+
+
 @router.get("/{game_id}/scorecard-photo")
 async def get_scorecard_photo(game_id: str, db: Session = Depends(database.get_db)) -> Response:
     """Return the stored scorecard photo for a scanned round (for later per-hole backfill)."""

--- a/backend/migrations/add_scorecard_image_postgres.sql
+++ b/backend/migrations/add_scorecard_image_postgres.sql
@@ -1,0 +1,1 @@
+ALTER TABLE game_state ADD COLUMN IF NOT EXISTS scorecard_image TEXT;

--- a/backend/tests/unit/routers/test_scorecard_photo.py
+++ b/backend/tests/unit/routers/test_scorecard_photo.py
@@ -1,0 +1,37 @@
+import base64
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app import models
+from app.database import SessionLocal, engine
+from app.main import app
+
+client = TestClient(app)
+
+
+def _make_round_with_image(image_b64: str | None) -> str:
+    models.Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        gid = str(uuid.uuid4())
+        g = models.GameStateModel(game_id=gid, game_status="completed", state={}, scorecard_image=image_b64)
+        db.merge(g)
+        db.commit()
+        return g.game_id
+    finally:
+        db.close()
+
+
+def test_get_scorecard_photo_returns_image_bytes():
+    raw = b"\xff\xd8\xff\xe0jpegbytes"
+    gid = _make_round_with_image("data:image/jpeg;base64," + base64.b64encode(raw).decode())
+    resp = client.get(f"/games/{gid}/scorecard-photo")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/")
+    assert resp.content == raw
+
+
+def test_get_scorecard_photo_404_when_none():
+    gid = _make_round_with_image(None)
+    assert client.get(f"/games/{gid}/scorecard-photo").status_code == 404

--- a/backend/tests/unit/routers/test_scorecard_photo.py
+++ b/backend/tests/unit/routers/test_scorecard_photo.py
@@ -40,17 +40,28 @@ def test_get_scorecard_photo_404_when_none():
 def test_patch_scorecard_recomputes_standings_from_new_per_hole():
     # create a round (totals-only: A +8 on hole 18, B -8)
     models.Base.metadata.create_all(bind=engine)
-    create = client.post("/games/from-scorecard", json={
-        "players": [{"name": "A"}, {"name": "B"}, {"name": "C"}, {"name": "D"}],
-        "per_hole_quarters": [{"player_index": i, "hole": 18, "quarters": q} for i, q in enumerate([8, -8, 4, -4])],
-    })
+    create = client.post(
+        "/games/from-scorecard",
+        json={
+            "players": [{"name": "A"}, {"name": "B"}, {"name": "C"}, {"name": "D"}],
+            "per_hole_quarters": [{"player_index": i, "hole": 18, "quarters": q} for i, q in enumerate([8, -8, 4, -4])],
+        },
+    )
     gid = create.json()["game_id"]
     # backfill: spread A's +8 across holes 1 and 2 (sum still 8) — standings unchanged
-    patch = client.patch(f"/games/{gid}/scorecard", json={"per_hole_quarters": [
-        {"player_index": 0, "hole": 1, "quarters": 5}, {"player_index": 0, "hole": 2, "quarters": 3},
-        {"player_index": 1, "hole": 1, "quarters": -5}, {"player_index": 1, "hole": 2, "quarters": -3},
-        {"player_index": 2, "hole": 1, "quarters": 4}, {"player_index": 3, "hole": 1, "quarters": -4},
-    ]})
+    patch = client.patch(
+        f"/games/{gid}/scorecard",
+        json={
+            "per_hole_quarters": [
+                {"player_index": 0, "hole": 1, "quarters": 5},
+                {"player_index": 0, "hole": 2, "quarters": 3},
+                {"player_index": 1, "hole": 1, "quarters": -5},
+                {"player_index": 1, "hole": 2, "quarters": -3},
+                {"player_index": 2, "hole": 1, "quarters": 4},
+                {"player_index": 3, "hole": 1, "quarters": -4},
+            ]
+        },
+    )
     assert patch.status_code == 200, patch.text
     db = SessionLocal()
     try:

--- a/backend/tests/unit/routers/test_scorecard_photo.py
+++ b/backend/tests/unit/routers/test_scorecard_photo.py
@@ -70,6 +70,19 @@ def test_patch_scorecard_recomputes_standings_from_new_per_hole():
         assert {e["hole"] for e in state["hole_history"]} == {1, 2}
         # standings preserved: A total +8
         assert state["standings"]["p1"] == 8
+
+        # I1 regression guard: GameRecord.final_scores must reflect the new standings
+        # after PATCH (not the stale initial values from before the backfill).
+        record = db.query(models.GameRecord).filter_by(game_id=gid).first()
+        assert record is not None, "GameRecord must exist after backfill"
+        assert record.final_scores is not None, "GameRecord.final_scores must be set"
+        assert record.final_scores.get("p1") == 8, (
+            f"GameRecord.final_scores['p1'] should be 8 after backfill, got {record.final_scores.get('p1')}"
+        )
+        # total_holes_played should match the number of holes in new hole_history (2)
+        assert record.total_holes_played == 2, (
+            f"GameRecord.total_holes_played should be 2 after backfill, got {record.total_holes_played}"
+        )
     finally:
         db.close()
 

--- a/backend/tests/unit/routers/test_scorecard_photo.py
+++ b/backend/tests/unit/routers/test_scorecard_photo.py
@@ -35,3 +35,33 @@ def test_get_scorecard_photo_returns_image_bytes():
 def test_get_scorecard_photo_404_when_none():
     gid = _make_round_with_image(None)
     assert client.get(f"/games/{gid}/scorecard-photo").status_code == 404
+
+
+def test_patch_scorecard_recomputes_standings_from_new_per_hole():
+    # create a round (totals-only: A +8 on hole 18, B -8)
+    models.Base.metadata.create_all(bind=engine)
+    create = client.post("/games/from-scorecard", json={
+        "players": [{"name": "A"}, {"name": "B"}, {"name": "C"}, {"name": "D"}],
+        "per_hole_quarters": [{"player_index": i, "hole": 18, "quarters": q} for i, q in enumerate([8, -8, 4, -4])],
+    })
+    gid = create.json()["game_id"]
+    # backfill: spread A's +8 across holes 1 and 2 (sum still 8) — standings unchanged
+    patch = client.patch(f"/games/{gid}/scorecard", json={"per_hole_quarters": [
+        {"player_index": 0, "hole": 1, "quarters": 5}, {"player_index": 0, "hole": 2, "quarters": 3},
+        {"player_index": 1, "hole": 1, "quarters": -5}, {"player_index": 1, "hole": 2, "quarters": -3},
+        {"player_index": 2, "hole": 1, "quarters": 4}, {"player_index": 3, "hole": 1, "quarters": -4},
+    ]})
+    assert patch.status_code == 200, patch.text
+    db = SessionLocal()
+    try:
+        state = db.query(models.GameStateModel).filter_by(game_id=gid).first().state
+        # hole_history now has holes 1 and 2 (not just 18)
+        assert {e["hole"] for e in state["hole_history"]} == {1, 2}
+        # standings preserved: A total +8
+        assert state["standings"]["p1"] == 8
+    finally:
+        db.close()
+
+
+def test_patch_scorecard_404_for_missing_round():
+    assert client.patch("/games/nope/scorecard", json={"per_hole_quarters": []}).status_code == 404

--- a/backend/tests/unit/routers/test_scorecard_round.py
+++ b/backend/tests/unit/routers/test_scorecard_round.py
@@ -192,3 +192,32 @@ def test_from_scorecard_rejects_bad_player_index():
     }
     resp = client.post("/games/from-scorecard", json=body)
     assert resp.status_code == 400
+
+
+def test_from_scorecard_stores_image_base64():
+    models.Base.metadata.create_all(bind=engine)
+    body = {
+        "players": [{"name": "A"}, {"name": "B"}, {"name": "C"}, {"name": "D"}],
+        "per_hole_quarters": _per_hole_4p(),
+        "image_base64": "data:image/jpeg;base64,SGVsbG8=",
+    }
+    game_id = client.post("/games/from-scorecard", json=body).json()["game_id"]
+    db = SessionLocal()
+    try:
+        row = db.query(models.GameStateModel).filter_by(game_id=game_id).first()
+        assert row.scorecard_image == "data:image/jpeg;base64,SGVsbG8="
+    finally:
+        db.close()
+
+
+def test_from_scorecard_ignores_oversize_image_but_still_saves():
+    models.Base.metadata.create_all(bind=engine)
+    body = {
+        "players": [{"name": "A"}, {"name": "B"}, {"name": "C"}, {"name": "D"}],
+        "per_hole_quarters": _per_hole_4p(),
+        "image_base64": "x" * (2_000_001),  # over the 2MB ceiling
+    }
+    resp = client.post("/games/from-scorecard", json=body)
+    assert resp.status_code == 200  # round still saved
+    row = SessionLocal().query(models.GameStateModel).filter_by(game_id=resp.json()["game_id"]).first()
+    assert row.scorecard_image is None

--- a/backend/tests/unit/test_models_scorecard_image.py
+++ b/backend/tests/unit/test_models_scorecard_image.py
@@ -1,0 +1,17 @@
+from app import models
+from app.database import SessionLocal, engine
+
+
+def test_game_state_has_scorecard_image_column():
+    models.Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        g = models.GameStateModel(game_id="img-col-test", game_status="completed", state={}, scorecard_image="data:image/jpeg;base64,AAAA")
+        db.add(g)
+        db.commit()
+        row = db.query(models.GameStateModel).filter_by(game_id="img-col-test").first()
+        assert row.scorecard_image == "data:image/jpeg;base64,AAAA"
+    finally:
+        db.query(models.GameStateModel).filter_by(game_id="img-col-test").delete()
+        db.commit()
+        db.close()

--- a/backend/tests/unit/test_models_scorecard_image.py
+++ b/backend/tests/unit/test_models_scorecard_image.py
@@ -6,7 +6,9 @@ def test_game_state_has_scorecard_image_column():
     models.Base.metadata.create_all(bind=engine)
     db = SessionLocal()
     try:
-        g = models.GameStateModel(game_id="img-col-test", game_status="completed", state={}, scorecard_image="data:image/jpeg;base64,AAAA")
+        g = models.GameStateModel(
+            game_id="img-col-test", game_status="completed", state={}, scorecard_image="data:image/jpeg;base64,AAAA"
+        )
         db.add(g)
         db.commit()
         row = db.query(models.GameStateModel).filter_by(game_id="img-col-test").first()

--- a/frontend/src/components/game/ScorecardBackfill.jsx
+++ b/frontend/src/components/game/ScorecardBackfill.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { computeHoleDeltas } from '../../utils/quarters';
-import ScorecardPhotoZoom from './ScorecardPhotoZoom';
+import ScorecardPhotoButton from './ScorecardPhotoButton';
 import { apiConfig } from '../../config/api.config';
 
 const API_URL = apiConfig.baseUrl;
@@ -54,7 +54,6 @@ function holeHistoryToRunningTotals(holeHistory, players) {
  *   players     — [{id, name}, ...] (order = player_index)
  *   holeHistory — [{hole, points_delta: {playerId: delta}}, ...]
  *   standings   — {playerId: signedTotal}
- *   photoUrl    — URL for the scorecard photo (or null)
  *   onSaved     — called after a successful PATCH
  *   onCancel    — called when the user cancels
  */
@@ -63,7 +62,6 @@ const ScorecardBackfill = ({
   players,
   holeHistory,
   standings,
-  photoUrl,
   onSaved,
   onCancel,
 }) => {
@@ -74,7 +72,6 @@ const ScorecardBackfill = ({
   );
 
   const [values, setValues] = useState(initialValues);
-  const [showPhoto, setShowPhoto] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(null);
 
@@ -143,15 +140,14 @@ const ScorecardBackfill = ({
     setSaving(true);
     setSaveError(null);
 
-    // Build per_hole_quarters from deltas — only nonzero entries needed
+    // Build per_hole_quarters: emit every hole 1-18 per player so the backend
+    // hole_history contains all 18 entries and allHolesPlayed() returns true
+    // even for no-op saves. Zero-delta holes are included (quarters: 0).
     const perHoleQuarters = [];
     for (let i = 0; i < players.length; i++) {
       const deltas = allDeltas[i] || {};
       for (const h of HOLES) {
-        const q = deltas[h];
-        if (q != null && q !== 0) {
-          perHoleQuarters.push({ player_index: i, hole: h, quarters: q });
-        }
+        perHoleQuarters.push({ player_index: i, hole: h, quarters: deltas[h] ?? 0 });
       }
     }
 
@@ -193,17 +189,8 @@ const ScorecardBackfill = ({
         (from the completed round) is shown per player.
       </p>
 
-      {/* Photo button */}
-      {photoUrl && (
-        <button
-          type="button"
-          onClick={() => setShowPhoto(true)}
-          className="self-start text-sm text-blue-600 hover:text-blue-800 underline"
-          aria-label="Open scorecard photo"
-        >
-          📷 Photo
-        </button>
-      )}
+      {/* Photo button — self-probing: renders nothing when no photo on server */}
+      <ScorecardPhotoButton gameId={gameId} />
 
       {/* Mismatch warnings (non-blocking) */}
       {mismatches.length > 0 && (
@@ -346,10 +333,6 @@ const ScorecardBackfill = ({
         </button>
       </div>
 
-      {/* Photo zoom overlay */}
-      {showPhoto && photoUrl && (
-        <ScorecardPhotoZoom src={photoUrl} onClose={() => setShowPhoto(false)} />
-      )}
     </div>
   );
 };
@@ -369,13 +352,8 @@ ScorecardBackfill.propTypes = {
     }),
   ).isRequired,
   standings: PropTypes.objectOf(PropTypes.number).isRequired,
-  photoUrl: PropTypes.string,
   onSaved: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-};
-
-ScorecardBackfill.defaultProps = {
-  photoUrl: null,
 };
 
 export default ScorecardBackfill;

--- a/frontend/src/components/game/ScorecardBackfill.jsx
+++ b/frontend/src/components/game/ScorecardBackfill.jsx
@@ -1,0 +1,381 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { computeHoleDeltas } from '../../utils/quarters';
+import ScorecardPhotoZoom from './ScorecardPhotoZoom';
+import { apiConfig } from '../../config/api.config';
+
+const API_URL = apiConfig.baseUrl;
+
+const HOLES = Array.from({ length: 18 }, (_, i) => i + 1);
+
+/**
+ * Convert hole_history deltas back to per-player running totals.
+ * hole_history entries: { hole, points_delta: { playerId: delta } }
+ * Returns a map: { "playerIdx-hole": runningTotal }
+ */
+function holeHistoryToRunningTotals(holeHistory, players) {
+  // Build cumulative running totals per player per hole
+  // First accumulate deltas per player per hole
+  const deltasByPlayerHole = {};
+  for (const entry of holeHistory) {
+    const hole = entry.hole;
+    const deltas = entry.points_delta || {};
+    for (let i = 0; i < players.length; i++) {
+      const playerId = players[i].id;
+      const delta = deltas[playerId] ?? 0;
+      const key = `${i}-${hole}`;
+      deltasByPlayerHole[key] = delta;
+    }
+  }
+
+  // Convert deltas to running totals
+  const running = {};
+  for (let i = 0; i < players.length; i++) {
+    let cumulative = 0;
+    for (const h of HOLES) {
+      const key = `${i}-${h}`;
+      const delta = deltasByPlayerHole[key];
+      if (delta != null) {
+        cumulative += delta;
+        running[key] = cumulative;
+      }
+      // holes not in history are left blank (undefined)
+    }
+  }
+  return running;
+}
+
+/**
+ * ScorecardBackfill — editable per-hole running-total grid for backfilling
+ * hole-by-hole quarter details on a completed round.
+ *
+ * Props:
+ *   gameId      — game identifier
+ *   players     — [{id, name}, ...] (order = player_index)
+ *   holeHistory — [{hole, points_delta: {playerId: delta}}, ...]
+ *   standings   — {playerId: signedTotal}
+ *   photoUrl    — URL for the scorecard photo (or null)
+ *   onSaved     — called after a successful PATCH
+ *   onCancel    — called when the user cancels
+ */
+const ScorecardBackfill = ({
+  gameId,
+  players,
+  holeHistory,
+  standings,
+  photoUrl,
+  onSaved,
+  onCancel,
+}) => {
+  // Pre-fill running totals from existing hole_history
+  const initialValues = useMemo(
+    () => holeHistoryToRunningTotals(holeHistory, players),
+    [holeHistory, players],
+  );
+
+  const [values, setValues] = useState(initialValues);
+  const [showPhoto, setShowPhoto] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
+
+  const handleChange = useCallback((playerIdx, hole, raw) => {
+    const parsed = raw === '' ? undefined : Number(raw);
+    setValues((prev) => {
+      const next = { ...prev };
+      const key = `${playerIdx}-${hole}`;
+      if (raw === '' || parsed == null || !Number.isFinite(parsed)) {
+        delete next[key];
+      } else {
+        next[key] = parsed;
+      }
+      return next;
+    });
+  }, []);
+
+  // Compute per-hole deltas for each player from the running-total grid
+  const allDeltas = useMemo(() => {
+    const result = {};
+    for (let i = 0; i < players.length; i++) {
+      const totalsArr = [];
+      for (const h of HOLES) {
+        const v = values[`${i}-${h}`];
+        if (v != null) totalsArr.push({ hole: h, value: v });
+      }
+      result[i] = computeHoleDeltas(totalsArr);
+    }
+    return result;
+  }, [values, players.length]);
+
+  // Per-player final running total (last entered cell)
+  const playerFinalTotals = useMemo(() => {
+    const finals = {};
+    for (let i = 0; i < players.length; i++) {
+      let last = null;
+      for (const h of HOLES) {
+        const v = values[`${i}-${h}`];
+        if (v != null) last = v;
+      }
+      finals[i] = last;
+    }
+    return finals;
+  }, [values]);
+
+  // Mismatch: player's entered final total doesn't match their locked standing
+  const mismatches = useMemo(() => {
+    return players
+      .map((player, i) => {
+        const locked = standings[player.id];
+        const entered = playerFinalTotals[i];
+        if (entered == null) return null; // nothing entered yet — no warning
+        if (entered !== locked) {
+          return {
+            name: player.name,
+            entered,
+            locked,
+          };
+        }
+        return null;
+      })
+      .filter(Boolean);
+  }, [players, standings, playerFinalTotals]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveError(null);
+
+    // Build per_hole_quarters from deltas — only nonzero entries needed
+    const perHoleQuarters = [];
+    for (let i = 0; i < players.length; i++) {
+      const deltas = allDeltas[i] || {};
+      for (const h of HOLES) {
+        const q = deltas[h];
+        if (q != null && q !== 0) {
+          perHoleQuarters.push({ player_index: i, hole: h, quarters: q });
+        }
+      }
+    }
+
+    try {
+      const res = await fetch(`${API_URL}/games/${gameId}/scorecard`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ per_hole_quarters: perHoleQuarters }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Save failed: ${res.status} ${text}`);
+      }
+      onSaved();
+    } catch (err) {
+      setSaveError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-gray-900">Fill in hole-by-hole detail</h2>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-sm text-gray-400 hover:text-gray-600"
+        >
+          ✕ Cancel
+        </button>
+      </div>
+
+      <p className="text-sm text-gray-500">
+        Enter each player's <strong>running total</strong> through each hole. Per-hole
+        quarters are computed automatically. The <strong>locked final total</strong>{' '}
+        (from the completed round) is shown per player.
+      </p>
+
+      {/* Photo button */}
+      {photoUrl && (
+        <button
+          type="button"
+          onClick={() => setShowPhoto(true)}
+          className="self-start text-sm text-blue-600 hover:text-blue-800 underline"
+          aria-label="Open scorecard photo"
+        >
+          📷 Photo
+        </button>
+      )}
+
+      {/* Mismatch warnings (non-blocking) */}
+      {mismatches.length > 0 && (
+        <div className="bg-amber-50 border border-amber-300 rounded-lg p-3 text-sm text-amber-800">
+          ⚠️ The following players' entered running totals don't reach locked total:
+          {mismatches.map((m) => (
+            <div key={m.name} className="ml-2 mt-1 font-semibold">
+              {m.name}: entered {m.entered}, locked {m.locked}
+            </div>
+          ))}
+          <div className="mt-1 text-amber-700">You can still save — this is a warning only.</div>
+        </div>
+      )}
+
+      {/* Save error */}
+      {saveError && (
+        <div className="bg-red-50 border border-red-300 rounded-lg p-3 text-sm text-red-700">
+          {saveError}
+        </div>
+      )}
+
+      {/* Per-hole grid */}
+      <div className="overflow-x-auto">
+        <table className="text-sm border-collapse min-w-full">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="sticky left-0 bg-gray-100 px-2 py-2 text-left font-semibold text-gray-600 min-w-[100px]">
+                Player
+              </th>
+              <th className="px-2 py-2 text-center font-semibold text-gray-600 min-w-[60px]">
+                Locked
+              </th>
+              {HOLES.map((h) => (
+                <th
+                  key={h}
+                  className="px-1 py-2 text-center font-semibold text-gray-600 w-10"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((player, i) => {
+              const locked = standings[player.id];
+              const finalEntered = playerFinalTotals[i];
+              const mismatch =
+                finalEntered != null && finalEntered !== locked;
+
+              return (
+                <React.Fragment key={player.id}>
+                  {/* Running total row — editable */}
+                  <tr className="border-t border-gray-200">
+                    <td
+                      className="sticky left-0 bg-white px-2 py-1 font-medium text-gray-800"
+                      rowSpan={2}
+                    >
+                      <div>{player.name}</div>
+                      <div
+                        className={`text-xs font-semibold mt-0.5 ${
+                          mismatch ? 'text-amber-600' : 'text-gray-500'
+                        }`}
+                      >
+                        Locked: {locked != null ? locked : '—'}
+                      </div>
+                    </td>
+                    <td className="px-2 py-1 text-center text-xs text-gray-400 whitespace-nowrap">
+                      Running total
+                    </td>
+                    {HOLES.map((h) => {
+                      const key = `${i}-${h}`;
+                      const val = values[key];
+                      return (
+                        <td key={h} className="px-1 py-1">
+                          <input
+                            type="number"
+                            value={val ?? ''}
+                            onChange={(e) => handleChange(i, h, e.target.value)}
+                            className="w-10 text-center text-sm border border-gray-300 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                            placeholder="—"
+                            aria-label={`running total ${player.name} hole ${h}`}
+                          />
+                        </td>
+                      );
+                    })}
+                  </tr>
+                  {/* Per-hole delta row — read-only */}
+                  <tr className="border-b border-gray-200 bg-gray-50">
+                    <td className="px-2 py-1 text-xs text-gray-400 whitespace-nowrap">
+                      Per-hole Δ
+                    </td>
+                    {HOLES.map((h) => {
+                      const delta = allDeltas[i]?.[h];
+                      return (
+                        <td
+                          key={h}
+                          className={`px-1 py-1 text-center text-xs font-mono font-semibold ${
+                            delta == null
+                              ? 'text-gray-300'
+                              : delta > 0
+                              ? 'text-green-600'
+                              : delta < 0
+                              ? 'text-red-600'
+                              : 'text-gray-400'
+                          }`}
+                        >
+                          {delta != null
+                            ? delta > 0
+                              ? `+${delta}`
+                              : delta
+                            : '—'}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="flex-1 py-3 bg-green-600 text-white rounded-xl font-semibold hover:bg-green-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          aria-label="Save hole detail"
+        >
+          {saving ? 'Saving…' : '✅ Save hole detail'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="py-3 px-6 bg-gray-100 text-gray-700 rounded-xl font-semibold hover:bg-gray-200 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {/* Photo zoom overlay */}
+      {showPhoto && photoUrl && (
+        <ScorecardPhotoZoom src={photoUrl} onClose={() => setShowPhoto(false)} />
+      )}
+    </div>
+  );
+};
+
+ScorecardBackfill.propTypes = {
+  gameId: PropTypes.string.isRequired,
+  players: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  holeHistory: PropTypes.arrayOf(
+    PropTypes.shape({
+      hole: PropTypes.number.isRequired,
+      points_delta: PropTypes.objectOf(PropTypes.number),
+    }),
+  ).isRequired,
+  standings: PropTypes.objectOf(PropTypes.number).isRequired,
+  photoUrl: PropTypes.string,
+  onSaved: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+ScorecardBackfill.defaultProps = {
+  photoUrl: null,
+};
+
+export default ScorecardBackfill;

--- a/frontend/src/components/game/ScorecardPhoto.jsx
+++ b/frontend/src/components/game/ScorecardPhoto.jsx
@@ -3,7 +3,7 @@ import ScorecardCapture from './ScorecardCapture';
 import ScorecardReview from './ScorecardReview';
 import GHINPostModal from './GHINPostModal';
 import { apiConfig } from '../../config/api.config';
-import { preprocessScorecardImage } from '../../utils/scorecardImage';
+import { preprocessScorecardImage, downscaleToBase64 } from '../../utils/scorecardImage';
 
 const API_URL = apiConfig.baseUrl;
 
@@ -46,6 +46,7 @@ const ScorecardPhoto = ({
   const [errorMsg, setErrorMsg] = useState(null);
   const [photoUrl, setPhotoUrl] = useState(null);
   const photoUrlRef = useRef(null);
+  const photoB64Ref = useRef(null);
   // Free the retained object URL when this flow unmounts.
   useEffect(() => () => { if (photoUrlRef.current) URL.revokeObjectURL(photoUrlRef.current); }, []);
 
@@ -69,6 +70,7 @@ const ScorecardPhoto = ({
     } catch {
       // no object URL support in this context — proceed without in-app photo zoom
     }
+    downscaleToBase64(file, 1200).then((b64) => { photoB64Ref.current = b64; }).catch(() => {});
 
     // Auto-orient via EXIF and downscale oversized phone shots before
     // upload — much cleaner input for the vision model and ~5–10x less
@@ -114,7 +116,7 @@ const ScorecardPhoto = ({
         const res = await fetch(`${API_URL}/games/from-scorecard`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ...payload, course_name: 'Wing Point' }),
+          body: JSON.stringify({ ...payload, course_name: 'Wing Point', image_base64: photoB64Ref.current || undefined }),
         });
         if (!res.ok) {
           const detail = await res.json().catch(() => ({}));

--- a/frontend/src/components/game/ScorecardPhotoButton.jsx
+++ b/frontend/src/components/game/ScorecardPhotoButton.jsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { apiConfig } from '../../config/api.config';
+import ScorecardPhotoZoom from './ScorecardPhotoZoom';
+
+const API_URL = apiConfig.baseUrl;
+
+/**
+ * ScorecardPhotoButton — shows a "📷 Photo" button when the saved round has a
+ * scorecard photo on the server. Clicking opens the full-screen zoom overlay.
+ * Renders nothing when the photo endpoint returns a non-OK response.
+ */
+const ScorecardPhotoButton = ({ gameId }) => {
+  const [hasPhoto, setHasPhoto] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!gameId) return;
+    fetch(`${API_URL}/games/${gameId}/scorecard-photo`)
+      .then((res) => setHasPhoto(res.ok))
+      .catch(() => setHasPhoto(false));
+  }, [gameId]);
+
+  if (!hasPhoto) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        style={{
+          padding: '12px 24px',
+          fontSize: '16px',
+          fontWeight: 'bold',
+          borderRadius: '8px',
+          border: '2px solid #1976d2',
+          background: 'white',
+          color: '#1976d2',
+          cursor: 'pointer',
+          transition: 'all 0.2s',
+        }}
+      >
+        📷 Photo
+      </button>
+      {isOpen && (
+        <ScorecardPhotoZoom
+          src={`${API_URL}/games/${gameId}/scorecard-photo`}
+          onClose={() => setIsOpen(false)}
+        />
+      )}
+    </>
+  );
+};
+
+ScorecardPhotoButton.propTypes = {
+  gameId: PropTypes.string.isRequired,
+};
+
+export default ScorecardPhotoButton;

--- a/frontend/src/components/game/ScorecardReview.jsx
+++ b/frontend/src/components/game/ScorecardReview.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { flipSign, parseQuarter } from '../../utils/quarters';
+import { flipSign, parseQuarter, computeHoleDeltas } from '../../utils/quarters';
 import ScorecardPhotoZoom from './ScorecardPhotoZoom';
 
 /**
@@ -10,24 +10,13 @@ import ScorecardPhotoZoom from './ScorecardPhotoZoom';
  * Zero-sum validation highlights unbalanced holes.
  */
 
+// computeDeltas extracted to utils/quarters as computeHoleDeltas
+
 const CONFIDENCE_STYLE = (confidence) => {
   if (confidence == null) return 'border-red-400 bg-red-50';
   if (confidence >= 0.85) return 'border-gray-300';
   if (confidence >= 0.50) return 'border-yellow-400 bg-yellow-50';
   return 'border-red-400 bg-red-50';
-};
-
-const computeDeltas = (runningTotals) => {
-  // runningTotals: array of { hole, value } sorted by hole
-  const sorted = [...runningTotals].sort((a, b) => a.hole - b.hole);
-  const deltas = {};
-  let prev = 0;
-  for (const { hole, value } of sorted) {
-    const v = value ?? 0;
-    deltas[hole] = v - prev;
-    prev = v;
-  }
-  return deltas;
 };
 
 const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
@@ -142,7 +131,7 @@ const ScorecardReview = ({ extraction, players, onConfirm, onCancel, mode = 'att
         const val = values[`${pi}-${h}`];
         if (val !== '' && val != null) totals.push({ hole: h, value: val });
       }
-      result[pi] = computeDeltas(totals);
+      result[pi] = computeHoleDeltas(totals);
     }
     return result;
   }, [values, extractedPlayers.length]);

--- a/frontend/src/components/game/SimpleScorekeeper.jsx
+++ b/frontend/src/components/game/SimpleScorekeeper.jsx
@@ -13,6 +13,7 @@ import PropTypes from "prop-types";
 import { useTheme } from "../../theme/Provider";
 import { Input } from "../ui";
 import GameCompletionView from "./GameCompletionView";
+import ScorecardPhotoButton from "./ScorecardPhotoButton";
 import Scorecard from "./Scorecard";
 import ShotAnalysisWidget from "./ShotAnalysisWidget";
 import BettingOddsPanel from "../betting/BettingOddsPanel";
@@ -783,24 +784,27 @@ const SimpleScorekeeper = ({
   // Show completion view if game is complete and not in edit mode
   if (isGameComplete && !isEditingCompleteGame) {
     return (
-      <GameCompletionView
-        players={players}
-        playerStandings={playerStandings}
-        holeHistory={holeHistory}
-        onNewGame={() => {
-          // Reset to start a new game
-          window.location.reload();
-        }}
-        onEditScores={() => {
-          // Enter edit mode - set to hole 19 so ALL holes appear as "completed" and editable
-          setIsEditingCompleteGame(true);
-          setCurrentHole(19); // All holes 1-18 will show as completed (editable)
-        }}
-        onMarkComplete={handleMarkComplete}
-        isCompleted={isGameMarkedComplete}
-        courseHoles={courseData?.holes || []}
-        strokeAllocation={strokeAllocation}
-      />
+      <>
+        <GameCompletionView
+          players={players}
+          playerStandings={playerStandings}
+          holeHistory={holeHistory}
+          onNewGame={() => {
+            // Reset to start a new game
+            window.location.reload();
+          }}
+          onEditScores={() => {
+            // Enter edit mode - set to hole 19 so ALL holes appear as "completed" and editable
+            setIsEditingCompleteGame(true);
+            setCurrentHole(19); // All holes 1-18 will show as completed (editable)
+          }}
+          onMarkComplete={handleMarkComplete}
+          isCompleted={isGameMarkedComplete}
+          courseHoles={courseData?.holes || []}
+          strokeAllocation={strokeAllocation}
+        />
+        {gameId && <ScorecardPhotoButton gameId={gameId} />}
+      </>
     );
   }
 

--- a/frontend/src/components/game/__tests__/ScorecardBackfill.test.jsx
+++ b/frontend/src/components/game/__tests__/ScorecardBackfill.test.jsx
@@ -18,6 +18,16 @@ vi.mock('../ScorecardPhotoZoom', () => ({
   ),
 }));
 
+// Mock ScorecardPhotoButton — it is a self-probing component that fetches
+// /scorecard-photo internally. We control its rendered output per test.
+vi.mock('../ScorecardPhotoButton', () => ({
+  default: ({ gameId }) => (
+    <button aria-label="Open scorecard photo" data-testid={`photo-btn-${gameId}`}>
+      📷 Photo
+    </button>
+  ),
+}));
+
 const players = [
   { id: 'p1', name: 'Alice' },
   { id: 'p2', name: 'Bob' },
@@ -48,7 +58,6 @@ describe('ScorecardBackfill — money path', () => {
         players={players}
         holeHistory={holeHistory}
         standings={standings}
-        photoUrl="http://test-api/games/g1/scorecard-photo"
         onSaved={onSaved}
         onCancel={onCancel}
       />,
@@ -94,6 +103,16 @@ describe('ScorecardBackfill — money path', () => {
       .reduce((acc, q) => acc + q.quarters, 0);
     expect(p2Sum).toBe(-6);
 
+    // C1 regression guard: PATCH body must contain all 18 holes for each player
+    // so hole_history on the backend has full entries and allHolesPlayed() returns true.
+    const p1Holes = body.per_hole_quarters
+      .filter((q) => q.player_index === 0)
+      .map((q) => q.hole);
+    expect(p1Holes).toHaveLength(18);
+    for (let h = 1; h <= 18; h++) {
+      expect(p1Holes).toContain(h);
+    }
+
     expect(onSaved).toHaveBeenCalledTimes(1);
   });
 });
@@ -113,7 +132,6 @@ describe('ScorecardBackfill — mismatch warning', () => {
         players={players}
         holeHistory={holeHistory}
         standings={standings}
-        photoUrl={null}
         onSaved={onSaved}
         onCancel={() => {}}
       />,
@@ -137,37 +155,35 @@ describe('ScorecardBackfill — mismatch warning', () => {
 });
 
 describe('ScorecardBackfill — photo button', () => {
-  test('Photo button opens the zoom overlay when photoUrl is provided', () => {
+  test('ScorecardPhotoButton is always rendered (self-probing: it renders nothing on 404)', () => {
+    // The component always renders ScorecardPhotoButton; the button itself
+    // decides whether to show based on the /scorecard-photo endpoint response.
+    // Our mock always renders the button, confirming the component is present.
     render(
       <ScorecardBackfill
         gameId="g1"
         players={players}
         holeHistory={holeHistory}
         standings={standings}
-        photoUrl="http://test-api/games/g1/scorecard-photo"
         onSaved={() => {}}
         onCancel={() => {}}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: /photo/i }));
-    expect(screen.getByTestId('photo-zoom')).toBeTruthy();
-    expect(screen.getByAltText('scorecard-zoom').getAttribute('src')).toBe(
-      'http://test-api/games/g1/scorecard-photo',
-    );
+    // The mocked ScorecardPhotoButton renders with this data-testid
+    expect(screen.getByTestId('photo-btn-g1')).toBeTruthy();
   });
 
-  test('No photo button when photoUrl is null', () => {
+  test('ScorecardPhotoButton receives the correct gameId prop', () => {
     render(
       <ScorecardBackfill
-        gameId="g1"
+        gameId="round-xyz"
         players={players}
         holeHistory={holeHistory}
         standings={standings}
-        photoUrl={null}
         onSaved={() => {}}
         onCancel={() => {}}
       />,
     );
-    expect(screen.queryByRole('button', { name: /photo/i })).toBeNull();
+    expect(screen.getByTestId('photo-btn-round-xyz')).toBeTruthy();
   });
 });

--- a/frontend/src/components/game/__tests__/ScorecardBackfill.test.jsx
+++ b/frontend/src/components/game/__tests__/ScorecardBackfill.test.jsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ScorecardBackfill from '../ScorecardBackfill';
+
+// Mock api config
+vi.mock('../../../config/api.config', () => ({
+  apiConfig: { baseUrl: 'http://test-api' },
+}));
+
+// Mock ScorecardPhotoZoom so we can test without real CSS/scroll
+vi.mock('../ScorecardPhotoZoom', () => ({
+  default: ({ src, onClose }) => (
+    <div data-testid="photo-zoom">
+      <img alt="scorecard-zoom" src={src} />
+      <button onClick={onClose}>close zoom</button>
+    </div>
+  ),
+}));
+
+const players = [
+  { id: 'p1', name: 'Alice' },
+  { id: 'p2', name: 'Bob' },
+];
+const standings = { p1: 6, p2: -6 };
+// hole_history with no per-hole detail (totals-only, everything on hole 18)
+const holeHistory = [
+  { hole: 18, points_delta: { p1: 6, p2: -6 } },
+];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('ScorecardBackfill — money path', () => {
+  test('PATCH body per_hole_quarters sums to locked totals per player and calls onSaved', async () => {
+    const onSaved = vi.fn();
+    const onCancel = vi.fn();
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ game_id: 'g1', standings }),
+    });
+
+    render(
+      <ScorecardBackfill
+        gameId="g1"
+        players={players}
+        holeHistory={holeHistory}
+        standings={standings}
+        photoUrl="http://test-api/games/g1/scorecard-photo"
+        onSaved={onSaved}
+        onCancel={onCancel}
+      />,
+    );
+
+    // Verify the locked totals are shown (uses "Locked: 6" and "Locked: -6" text)
+    expect(screen.getAllByText(/Locked: 6/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Locked: -6/).length).toBeGreaterThan(0);
+
+    // Enter running totals for hole 18 only (simplest path: 1 nonzero delta each)
+    // p1 (row 0, Alice): running total at hole 18 = 6
+    // p2 (row 1, Bob): running total at hole 18 = -6
+    const aliceHole18 = screen.getByRole('spinbutton', {
+      name: /running total alice hole 18/i,
+    });
+    const bobHole18 = screen.getByRole('spinbutton', {
+      name: /running total bob hole 18/i,
+    });
+    fireEvent.change(aliceHole18, { target: { value: '6' } });
+    fireEvent.change(bobHole18, { target: { value: '-6' } });
+
+    // Save
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe('http://test-api/games/g1/scorecard');
+    expect(opts.method).toBe('PATCH');
+
+    const body = JSON.parse(opts.body);
+    expect(body).toHaveProperty('per_hole_quarters');
+
+    // p1 (player_index=0) quarters sum = 6
+    const p1Sum = body.per_hole_quarters
+      .filter((q) => q.player_index === 0)
+      .reduce((acc, q) => acc + q.quarters, 0);
+    expect(p1Sum).toBe(6);
+
+    // p2 (player_index=1) quarters sum = -6
+    const p2Sum = body.per_hole_quarters
+      .filter((q) => q.player_index === 1)
+      .reduce((acc, q) => acc + q.quarters, 0);
+    expect(p2Sum).toBe(-6);
+
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ScorecardBackfill — mismatch warning', () => {
+  test('shows amber warning when running totals do not reach locked total, but Save still works', async () => {
+    const onSaved = vi.fn();
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ game_id: 'g1', standings }),
+    });
+
+    render(
+      <ScorecardBackfill
+        gameId="g1"
+        players={players}
+        holeHistory={holeHistory}
+        standings={standings}
+        photoUrl={null}
+        onSaved={onSaved}
+        onCancel={() => {}}
+      />,
+    );
+
+    // Enter a wrong total for Alice (4 instead of 6) → mismatch
+    const aliceHole18 = screen.getByRole('spinbutton', {
+      name: /running total alice hole 18/i,
+    });
+    fireEvent.change(aliceHole18, { target: { value: '4' } });
+
+    // Warning should be visible (text is split across elements so query by test id via container)
+    const container = document.body;
+    expect(container.textContent).toMatch(/don't reach locked total|doesn't reach locked total/i);
+
+    // Save still fires (non-blocking)
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ScorecardBackfill — photo button', () => {
+  test('Photo button opens the zoom overlay when photoUrl is provided', () => {
+    render(
+      <ScorecardBackfill
+        gameId="g1"
+        players={players}
+        holeHistory={holeHistory}
+        standings={standings}
+        photoUrl="http://test-api/games/g1/scorecard-photo"
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /photo/i }));
+    expect(screen.getByTestId('photo-zoom')).toBeTruthy();
+    expect(screen.getByAltText('scorecard-zoom').getAttribute('src')).toBe(
+      'http://test-api/games/g1/scorecard-photo',
+    );
+  });
+
+  test('No photo button when photoUrl is null', () => {
+    render(
+      <ScorecardBackfill
+        gameId="g1"
+        players={players}
+        holeHistory={holeHistory}
+        standings={standings}
+        photoUrl={null}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /photo/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx
+++ b/frontend/src/components/game/__tests__/ScorecardPhoto.players.test.jsx
@@ -6,8 +6,11 @@ import ScorecardPhoto from '../ScorecardPhoto';
 vi.mock('../ScorecardCapture', () => ({
   default: ({ onCapture }) => <button onClick={() => onCapture(new File(['x'], 'c.jpg', { type: 'image/jpeg' }))}>capture</button>,
 }));
-vi.mock('../ScorecardReview', () => ({ default: () => <div data-testid="review" /> }));
-vi.mock('../../../utils/scorecardImage', () => ({ preprocessScorecardImage: async (f) => f }));
+vi.mock('../ScorecardReview', () => ({ default: ({ onConfirm }) => <button onClick={() => onConfirm({})}>confirm</button> }));
+vi.mock('../../../utils/scorecardImage', () => ({
+  preprocessScorecardImage: async (f) => f,
+  downscaleToBase64: async () => 'data:image/jpeg;base64,QQ==',
+}));
 
 beforeEach(() => {
   global.fetch = vi.fn(async () => ({
@@ -24,4 +27,29 @@ test('new-round scan posts the picked players as a form field', async () => {
   await waitFor(() => expect(global.fetch).toHaveBeenCalled());
   const body = global.fetch.mock.calls[0][1].body; // FormData
   expect(body.get('players')).toBe('["CK","SS","SG"]');
+});
+
+test('new-round save includes image_base64 in the from-scorecard POST', async () => {
+  render(
+    <ScorecardPhoto mode="new-round" pickedPlayers={[]} rosterNames={[]} players={[]} onSaved={() => {}} onCancel={() => {}} />,
+  );
+  // Trigger capture → scan
+  screen.getByText('capture').click();
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+  // Reset fetch so we can detect the save call separately
+  global.fetch.mockClear();
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ id: 'round-1' }),
+  }));
+
+  // Confirm the review to trigger the from-scorecard save
+  screen.getByText('confirm').click();
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+  const [url, opts] = global.fetch.mock.calls[0];
+  expect(url).toMatch(/games\/from-scorecard/);
+  const sentBody = JSON.parse(opts.body);
+  expect(sentBody.image_base64).toBe('data:image/jpeg;base64,QQ==');
 });

--- a/frontend/src/components/game/__tests__/ScorecardPhotoButton.test.jsx
+++ b/frontend/src/components/game/__tests__/ScorecardPhotoButton.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ScorecardPhotoButton from '../ScorecardPhotoButton';
+
+// Mock the api config so the component does not need a live server
+vi.mock('../../../config/api.config', () => ({
+  apiConfig: { baseUrl: 'http://test-api' },
+}));
+
+// Mock the zoom overlay so we can assert it renders without needing CSS/scroll
+vi.mock('../ScorecardPhotoZoom', () => ({
+  default: ({ src, onClose }) => (
+    <div>
+      <img alt="scorecard" src={src} />
+      <button onClick={onClose}>close</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('ScorecardPhotoButton', () => {
+  test('shows Photo button and opens overlay when fetch returns ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
+
+    render(<ScorecardPhotoButton gameId="game-123" />);
+
+    // Button should appear after fetch resolves
+    const btn = await screen.findByRole('button', { name: /photo/i });
+    expect(btn).toBeTruthy();
+
+    // Clicking the button opens the zoom overlay
+    fireEvent.click(btn);
+    expect(screen.getByAltText('scorecard')).toBeTruthy();
+
+    // The overlay src points at the scorecard-photo endpoint
+    expect(screen.getByAltText('scorecard').getAttribute('src')).toBe(
+      'http://test-api/games/game-123/scorecard-photo',
+    );
+  });
+
+  test('renders nothing when fetch returns 404 (not ok)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+    render(<ScorecardPhotoButton gameId="game-404" />);
+
+    // Wait for the fetch promise to settle
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByRole('button', { name: /photo/i })).toBeNull();
+  });
+
+  test('renders nothing when fetch rejects (network error)', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    render(<ScorecardPhotoButton gameId="game-err" />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByRole('button', { name: /photo/i })).toBeNull();
+  });
+});

--- a/frontend/src/pages/PlayerProfilePage.jsx
+++ b/frontend/src/pages/PlayerProfilePage.jsx
@@ -83,7 +83,7 @@ const PlayerProfilePage = () => {
     );
   }
 
-  const { name, handicap, description, last_played, created_at, available_days, match_history, badges, stats } = profile;
+  const { name, handicap, description, avatar_url, last_played, created_at, available_days, match_history, badges, stats } = profile;
 
   return (
     <div style={{ maxWidth: 640, margin: '0 auto', padding: '20px 16px' }}>
@@ -91,14 +91,25 @@ const PlayerProfilePage = () => {
       {/* Header card */}
       <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 16, padding: 24, marginBottom: 16 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-          <div style={{
-            width: 64, height: 64, borderRadius: '50%',
-            background: '#f0fdf4', border: '2px solid #10b981',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: 28, flexShrink: 0,
-          }}>
-            🏌️
-          </div>
+          {avatar_url ? (
+            <img
+              src={avatar_url}
+              alt={name}
+              style={{
+                width: 64, height: 64, borderRadius: '50%',
+                objectFit: 'cover', border: '2px solid #10b981', flexShrink: 0,
+              }}
+            />
+          ) : (
+            <div style={{
+              width: 64, height: 64, borderRadius: '50%',
+              background: '#f0fdf4', border: '2px solid #10b981',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 28, flexShrink: 0,
+            }}>
+              🏌️
+            </div>
+          )}
           <div style={{ flex: 1, minWidth: 0 }}>
             <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: '#1f2937' }}>{name}</h1>
             <div style={{ display: 'flex', gap: 12, marginTop: 6, flexWrap: 'wrap', alignItems: 'center' }}>

--- a/frontend/src/pages/SimpleScorekeeperPage.jsx
+++ b/frontend/src/pages/SimpleScorekeeperPage.jsx
@@ -1,7 +1,8 @@
 // frontend/src/pages/SimpleScorekeeperPage.js
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { SimpleScorekeeper } from '../components/game';
+import ScorecardBackfill from '../components/game/ScorecardBackfill';
 import { Card } from '../components/ui';
 import { useTheme } from '../theme/Provider';
 import ErrorBoundary, { GameErrorFallback } from '../components/common/ErrorBoundary';
@@ -19,38 +20,40 @@ const SimpleScorekeeperPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [gameData, setGameData] = useState(null);
+  const [showBackfill, setShowBackfill] = useState(false);
+
+  const loadGame = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await fetch(`${API_URL}/games/${gameId}/state`);
+
+      if (!response.ok) {
+        throw new Error('Failed to load game');
+      }
+
+      const data = await response.json();
+      // Reconcile the local cache against server truth: flush unsynced edits,
+      // or heal a stale/duplicated cache by overwriting it with server state.
+      // Map GET /state (snake_case) into the local cache shape (camelCase).
+      syncManager.reconcileOnLoad(gameId, {
+        holeHistory: data.hole_history || [],
+        currentHole: data.current_hole,
+        playerStandings: data.standings || {},
+      });
+      setGameData(data);
+      setLoading(false);
+    } catch (err) {
+      console.error('Error loading game:', err);
+      setError(err.message);
+      setLoading(false);
+    }
+  }, [gameId]);
 
   useEffect(() => {
-    const loadGame = async () => {
-      try {
-        const response = await fetch(`${API_URL}/games/${gameId}/state`);
-
-        if (!response.ok) {
-          throw new Error('Failed to load game');
-        }
-
-        const data = await response.json();
-        // Reconcile the local cache against server truth: flush unsynced edits,
-        // or heal a stale/duplicated cache by overwriting it with server state.
-        // Map GET /state (snake_case) into the local cache shape (camelCase).
-        syncManager.reconcileOnLoad(gameId, {
-          holeHistory: data.hole_history || [],
-          currentHole: data.current_hole,
-          playerStandings: data.standings || {},
-        });
-        setGameData(data);
-        setLoading(false);
-      } catch (err) {
-        console.error('Error loading game:', err);
-        setError(err.message);
-        setLoading(false);
-      }
-    };
-
     if (gameId) {
       loadGame();
     }
-  }, [gameId]);
+  }, [gameId, loadGame]);
 
   if (loading) {
     return (
@@ -153,6 +156,28 @@ const SimpleScorekeeperPage = () => {
   const courseName = gameData.course_name || 'Wing Point Golf & Country Club';
   const baseWager = gameData.base_wager || 1;
 
+  const isCompleted = gameData.game_status === 'completed';
+
+  // "Fill in holes" backfill editor — only available for completed rounds
+  if (isCompleted && showBackfill) {
+    return (
+      <div style={{ padding: '20px', maxWidth: '800px', margin: '0 auto' }}>
+        <ScorecardBackfill
+          gameId={gameId}
+          players={players}
+          holeHistory={holeHistory}
+          standings={gameData.standings || {}}
+          photoUrl={`${API_URL}/games/${gameId}/scorecard-photo`}
+          onSaved={() => {
+            setShowBackfill(false);
+            loadGame();
+          }}
+          onCancel={() => setShowBackfill(false)}
+        />
+      </div>
+    );
+  }
+
   return (
     <ErrorBoundary FallbackComponent={GameErrorFallback}>
       <SimpleScorekeeper
@@ -164,6 +189,27 @@ const SimpleScorekeeperPage = () => {
         courseName={courseName}
         initialStrokeAllocation={strokeAllocation}
       />
+      {isCompleted && (
+        <div style={{ padding: '0 20px 20px', maxWidth: '800px', margin: '0 auto', textAlign: 'center' }}>
+          <button
+            type="button"
+            onClick={() => setShowBackfill(true)}
+            style={{
+              padding: '12px 24px',
+              fontSize: '16px',
+              fontWeight: 'bold',
+              borderRadius: '8px',
+              border: '2px solid #f59e0b',
+              background: 'white',
+              color: '#b45309',
+              cursor: 'pointer',
+              transition: 'all 0.2s',
+            }}
+          >
+            ✏️ Fill in holes
+          </button>
+        </div>
+      )}
     </ErrorBoundary>
   );
 };

--- a/frontend/src/pages/SimpleScorekeeperPage.jsx
+++ b/frontend/src/pages/SimpleScorekeeperPage.jsx
@@ -143,7 +143,9 @@ const SimpleScorekeeperPage = () => {
   }
 
   const players = gameData.players || [];
-  const currentHoleNumber = gameData.current_hole || 1;
+  // Completed games (including scorecard-scan rounds) have no current_hole in
+  // their state; use 19 so SimpleScorekeeper's isGameComplete gate fires.
+  const currentHoleNumber = gameData.current_hole || (gameData.game_status === 'completed' ? 19 : 1);
 
   // Get hole history and stroke allocation for SimpleScorekeeper
   const holeHistory = gameData.hole_history || [];

--- a/frontend/src/pages/SimpleScorekeeperPage.jsx
+++ b/frontend/src/pages/SimpleScorekeeperPage.jsx
@@ -167,7 +167,6 @@ const SimpleScorekeeperPage = () => {
           players={players}
           holeHistory={holeHistory}
           standings={gameData.standings || {}}
-          photoUrl={`${API_URL}/games/${gameId}/scorecard-photo`}
           onSaved={() => {
             setShowBackfill(false);
             loadGame();

--- a/frontend/src/utils/__tests__/scorecardImage.test.js
+++ b/frontend/src/utils/__tests__/scorecardImage.test.js
@@ -1,0 +1,9 @@
+import { test, expect, vi } from 'vitest';
+import { downscaleToBase64 } from '../scorecardImage';
+
+test('downscaleToBase64 returns null when canvas/bitmap unavailable (jsdom)', async () => {
+  // jsdom has no real canvas encoding; the helper must degrade to null, not throw.
+  const file = new File([new Uint8Array([1, 2, 3])], 'c.jpg', { type: 'image/jpeg' });
+  const out = await downscaleToBase64(file, 1200);
+  expect(out === null || typeof out === 'string').toBe(true);
+});

--- a/frontend/src/utils/quarters.js
+++ b/frontend/src/utils/quarters.js
@@ -79,3 +79,26 @@ export function isNegativeInput(raw) {
   if (typeof raw === "number") return raw < 0;
   return String(raw ?? "").trim().startsWith("-");
 }
+
+/**
+ * Convert an array of {hole, value} running totals into a per-hole delta map.
+ * The running total at hole N is the cumulative sum; the delta is the change
+ * from the previous hole (hole 1 has no predecessor so its delta = its value).
+ *
+ * Used by ScorecardReview (scorecard scan review) and ScorecardBackfill
+ * (post-round hole-by-hole backfill editor).
+ *
+ * @param {Array<{hole: number, value: number|null}>} runningTotals
+ * @returns {Object<number, number>} Map of hole number → per-hole delta
+ */
+export function computeHoleDeltas(runningTotals) {
+  const sorted = [...runningTotals].sort((a, b) => a.hole - b.hole);
+  const deltas = {};
+  let prev = 0;
+  for (const { hole, value } of sorted) {
+    const v = value ?? 0;
+    deltas[hole] = v - prev;
+    prev = v;
+  }
+  return deltas;
+}

--- a/frontend/src/utils/scorecardImage.js
+++ b/frontend/src/utils/scorecardImage.js
@@ -64,3 +64,33 @@ export async function preprocessScorecardImage(file) {
   const baseName = (file.name || "scorecard").replace(/\.\w+$/, "");
   return new File([blob], `${baseName}.jpg`, { type: "image/jpeg" });
 }
+
+export async function downscaleToBase64(file, maxDim = 1200) {
+  if (!file || typeof createImageBitmap !== "function") return null;
+  try {
+    let bitmap;
+    try {
+      bitmap = await createImageBitmap(file, { imageOrientation: "from-image" });
+    } catch {
+      bitmap = await createImageBitmap(file);
+    }
+    let { width, height } = bitmap;
+    const longest = Math.max(width, height);
+    if (longest > maxDim) {
+      const scale = maxDim / longest;
+      width = Math.round(width * scale);
+      height = Math.round(height * scale);
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) { bitmap.close?.(); return null; }
+    ctx.drawImage(bitmap, 0, 0, width, height);
+    bitmap.close?.();
+    const dataUrl = canvas.toDataURL("image/jpeg", 0.7);
+    return dataUrl && dataUrl.startsWith("data:image") ? dataUrl : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What & why

Persist the scanned scorecard **photo** on the saved round and let users **backfill the per-hole quarters later** (on any device), without changing the already-correct settle-up totals. This is "Part B" — the scan reliably reads final totals, this preserves the photo so the hole-by-hole detail can be filled in at home.

Design + plan: `docs/superpowers/specs/2026-06-21-scorecard-photo-persist-backfill-design.md` and the matching plan in `docs/superpowers/plans/`.

## Changes

**Backend**
- New `scorecard_image` (Text/base64) column on `game_state` + idempotent Postgres migration (`add_scorecard_image_postgres.sql`, applied at startup; SQLite dev via `create_all`).
- `POST /games/from-scorecard` accepts optional `image_base64` (≤2 MB; oversize/garbled → ignored, round still saves).
- `GET /games/{id}/scorecard-photo` → decoded image bytes (handles data-URL or raw base64) / 404. Keeps blobs out of `/state`.
- `PATCH /games/{id}/scorecard` → recompute `hole_history` + standings from submitted per-hole, refresh `GamePlayerResult` rows **and** `GameRecord.final_scores`/`total_holes_played`.

**Frontend**
- Save path downscales the captured photo (~1200px, best-effort) and sends it as `image_base64`.
- `ScorecardPhotoButton` — self-probing "📷 Photo" button on the completed-round view (fetches `/scorecard-photo`, hides on 404), reuses the existing zoom overlay.
- `ScorecardBackfill` — "✏️ Fill in holes" editor: per-hole running-total grid pre-filled from current `hole_history`, locked final totals with a **non-blocking** mismatch warning, photo zoom, Save → `PATCH`.
- Both wired into the completed view with a minimal page touch (standalone components — deliberately not coupling logic into the heavy `SimpleScorekeeperPage`).

## Money-safety

Standings = sum of per-hole quarters. The backfill emits **all 18 holes** (zeros included) so a no-op save can't collapse `hole_history` (which would otherwise hide the completed view), and the PATCH keeps `/history` and `/state` in agreement. Player↔index↔standings mapping verified consistent across save→state→backfill.

## How it was built

Subagent-driven: 7 TDD tasks, each spec+quality reviewed, then a whole-branch review on the most capable model. That review caught a **Critical** (backfill collapsing `hole_history` → completed rounds would vanish) and an **Important** (stale `GameRecord.final_scores` after a mismatched backfill), both fixed in `066520d` with regression tests.

## Test plan

- [x] Backend gate: `ruff check` + `ruff format --check` clean; **1535 passed** (`pytest`, only the documented Mac-SOCKS `startup_test` fails locally / passes in CI).
- [x] Frontend gate: `npm run typecheck` clean; **538 vitest passed**; `npm run build` clean.
- [ ] Manual E2E (post-deploy): scan a finished round with a photo → save → open it on another device → "📷 Photo" shows and zooms → "✏️ Fill in holes" → enter per-hole → Save → standings unchanged, photo still viewable.

This pull request and its description were written by Isaac.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload and store scorecard images when creating rounds
  * View scorecard photos from completed games
  * New "Fill in holes" editor to backfill per-hole data after game completion
  * Automatic image downscaling for storage efficiency

* **Tests**
  * Added comprehensive test coverage for scorecard features

* **Chores**
  * Database migration for scorecard image column support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->