### PR TITLE
chore(sync): cron to keep sheets→DB in sync

### DIFF
--- a/.github/workflows/sheet-sync.yml
+++ b/.github/workflows/sheet-sync.yml
@@ -1,0 +1,32 @@
+name: Sheet → DB Sync
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'  # every 2 hours (mirrors the in-process job that no-ops in prod)
+  workflow_dispatch:        # Allow manual trigger
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Sync Google Sheets rounds into legacy_rounds
+      run: |
+        echo "📋 Syncing sheet rounds into DB..."
+        RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+          "https://wolf-goat-pig.onrender.com/admin/spreadsheet/sync-legacy-rounds" \
+          -H "X-Admin-Email: stuagano@gmail.com" \
+          --max-time 120)
+
+        HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+        BODY=$(echo "$RESPONSE" | head -n -1)
+
+        echo "Status: $HTTP_CODE"
+        echo "Response: $BODY"
+
+        if [ "$HTTP_CODE" != "200" ]; then
+          echo "❌ Sync failed with status $HTTP_CODE"
+          exit 1
+        fi
+
+        echo "✅ Sheet → DB sync complete"

--- a/backend/app/services/spreadsheet_sync_service.py
+++ b/backend/app/services/spreadsheet_sync_service.py
@@ -2,8 +2,8 @@
 
 This service provides two-way sync between the Wolf Goat Pig app and the
 legacy Google Sheets dashboard at:
-- Primary (read-only): https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
-- Writable copy: https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM
+- Primary (read-only): https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM
+- Writable copy: https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
 
 Sheet Structure:
 - Dashboard: Leaderboard summary (auto-calculated from Details)


### PR DESCRIPTION
## What

Adds `.github/workflows/sheet-sync.yml` — a 2-hourly GitHub Actions cron that POSTs `/admin/spreadsheet/sync-legacy-rounds`, reading both Google Sheets (primary + writable copy) into the `legacy_rounds` DB table.

## Why

The in-process `email_scheduler._sync_legacy_rounds` job (meant to run every 2h) **does not fire in prod** — the vendored `schedule.py` shim shadows the real lib when prod runs with `rootDir=backend`. Result: `legacy_rounds` never got populated and `/admin/spreadsheet/leaderboard` returned `[]` despite 1241 rounds living in the sheets.

This is the same "scheduler is a no-op in prod → drive it from a GH Actions cron" pattern already used by `ghin-sync.yml` and `callout-list.yml`.

## Verified live

- `POST /admin/spreadsheet/sync-legacy-rounds` → `{"success": true, "rows_synced": 1243}`
- `/admin/spreadsheet/leaderboard` → went from `[]` to **62 entries**
- OAuth confirmed healthy (`oauth_status: configured`, `token_status: success`)

## Also in this PR

Fixes a stale module docstring in `spreadsheet_sync_service.py`: the primary/writable sheet IDs were swapped in the docstring (leftover from the `aaa3d19` constant swap). The code constants were already correct; this just aligns the docs.

## Notes

- The endpoint is guarded by the `X-Admin-Email` allowlist; the cron passes `stuagano@gmail.com`. Weak guard, fine for this — can switch to a `MONITOR_KEY`-style secret if preferred.
- Deliberately does **not** automate the primary→writable-copy reconcile: that endpoint is append-only and would re-create duplicates on any score correction.

This pull request and its description were written by Isaac.