### PR TITLE
fix(auth): recover from Missing Refresh Token & put score submission on the home page

### DIFF
--- a/frontend/src/components/rounds/PostRoundForm.jsx
+++ b/frontend/src/components/rounds/PostRoundForm.jsx
@@ -1,0 +1,487 @@
+import React, { useCallback, useMemo, useState } from "react";
+import LegacyNameSelector from "../auth/LegacyNameSelector";
+import { useLegacyPlayers } from "../../hooks/useLegacyPlayers";
+import { usePlayerProfile } from "../../hooks/usePlayerProfile";
+import { useAccessToken } from "../../hooks/useAccessToken";
+import { postMyRound } from "../../services/rounds";
+
+const todayLocalDate = () => {
+  const now = new Date();
+  const offsetMs = now.getTimezoneOffset() * 60000;
+  return new Date(now.getTime() - offsetMs).toISOString().slice(0, 10);
+};
+
+const FoursomePicker = ({ players, currentName, selectedNames, onChange }) => {
+  const availablePlayers = useMemo(
+    () => players.filter((name) => name && name !== currentName),
+    [players, currentName],
+  );
+
+  const togglePlayer = (name) => {
+    if (selectedNames.includes(name)) {
+      onChange(selectedNames.filter((selectedName) => selectedName !== name));
+      return;
+    }
+
+    if (selectedNames.length < 3) {
+      onChange([...selectedNames, name]);
+    }
+  };
+
+  return (
+    <div className="pr-foursome-picker">
+      <div className="pr-selected-foursome">
+        {selectedNames.length ? (
+          selectedNames.map((name) => (
+            <button type="button" key={name} onClick={() => togglePlayer(name)}>
+              {name} ×
+            </button>
+          ))
+        ) : (
+          <span className="pr-muted">Select 1-3 other members who played with you.</span>
+        )}
+      </div>
+      <div className="pr-player-grid" role="group" aria-label="Foursome members">
+        {availablePlayers.map((name) => {
+          const selected = selectedNames.includes(name);
+          return (
+            <button
+              type="button"
+              key={name}
+              className={selected ? "selected" : ""}
+              onClick={() => togglePlayer(name)}
+              disabled={!selected && selectedNames.length >= 3}
+            >
+              {name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Self-contained "post a Wolf-Goat-Pig round result" form.
+ *
+ * Handles legacy-name linking, foursome selection, and — critically — recovers
+ * from the "Missing Refresh Token" auth error: submission uses a resilient token
+ * getter, and if auth still can't be recovered the user gets an explicit
+ * "Try again" / "Sign in again" choice instead of a dead-end error.
+ *
+ * @param {object} props
+ * @param {() => void} [props.onPosted] - called after a round is posted (refresh lists)
+ * @param {boolean} [props.compact] - tighter layout for embedding (e.g. home page)
+ */
+const PostRoundForm = ({ onPosted, compact = false }) => {
+  const { getToken, reauthenticate, isRecoverableAuthError } = useAccessToken();
+  const {
+    profile,
+    loading: profileLoading,
+    error: profileError,
+    updateLegacyName,
+  } = usePlayerProfile();
+  const { players, loading: rosterLoading, error: rosterError } = useLegacyPlayers();
+
+  const [form, setForm] = useState({
+    date: todayLocalDate(),
+    score: "",
+    location: "",
+    group: "",
+    duration: "",
+    foursome: [],
+  });
+  const [submitState, setSubmitState] = useState({
+    loading: false,
+    error: "",
+    success: "",
+    canRetry: false,
+    needsReauth: false,
+  });
+  const [showLinkFlow, setShowLinkFlow] = useState(false);
+
+  const legacyName = profile?.legacy_name || "";
+
+  const updateForm = (field, value) => {
+    setForm((current) => ({ ...current, [field]: value }));
+  };
+
+  const submitRound = useCallback(async () => {
+    setSubmitState({ loading: true, error: "", success: "", canRetry: false, needsReauth: false });
+    setShowLinkFlow(false);
+
+    if (form.foursome.length < 1 || form.foursome.length > 3) {
+      setSubmitState({
+        loading: false,
+        error: "Select 1-3 other foursome members.",
+        success: "",
+        canRetry: false,
+        needsReauth: false,
+      });
+      return;
+    }
+
+    if (!String(form.score).trim() || Number.isNaN(Number(form.score))) {
+      setSubmitState({
+        loading: false,
+        error: "Enter WGP quarters won/lost as a number.",
+        success: "",
+        canRetry: false,
+        needsReauth: false,
+      });
+      return;
+    }
+
+    try {
+      await postMyRound(getToken, {
+        date: form.date,
+        score: Number(form.score),
+        location: form.location.trim() || undefined,
+        group: form.group.trim() || undefined,
+        duration: form.duration.trim() || undefined,
+        foursome: form.foursome,
+      });
+      setSubmitState({
+        loading: false,
+        error: "",
+        success: "Round posted for attestation.",
+        canRetry: false,
+        needsReauth: false,
+      });
+      setForm((current) => ({
+        ...current,
+        score: "",
+        location: "",
+        group: "",
+        duration: "",
+        foursome: [],
+      }));
+      if (onPosted) onPosted();
+    } catch (error) {
+      if (isRecoverableAuthError(error)) {
+        // Silent refresh + fallback both failed — the session needs a real login.
+        setSubmitState({
+          loading: false,
+          error: "Your sign-in expired. Try again, or sign in again to post your score.",
+          success: "",
+          canRetry: true,
+          needsReauth: true,
+        });
+        return;
+      }
+      const message = error.status === 409 ? "already posted for that date" : error.message;
+      setSubmitState({
+        loading: false,
+        error: message,
+        success: "",
+        canRetry: error.status !== 400,
+        needsReauth: false,
+      });
+      if (error.status === 400) {
+        setShowLinkFlow(true);
+      }
+    }
+  }, [form, getToken, isRecoverableAuthError, onPosted]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    submitRound();
+  };
+
+  const handleLegacySelect = async (name) => {
+    await updateLegacyName(name);
+    setShowLinkFlow(false);
+    setSubmitState({
+      loading: false,
+      error: "",
+      success: "Roster name linked. You can post your round now.",
+      canRetry: false,
+      needsReauth: false,
+    });
+  };
+
+  return (
+    <div className={`pr-form-root ${compact ? "compact" : ""}`}>
+      {profileLoading && <p className="pr-muted">Loading profile...</p>}
+      {profileError && <div className="pr-alert error">{profileError}</div>}
+      {legacyName && (
+        <p className="pr-linked-name">
+          Posting as <strong>{legacyName}</strong>
+        </p>
+      )}
+      {!legacyName && !profileLoading && (
+        <div className="pr-alert warning">Link your roster name before posting a round.</div>
+      )}
+
+      <form onSubmit={handleSubmit} className="pr-form">
+        <div className="pr-field-row">
+          <label>
+            Date
+            <input
+              type="date"
+              value={form.date}
+              onChange={(event) => updateForm("date", event.target.value)}
+              required
+            />
+          </label>
+
+          <label>
+            WGP quarters won/lost
+            <input
+              type="number"
+              step="1"
+              inputMode="numeric"
+              value={form.score}
+              onChange={(event) => updateForm("score", event.target.value)}
+              placeholder="Example: -3 or 8"
+              required
+            />
+          </label>
+        </div>
+
+        {!compact && (
+          <div className="pr-field-row">
+            <label>
+              Location <span>(optional)</span>
+              <input
+                type="text"
+                value={form.location}
+                onChange={(event) => updateForm("location", event.target.value)}
+                placeholder="Wing Point"
+              />
+            </label>
+
+            <label>
+              Group <span>(optional)</span>
+              <input
+                type="text"
+                value={form.group}
+                onChange={(event) => updateForm("group", event.target.value)}
+                placeholder="Morning game"
+              />
+            </label>
+
+            <label>
+              Duration <span>(optional)</span>
+              <input
+                type="text"
+                value={form.duration}
+                onChange={(event) => updateForm("duration", event.target.value)}
+                placeholder="18 holes"
+              />
+            </label>
+          </div>
+        )}
+
+        <div>
+          <label className="pr-standalone-label">Foursome members</label>
+          {rosterLoading ? (
+            <p className="pr-muted">Loading roster...</p>
+          ) : rosterError ? (
+            <div className="pr-alert error">{rosterError}</div>
+          ) : (
+            <FoursomePicker
+              players={players}
+              currentName={legacyName}
+              selectedNames={form.foursome}
+              onChange={(foursome) => updateForm("foursome", foursome)}
+            />
+          )}
+        </div>
+
+        {submitState.error && (
+          <div className="pr-alert error">
+            <p>{submitState.error}</p>
+            {(submitState.canRetry || submitState.needsReauth) && (
+              <div className="pr-alert-actions">
+                {submitState.canRetry && (
+                  <button type="button" onClick={submitRound} disabled={submitState.loading}>
+                    Try again
+                  </button>
+                )}
+                {submitState.needsReauth && (
+                  <button type="button" className="secondary" onClick={reauthenticate}>
+                    Sign in again
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+        {submitState.success && <div className="pr-alert success">{submitState.success}</div>}
+
+        <button type="submit" className="pr-submit" disabled={submitState.loading || rosterLoading}>
+          {submitState.loading ? "Posting..." : "Post Round"}
+        </button>
+      </form>
+
+      {(showLinkFlow || (!legacyName && !profileLoading)) && (
+        <div className="pr-link-flow">
+          <LegacyNameSelector
+            currentName={legacyName}
+            onSelect={handleLegacySelect}
+            onSkip={() => setShowLinkFlow(false)}
+          />
+        </div>
+      )}
+
+      <style>{`
+        .pr-form-root {
+          color: #1f2937;
+        }
+
+        .pr-form {
+          display: grid;
+          gap: 16px;
+          margin-top: 12px;
+        }
+
+        .pr-field-row {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+          gap: 16px;
+        }
+
+        .pr-form label,
+        .pr-standalone-label {
+          display: grid;
+          gap: 6px;
+          font-weight: 700;
+          color: #374151;
+        }
+
+        .pr-form label span {
+          font-weight: 500;
+          color: #6b7280;
+        }
+
+        .pr-form input {
+          border: 1px solid #d1d5db;
+          border-radius: 10px;
+          padding: 11px 12px;
+          font-size: 16px;
+        }
+
+        .pr-form input:focus {
+          outline: 2px solid #9acd7e;
+          border-color: #2d5a27;
+        }
+
+        .pr-submit,
+        .pr-alert button {
+          background: #2d5a27;
+          color: #ffffff;
+          border: none;
+          border-radius: 10px;
+          padding: 11px 16px;
+          font-weight: 700;
+          cursor: pointer;
+        }
+
+        .pr-alert button.secondary {
+          background: #ffffff;
+          color: #2d5a27;
+          border: 1px solid #2d5a27;
+        }
+
+        .pr-submit:disabled,
+        .pr-player-grid button:disabled,
+        .pr-alert button:disabled {
+          opacity: 0.55;
+          cursor: not-allowed;
+        }
+
+        .pr-linked-name {
+          color: #4b5563;
+        }
+
+        .pr-muted {
+          color: #6b7280;
+        }
+
+        .pr-alert {
+          border-radius: 10px;
+          padding: 12px 14px;
+          margin: 4px 0;
+        }
+
+        .pr-alert p {
+          margin: 0;
+        }
+
+        .pr-alert-actions {
+          display: flex;
+          gap: 10px;
+          margin-top: 10px;
+          flex-wrap: wrap;
+        }
+
+        .pr-alert.error {
+          background: #fee2e2;
+          color: #991b1b;
+          border: 1px solid #fecaca;
+        }
+
+        .pr-alert.warning {
+          background: #fef3c7;
+          color: #92400e;
+          border: 1px solid #fde68a;
+        }
+
+        .pr-alert.success {
+          background: #dcfce7;
+          color: #166534;
+          border: 1px solid #bbf7d0;
+        }
+
+        .pr-selected-foursome {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          min-height: 42px;
+          align-items: center;
+          margin: 8px 0 12px;
+        }
+
+        .pr-selected-foursome button,
+        .pr-player-grid button {
+          border: 1px solid #d1d5db;
+          border-radius: 999px;
+          background: #f9fafb;
+          color: #374151;
+          padding: 8px 12px;
+          cursor: pointer;
+        }
+
+        .pr-selected-foursome button,
+        .pr-player-grid button.selected {
+          background: #e7f5e4;
+          border-color: #2d5a27;
+          color: #1f3b1b;
+          font-weight: 700;
+        }
+
+        .pr-player-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+          gap: 8px;
+          max-height: 260px;
+          overflow: auto;
+          padding: 2px;
+        }
+
+        .pr-form-root.compact .pr-player-grid {
+          max-height: 180px;
+        }
+
+        .pr-link-flow {
+          margin-top: 20px;
+          border-top: 1px solid #e5e7eb;
+          padding-top: 20px;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default PostRoundForm;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -45,6 +45,9 @@ export const AuthProvider = ({ children }) => {
         }}
         cacheLocation="localstorage"
         useRefreshTokens={true}
+        // Fall back to a silent /authorize iframe when the cached refresh token
+        // is missing or expired, instead of throwing "Missing Refresh Token".
+        useRefreshTokensFallback={true}
       >
         <AuthContext.Provider value={value}>
           {children}

--- a/frontend/src/context/__tests__/AuthContext.test.jsx
+++ b/frontend/src/context/__tests__/AuthContext.test.jsx
@@ -38,4 +38,19 @@ describe('AuthProvider Auth0 configuration', () => {
       expect(capturedProps.authorizationParams.scope).toContain('offline_access');
     }
   });
+
+  test('enables the refresh-token fallback so a missing refresh token recovers via silent auth', () => {
+    render(
+      <AuthProvider>
+        <div>child</div>
+      </AuthProvider>,
+    );
+
+    expect(capturedProps).not.toBeNull();
+    // Without this, an expired/absent refresh token throws "Missing Refresh
+    // Token" with no recovery path instead of falling back to a silent iframe.
+    if (capturedProps.useRefreshTokens) {
+      expect(capturedProps.useRefreshTokensFallback).toBe(true);
+    }
+  });
 });

--- a/frontend/src/hooks/useAccessToken.js
+++ b/frontend/src/hooks/useAccessToken.js
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { acquireAccessToken, isRecoverableAuthError } from "../services/authToken";
+
+/**
+ * Provides a token getter that recovers from the "Missing Refresh Token" error
+ * (see services/authToken.js), plus a `reauthenticate` helper for the terminal
+ * case where even the silent fallback fails and the user must sign in again.
+ *
+ * Usage:
+ *   const { getToken, reauthenticate } = useAccessToken();
+ *   const token = await getToken();               // resilient
+ *   isRecoverableAuthError(err) && reauthenticate();
+ */
+export const useAccessToken = () => {
+  const { getAccessTokenSilently, loginWithRedirect } = useAuth0();
+
+  const getToken = useCallback(
+    () => acquireAccessToken(getAccessTokenSilently),
+    [getAccessTokenSilently],
+  );
+
+  const reauthenticate = useCallback(
+    () =>
+      loginWithRedirect({
+        // Send the user back to the page they were on after re-login.
+        appState: { returnTo: `${window.location.pathname}${window.location.search}` },
+      }),
+    [loginWithRedirect],
+  );
+
+  return { getToken, reauthenticate, isRecoverableAuthError };
+};
+
+export default useAccessToken;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { LoginButton, AuthHealthCheck } from '../components/auth';
 import StaleGameBanner from '../components/game/StaleGameBanner';
+import PostRoundForm from '../components/rounds/PostRoundForm';
 
 function HomePage() {
   const navigate = useNavigate();
@@ -203,6 +204,64 @@ function HomePage() {
           )}
         </div>
         
+        {/* Submit a Score - key capability, available right on the home page */}
+        {isAuthenticated && (
+          <div style={{
+            background: 'rgba(255, 255, 255, 0.98)',
+            borderRadius: '16px',
+            padding: '32px',
+            marginBottom: '30px',
+            boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.2)',
+            backdropFilter: 'blur(10px)',
+            border: '2px solid rgba(4, 120, 87, 0.3)'
+          }}>
+            <h3 style={{
+              fontSize: '2rem',
+              fontWeight: 'bold',
+              color: '#1F2937',
+              marginBottom: '8px',
+              textAlign: 'center'
+            }}>
+              📝 Submit a Score
+            </h3>
+            <p style={{
+              color: '#6B7280',
+              fontSize: '1.1rem',
+              textAlign: 'center',
+              marginBottom: '20px'
+            }}>
+              Post today's Wolf-Goat-Pig quarters right here — no extra navigation.
+            </p>
+            <PostRoundForm compact />
+            <div style={{ textAlign: 'center', marginTop: '16px' }}>
+              <button
+                onClick={() => navigate('/rounds/post')}
+                style={{
+                  padding: '10px 24px',
+                  background: 'transparent',
+                  color: '#047857',
+                  border: '1px solid #047857',
+                  borderRadius: '8px',
+                  fontSize: '14px',
+                  fontWeight: '600',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s'
+                }}
+                onMouseEnter={(e) => {
+                  e.target.style.background = '#047857';
+                  e.target.style.color = 'white';
+                }}
+                onMouseLeave={(e) => {
+                  e.target.style.background = 'transparent';
+                  e.target.style.color = '#047857';
+                }}
+              >
+                View my rounds &amp; attestation queue
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Player Sign-Up & Availability - Primary CTA */}
         <div style={{
           background: 'rgba(255, 255, 255, 0.98)',

--- a/frontend/src/pages/PostRoundPage.jsx
+++ b/frontend/src/pages/PostRoundPage.jsx
@@ -1,20 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useAuth0 } from "@auth0/auth0-react";
-import LegacyNameSelector from "../components/auth/LegacyNameSelector";
-import { useLegacyPlayers } from "../hooks/useLegacyPlayers";
-import { usePlayerProfile } from "../hooks/usePlayerProfile";
+import React, { useCallback, useEffect, useState } from "react";
+import PostRoundForm from "../components/rounds/PostRoundForm";
+import { useAccessToken } from "../hooks/useAccessToken";
 import {
   attestRound,
   fetchMyRounds,
   fetchPendingAttestations,
-  postMyRound,
 } from "../services/rounds";
-
-const todayLocalDate = () => {
-  const now = new Date();
-  const offsetMs = now.getTimezoneOffset() * 60000;
-  return new Date(now.getTime() - offsetMs).toISOString().slice(0, 10);
-};
 
 const statusLabel = (status) => (status === "attested" ? "Attested" : "Pending");
 
@@ -119,82 +110,15 @@ const AttestationQueue = ({ rounds, loading, error, attestingId, onAttest, onRef
   );
 };
 
-const FoursomePicker = ({ players, currentName, selectedNames, onChange }) => {
-  const availablePlayers = useMemo(
-    () => players.filter((name) => name && name !== currentName),
-    [players, currentName],
-  );
-
-  const togglePlayer = (name) => {
-    if (selectedNames.includes(name)) {
-      onChange(selectedNames.filter((selectedName) => selectedName !== name));
-      return;
-    }
-
-    if (selectedNames.length < 3) {
-      onChange([...selectedNames, name]);
-    }
-  };
-
-  return (
-    <div className="foursome-picker">
-      <div className="selected-foursome">
-        {selectedNames.length ? selectedNames.map((name) => (
-          <button type="button" key={name} onClick={() => togglePlayer(name)}>
-            {name} ×
-          </button>
-        )) : <span className="muted">Select 1-3 other members who played with you.</span>}
-      </div>
-      <div className="player-grid" role="group" aria-label="Foursome members">
-        {availablePlayers.map((name) => {
-          const selected = selectedNames.includes(name);
-          return (
-            <button
-              type="button"
-              key={name}
-              className={selected ? "selected" : ""}
-              onClick={() => togglePlayer(name)}
-              disabled={!selected && selectedNames.length >= 3}
-            >
-              {name}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-};
-
 const PostRoundPage = () => {
-  const { getAccessTokenSilently } = useAuth0();
-  const {
-    profile,
-    loading: profileLoading,
-    error: profileError,
-    updateLegacyName,
-  } = usePlayerProfile();
-  const { players, loading: rosterLoading, error: rosterError } = useLegacyPlayers();
+  const { getToken } = useAccessToken();
 
-  const [form, setForm] = useState({
-    date: todayLocalDate(),
-    score: "",
-    location: "",
-    group: "",
-    duration: "",
-    foursome: [],
-  });
-  const [submitState, setSubmitState] = useState({ loading: false, error: "", success: "" });
-  const [showLinkFlow, setShowLinkFlow] = useState(false);
   const [myRounds, setMyRounds] = useState([]);
   const [myRoundsState, setMyRoundsState] = useState({ loading: true, error: "" });
   const [pendingRounds, setPendingRounds] = useState([]);
   const [pendingState, setPendingState] = useState({ loading: true, error: "" });
   const [attestingId, setAttestingId] = useState(null);
   const [attestState, setAttestState] = useState({ error: "", success: "" });
-
-  const legacyName = profile?.legacy_name || "";
-
-  const getToken = useCallback(() => getAccessTokenSilently(), [getAccessTokenSilently]);
 
   const loadMyRounds = useCallback(async () => {
     setMyRoundsState({ loading: true, error: "" });
@@ -222,52 +146,6 @@ const PostRoundPage = () => {
     loadMyRounds();
     loadPendingRounds();
   }, [loadMyRounds, loadPendingRounds]);
-
-  const updateForm = (field, value) => {
-    setForm((current) => ({ ...current, [field]: value }));
-  };
-
-  const handleSubmit = async (event) => {
-    event.preventDefault();
-    setSubmitState({ loading: true, error: "", success: "" });
-    setShowLinkFlow(false);
-
-    if (form.foursome.length < 1 || form.foursome.length > 3) {
-      setSubmitState({ loading: false, error: "Select 1-3 other foursome members.", success: "" });
-      return;
-    }
-
-    if (!form.score.trim() || Number.isNaN(Number(form.score))) {
-      setSubmitState({ loading: false, error: "Enter WGP quarters won/lost as a number.", success: "" });
-      return;
-    }
-
-    try {
-      await postMyRound(getToken, {
-        date: form.date,
-        score: Number(form.score),
-        location: form.location.trim() || undefined,
-        group: form.group.trim() || undefined,
-        duration: form.duration.trim() || undefined,
-        foursome: form.foursome,
-      });
-      setSubmitState({ loading: false, error: "", success: "Round posted for attestation." });
-      setForm((current) => ({ ...current, score: "", location: "", group: "", duration: "", foursome: [] }));
-      loadMyRounds();
-    } catch (error) {
-      const message = error.status === 409 ? "already posted for that date" : error.message;
-      if (error.status === 400) {
-        setShowLinkFlow(true);
-      }
-      setSubmitState({ loading: false, error: message, success: "" });
-    }
-  };
-
-  const handleLegacySelect = async (name) => {
-    await updateLegacyName(name);
-    setShowLinkFlow(false);
-    setSubmitState({ loading: false, error: "", success: "Roster name linked. You can post your round now." });
-  };
 
   const handleAttest = async (roundId) => {
     setAttestingId(roundId);
@@ -298,99 +176,7 @@ const PostRoundPage = () => {
       <section className="round-layout">
         <div className="round-card">
           <h2>Round Result</h2>
-          {profileLoading && <p className="muted">Loading profile...</p>}
-          {profileError && <div className="round-alert error">{profileError}</div>}
-          {legacyName && <p className="linked-name">Posting as <strong>{legacyName}</strong></p>}
-          {!legacyName && !profileLoading && (
-            <div className="round-alert warning">Link your roster name before posting a round.</div>
-          )}
-          <form onSubmit={handleSubmit} className="round-form">
-            <label>
-              Date
-              <input
-                type="date"
-                value={form.date}
-                onChange={(event) => updateForm("date", event.target.value)}
-                required
-              />
-            </label>
-
-            <label>
-              WGP quarters won/lost
-              <input
-                type="number"
-                step="1"
-                inputMode="numeric"
-                value={form.score}
-                onChange={(event) => updateForm("score", event.target.value)}
-                placeholder="Example: -3 or 8"
-                required
-              />
-            </label>
-
-            <label>
-              Location <span>(optional)</span>
-              <input
-                type="text"
-                value={form.location}
-                onChange={(event) => updateForm("location", event.target.value)}
-                placeholder="Wing Point"
-              />
-            </label>
-
-            <label>
-              Group <span>(optional)</span>
-              <input
-                type="text"
-                value={form.group}
-                onChange={(event) => updateForm("group", event.target.value)}
-                placeholder="Morning game"
-              />
-            </label>
-
-            <label>
-              Duration <span>(optional)</span>
-              <input
-                type="text"
-                value={form.duration}
-                onChange={(event) => updateForm("duration", event.target.value)}
-                placeholder="18 holes"
-              />
-            </label>
-
-            <div>
-              <label className="standalone-label">Foursome members</label>
-              {rosterLoading ? (
-                <p className="muted">Loading roster...</p>
-              ) : rosterError ? (
-                <div className="round-alert error">{rosterError}</div>
-              ) : (
-                <FoursomePicker
-                  players={players}
-                  currentName={legacyName}
-                  selectedNames={form.foursome}
-                  onChange={(foursome) => updateForm("foursome", foursome)}
-                />
-              )}
-            </div>
-
-            {submitState.error && <div className="round-alert error">{submitState.error}</div>}
-            {submitState.success && <div className="round-alert success">{submitState.success}</div>}
-
-            <button type="submit" disabled={submitState.loading || rosterLoading}>
-              {submitState.loading ? "Posting..." : "Post Round"}
-            </button>
-          </form>
-
-          {(showLinkFlow || (!legacyName && !profileLoading)) && (
-            <div className="link-flow">
-              <LegacyNameSelector
-                currentName={legacyName}
-                onSelect={handleLegacySelect}
-                onSkip={() => setShowLinkFlow(false)}
-              />
-            </div>
-          )}
+          <PostRoundForm onPosted={loadMyRounds} />
         </div>
 
         <div className="round-card">
@@ -477,60 +263,6 @@ const PostRoundPage = () => {
           margin-top: 24px;
         }
 
-        .round-form {
-          display: grid;
-          gap: 16px;
-          margin-top: 18px;
-        }
-
-        .round-form label,
-        .standalone-label {
-          display: grid;
-          gap: 6px;
-          font-weight: 700;
-          color: #374151;
-        }
-
-        .round-form label span {
-          font-weight: 500;
-          color: #6b7280;
-        }
-
-        .round-form input {
-          border: 1px solid #d1d5db;
-          border-radius: 10px;
-          padding: 11px 12px;
-          font-size: 16px;
-        }
-
-        .round-form input:focus {
-          outline: 2px solid #9acd7e;
-          border-color: #2d5a27;
-        }
-
-        .round-form > button,
-        .attestation-card button,
-        .round-alert button {
-          background: #2d5a27;
-          color: #ffffff;
-          border: none;
-          border-radius: 10px;
-          padding: 11px 16px;
-          font-weight: 700;
-          cursor: pointer;
-        }
-
-        .round-form > button:disabled,
-        .attestation-card button:disabled,
-        .player-grid button:disabled {
-          opacity: 0.55;
-          cursor: not-allowed;
-        }
-
-        .linked-name {
-          color: #4b5563;
-        }
-
         .muted {
           color: #6b7280;
         }
@@ -541,58 +273,26 @@ const PostRoundPage = () => {
           margin: 12px 0;
         }
 
+        .round-alert button {
+          background: #2d5a27;
+          color: #ffffff;
+          border: none;
+          border-radius: 10px;
+          padding: 11px 16px;
+          font-weight: 700;
+          cursor: pointer;
+        }
+
         .round-alert.error {
           background: #fee2e2;
           color: #991b1b;
           border: 1px solid #fecaca;
         }
 
-        .round-alert.warning {
-          background: #fef3c7;
-          color: #92400e;
-          border: 1px solid #fde68a;
-        }
-
         .round-alert.success {
           background: #dcfce7;
           color: #166534;
           border: 1px solid #bbf7d0;
-        }
-
-        .selected-foursome {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 8px;
-          min-height: 42px;
-          align-items: center;
-          margin: 8px 0 12px;
-        }
-
-        .selected-foursome button,
-        .player-grid button {
-          border: 1px solid #d1d5db;
-          border-radius: 999px;
-          background: #f9fafb;
-          color: #374151;
-          padding: 8px 12px;
-          cursor: pointer;
-        }
-
-        .selected-foursome button,
-        .player-grid button.selected {
-          background: #e7f5e4;
-          border-color: #2d5a27;
-          color: #1f3b1b;
-          font-weight: 700;
-        }
-
-        .player-grid {
-          display: grid;
-          grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-          gap: 8px;
-          max-height: 260px;
-          overflow: auto;
-          padding: 2px;
         }
 
         .attestation-list {
@@ -610,6 +310,21 @@ const PostRoundPage = () => {
           border-radius: 12px;
           padding: 16px;
           background: #f9fafb;
+        }
+
+        .attestation-card button {
+          background: #2d5a27;
+          color: #ffffff;
+          border: none;
+          border-radius: 10px;
+          padding: 11px 16px;
+          font-weight: 700;
+          cursor: pointer;
+        }
+
+        .attestation-card button:disabled {
+          opacity: 0.55;
+          cursor: not-allowed;
         }
 
         .attestation-card p {
@@ -667,12 +382,6 @@ const PostRoundPage = () => {
         .round-status-badge.attested {
           background: #dcfce7;
           color: #166534;
-        }
-
-        .link-flow {
-          margin-top: 20px;
-          border-top: 1px solid #e5e7eb;
-          padding-top: 20px;
         }
 
         @media (max-width: 900px) {

--- a/frontend/src/services/__tests__/authToken.test.js
+++ b/frontend/src/services/__tests__/authToken.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect, vi } from "vitest";
+import { acquireAccessToken, isRecoverableAuthError } from "../authToken";
+
+describe("isRecoverableAuthError", () => {
+  test("returns false for nullish input", () => {
+    expect(isRecoverableAuthError(null)).toBe(false);
+    expect(isRecoverableAuthError(undefined)).toBe(false);
+  });
+
+  test("detects the missing_refresh_token error code", () => {
+    expect(isRecoverableAuthError({ error: "missing_refresh_token" })).toBe(true);
+  });
+
+  test("detects login_required / consent_required codes", () => {
+    expect(isRecoverableAuthError({ error: "login_required" })).toBe(true);
+    expect(isRecoverableAuthError({ code: "consent_required" })).toBe(true);
+  });
+
+  test("detects the missing-refresh-token message text", () => {
+    expect(isRecoverableAuthError(new Error("Missing Refresh Token"))).toBe(true);
+  });
+
+  test("returns false for unrelated errors", () => {
+    expect(isRecoverableAuthError(new Error("Network request failed"))).toBe(false);
+    expect(isRecoverableAuthError({ error: "server_error" })).toBe(false);
+  });
+});
+
+describe("acquireAccessToken", () => {
+  test("returns the token from the first (cached) attempt", async () => {
+    const getToken = vi.fn().mockResolvedValue("cached-token");
+
+    await expect(acquireAccessToken(getToken)).resolves.toBe("cached-token");
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(getToken).toHaveBeenCalledWith();
+  });
+
+  test("retries with cacheMode:'off' on a missing refresh token", async () => {
+    const getToken = vi
+      .fn()
+      .mockRejectedValueOnce({ error: "missing_refresh_token" })
+      .mockResolvedValueOnce("fresh-token");
+
+    await expect(acquireAccessToken(getToken)).resolves.toBe("fresh-token");
+    expect(getToken).toHaveBeenCalledTimes(2);
+    expect(getToken).toHaveBeenLastCalledWith({ cacheMode: "off" });
+  });
+
+  test("does not retry on a non-recoverable error", async () => {
+    const err = new Error("boom");
+    const getToken = vi.fn().mockRejectedValue(err);
+
+    await expect(acquireAccessToken(getToken)).rejects.toBe(err);
+    expect(getToken).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates the error when the cache-off retry also fails", async () => {
+    const getToken = vi
+      .fn()
+      .mockRejectedValueOnce({ error: "missing_refresh_token" })
+      .mockRejectedValueOnce({ error: "login_required" });
+
+    await expect(acquireAccessToken(getToken)).rejects.toEqual({ error: "login_required" });
+    expect(getToken).toHaveBeenCalledTimes(2);
+  });
+
+  test("throws when getAccessTokenSilently is not a function", async () => {
+    await expect(acquireAccessToken(undefined)).rejects.toThrow(
+      "getAccessTokenSilently is not available",
+    );
+  });
+});

--- a/frontend/src/services/authToken.js
+++ b/frontend/src/services/authToken.js
@@ -1,0 +1,70 @@
+/**
+ * Resilient Auth0 access-token acquisition.
+ *
+ * The app requests refresh tokens (`offline_access` + `useRefreshTokens`). When a
+ * cached session predates that config, has third-party cookies blocked, or the
+ * refresh token has expired/rotated away, `getAccessTokenSilently()` throws
+ * `Missing Refresh Token` (`error === 'missing_refresh_token'`). Left unhandled
+ * that surfaces to the user as a hard failure when they try to submit a score.
+ *
+ * These helpers recover transparently: on a recoverable auth error we retry once
+ * with `cacheMode: 'off'`, forcing Auth0 to re-mint a token via the refresh-token
+ * fallback (silent `/authorize` iframe — requires `useRefreshTokensFallback` on
+ * the provider). If that still fails the caller can prompt a full re-login.
+ */
+
+// Auth0 error codes that mean "the cached credential is gone/stale — get a fresh
+// one" rather than a genuine failure we should surface as-is.
+const RECOVERABLE_AUTH_ERROR_CODES = new Set([
+  "missing_refresh_token",
+  "invalid_grant",
+  "login_required",
+  "consent_required",
+  "interaction_required",
+]);
+
+/**
+ * True when an error thrown by `getAccessTokenSilently` means we should retry
+ * with a fresh token (or re-login) rather than treat it as a real failure.
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+export const isRecoverableAuthError = (error) => {
+  if (!error) return false;
+  const code = error.error || error.code || "";
+  if (RECOVERABLE_AUTH_ERROR_CODES.has(code)) return true;
+  const message = (error.message || error.error_description || "").toLowerCase();
+  return (
+    message.includes("refresh token") ||
+    message.includes("login required") ||
+    message.includes("consent required")
+  );
+};
+
+/**
+ * Acquire an Auth0 access token, transparently recovering from a missing or
+ * expired refresh token. First attempt uses the cache; on a recoverable auth
+ * error it retries once bypassing the cache so Auth0 falls back to a silent
+ * `/authorize` iframe.
+ *
+ * @param {(opts?: object) => Promise<string>} getAccessTokenSilently - Auth0 SDK fn
+ * @returns {Promise<string>} access token
+ */
+export const acquireAccessToken = async (getAccessTokenSilently) => {
+  if (typeof getAccessTokenSilently !== "function") {
+    throw new Error("getAccessTokenSilently is not available");
+  }
+
+  try {
+    return await getAccessTokenSilently();
+  } catch (error) {
+    if (!isRecoverableAuthError(error)) {
+      throw error;
+    }
+    // Bypass the cache so the SDK re-mints a token via the refresh-token
+    // fallback rather than reusing the missing/expired one.
+    return await getAccessTokenSilently({ cacheMode: "off" });
+  }
+};
+
+export default acquireAccessToken;


### PR DESCRIPTION
## Problem

Submitting a score failed hard with Auth0's **`Missing Refresh Token`** error
(`audience: https://wolf-goat-pig.onrender.com`, `scope: openid profile email offline_access`).

The provider requested refresh tokens (`offline_access` + `useRefreshTokens`) but had **no fallback**, so whenever a cached session had no/expired refresh token — session predates `offline_access`, third-party cookies blocked, or the token rotated away — `getAccessTokenSilently()` threw and the user hit a dead end when trying to post a round. There was also no way to *put that key capability on the home page*.

## Changes

- **`AuthContext.jsx`** — enable `useRefreshTokensFallback`, so a missing/expired refresh token falls back to a silent `/authorize` iframe instead of throwing.
- **`services/authToken.js` + `hooks/useAccessToken.js`** (new) — a resilient token getter that retries once with `cacheMode:'off'` on recoverable auth errors (`missing_refresh_token`, `login_required`, `consent_required`, …), plus a `reauthenticate()` helper for the terminal case.
- **`components/rounds/PostRoundForm.jsx`** (new) — self-contained post-a-round form using the resilient token flow. On an unrecoverable auth failure it shows explicit **"Try again"** / **"Sign in again"** actions rather than a dead error.
- **`pages/PostRoundPage.jsx`** — now consumes `PostRoundForm` and routes its round/attestation reads through the resilient getter too.
- **`pages/HomePage.jsx`** — embeds a compact **"Submit a Score"** card for authenticated users, making posting a round a first-class capability on the home page.

## Tests

- `services/__tests__/authToken.test.js` — recoverable-error detection and the cache-off retry / no-retry / propagation paths.
- `context/__tests__/AuthContext.test.jsx` — locks in `useRefreshTokensFallback` alongside the existing `offline_access` pairing.

## Verification

Definition-of-done gate (mirrors `frontend-ci.yml`):

- `npm run typecheck` — clean (exit 0)
- `npx vitest run` — 560 passed
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNHmrpx2LcpZytaA98itcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNHmrpx2LcpZytaA98itcF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined form for submitting Wolf-Goat-Pig round results.
  * Added score submission directly to the home screen for authenticated players.
  * Added foursome member selection, score validation, success notifications, and duplicate-date warnings.
  * Added support for linking legacy player names when required.
  * Added automatic recovery and reauthentication options for certain sign-in issues.

* **Bug Fixes**
  * Improved recovery when cached authentication tokens are missing or expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->