### PR TITLE
feat(email): warmer welcome copy + admin diagnostic to send it

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -59,6 +59,29 @@ def get_email_config(x_admin_email: str = Header(None)):  # type: ignore
     }
 
 
+@router.post("/admin/test-welcome-email")
+def send_test_welcome_email(
+    to: str = Query(..., description="Recipient email for the sample welcome"),
+    name: str = Query(default="Golfer", description="Player name to greet"),
+    x_admin_email: str = Header(None),  # type: ignore
+):
+    """Send the welcome email to one address (admin only).
+
+    Diagnostic for proving the welcome path works end-to-end. Sends the real
+    template — does not create an account or seed preferences.
+    """
+    require_admin(x_admin_email)
+
+    email_service = get_email_service()
+    if not email_service.is_configured():
+        raise HTTPException(status_code=503, detail="Email service not configured")
+
+    ok = email_service.send_welcome_email(to_email=to, player_name=name)
+    if not ok:
+        raise HTTPException(status_code=500, detail="Email provider returned failure")
+    return {"sent": True, "to": to, "name": name, "template": "welcome_email"}
+
+
 @router.post("/admin/email-config")
 def update_email_config(config: dict[str, Any], x_admin_email: str = Header(None)):  # type: ignore
     """Update email configuration (admin only)"""

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -210,13 +210,18 @@ class EmailService:
         content = f"""
         <h2>Welcome to Wolf Goat Pig!</h2>
         <p>Hi {player_name},</p>
-        <p>Your account is all set &mdash; welcome to the league. Here's how it works:</p>
+        <p>Glad to have you in the group. Wolf Goat Pig is a Sunday tradition out
+        here, and your spot at the table is now official &mdash; no more chasing
+        the tee sheet or squinting at a spreadsheet to see where you stand.</p>
+        <p>Here's the short version of how it works:</p>
         <ul>
-            <li><strong>Sign up for play dates</strong> and we'll sync you to the tee sheet.</li>
-            <li><strong>Get matched &amp; paired</strong> &mdash; we'll email you when a group comes together.</li>
-            <li><strong>Track your games and standings</strong> right in the app.</li>
+            <li><strong>Sign up for a play date</strong> &mdash; you'll land right on the tee sheet, same as always.</li>
+            <li><strong>We'll match &amp; pair you</strong>, and email you the moment your group comes together.</li>
+            <li><strong>Scores, standings, and your running tally</strong> all live in the app.</li>
         </ul>
-        <p>See you on the course! &#127948;</p>
+        <p>Nothing to download and nothing to set up. Just sign up for the next
+        game and show up.</p>
+        <p>Welcome aboard &mdash; see you on the first tee. &#9971;</p>
         """
         template = Template(self._get_base_template())
         html_body = template.render(subject="Welcome to Wolf Goat Pig", content=content)
@@ -224,11 +229,15 @@ class EmailService:
         text_body = (
             f"Welcome to Wolf Goat Pig!\n\n"
             f"Hi {player_name},\n\n"
-            "Your account is all set - welcome to the league. Here's how it works:\n"
-            "- Sign up for play dates and we'll sync you to the tee sheet.\n"
-            "- Get matched & paired - we'll email you when a group comes together.\n"
-            "- Track your games and standings right in the app.\n\n"
-            "See you on the course!"
+            "Glad to have you in the group. Wolf Goat Pig is a Sunday tradition out "
+            "here, and your spot at the table is now official - no more chasing the "
+            "tee sheet or squinting at a spreadsheet to see where you stand.\n\n"
+            "Here's the short version of how it works:\n"
+            "- Sign up for a play date - you'll land right on the tee sheet, same as always.\n"
+            "- We'll match & pair you, and email you the moment your group comes together.\n"
+            "- Scores, standings, and your running tally all live in the app.\n\n"
+            "Nothing to download and nothing to set up. Just sign up for the next game and show up.\n\n"
+            "Welcome aboard - see you on the first tee!"
         )
 
         return self._send_email(


### PR DESCRIPTION
## What
- Rewrites the first-login **welcome email** with warmer, league-flavored copy (HTML + plaintext).
- Adds `POST /admin/test-welcome-email?to=<addr>&name=<name>` (admin-guarded) to send the real welcome template to a single address on demand — no account created, no preferences seeded. Same safe diagnostic pattern as `/callouts/test-email`.

## Test plan
- `ruff check` / `ruff format --check`: clean
- `pytest -k "welcome or email_service"`: 13 passed
- Post-merge: `POST /admin/test-welcome-email?to=stuagano@gmail.com&name=Stuart` → email lands

This pull request and its description were written by Isaac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added admin diagnostic endpoint to test welcome email delivery

* **Chores**
  - Improved welcome email template content with enhanced messaging and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->