### PR TITLE
fix(auth): extend Missing Refresh Token recovery to remaining subpages

### DIFF
--- a/frontend/src/components/chat/GroupMeChat.jsx
+++ b/frontend/src/components/chat/GroupMeChat.jsx
@@ -6,11 +6,15 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../config/api.config';
+import { acquireAccessToken } from '../../services/authToken';
 import { Message } from './MessageParts';
 
 const API_URL = apiConfig.baseUrl;
 const POLL_MS = 30000;
 const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
+const tokenOptions = AUTH0_AUDIENCE
+  ? { authorizationParams: { audience: AUTH0_AUDIENCE } }
+  : undefined;
 
 const GroupMeChat = () => {
   const { isAuthenticated, getAccessTokenSilently, loginWithRedirect } = useAuth0();
@@ -58,9 +62,7 @@ const GroupMeChat = () => {
     setSending(true);
     setSendError(null);
     try {
-      const token = await getAccessTokenSilently(
-        AUTH0_AUDIENCE ? { authorizationParams: { audience: AUTH0_AUDIENCE } } : undefined,
-      );
+      const token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
       const res = await fetch(`${API_URL}/groupme/messages`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },

--- a/frontend/src/components/game/livsow/LivSowTeamPage.jsx
+++ b/frontend/src/components/game/livsow/LivSowTeamPage.jsx
@@ -6,11 +6,15 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../../config/api.config';
+import { acquireAccessToken } from '../../../services/authToken';
 import { teamColor, RoleTag, WeekCell } from './shared';
 import LivSowTransactions from './LivSowTransactions';
 import TeamEditModal from './TeamEditModal';
 
 const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
+const tokenOptions = AUTH0_AUDIENCE
+  ? { authorizationParams: { audience: AUTH0_AUDIENCE } }
+  : undefined;
 
 const ROLE_ORDER = { Captain: 0, Starter: 1, Alternate: 2 };
 
@@ -47,9 +51,7 @@ const LivSowTeamPage = () => {
     let cancelled = false;
     (async () => {
       try {
-        const token = await getAccessTokenSilently(
-          AUTH0_AUDIENCE ? { authorizationParams: { audience: AUTH0_AUDIENCE } } : undefined,
-        );
+        const token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
         const res = await fetch(`${apiConfig.baseUrl}/data/livsow/teams/${teamSlug}/can-edit`, {
           headers: { Authorization: `Bearer ${token}` },
         });

--- a/frontend/src/components/game/livsow/TeamEditModal.jsx
+++ b/frontend/src/components/game/livsow/TeamEditModal.jsx
@@ -7,8 +7,12 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../../config/api.config';
+import { acquireAccessToken } from '../../../services/authToken';
 
 const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
+const tokenOptions = AUTH0_AUDIENCE
+  ? { authorizationParams: { audience: AUTH0_AUDIENCE } }
+  : undefined;
 
 const fieldLabel = { fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 4, display: 'block' };
 const fieldBox = {
@@ -29,9 +33,7 @@ const TeamEditModal = ({ slug, teamName, accent, initial, onClose, onSaved }) =>
     setSaving(true);
     setError(null);
     try {
-      const token = await getAccessTokenSilently(
-        AUTH0_AUDIENCE ? { authorizationParams: { audience: AUTH0_AUDIENCE } } : undefined,
-      );
+      const token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
       const res = await fetch(`${apiConfig.baseUrl}/data/livsow/teams/${slug}/content`, {
         method: 'PUT',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },

--- a/frontend/src/components/signup/MyMatches.jsx
+++ b/frontend/src/components/signup/MyMatches.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../../hooks/useAccessToken';
 import useTeeTimes from '../../hooks/useTeeTimes';
 import BookingModal from '../foretees/BookingModal';
 import { apiConfig } from '../../config/api.config';
@@ -41,7 +41,7 @@ const formatDateDisplay = (dateStr) => {
 
 const MyMatches = () => {
   const navigate = useNavigate();
-  const { getAccessTokenSilently } = useAuth0();
+  const { getToken } = useAccessToken();
   const { fetchTeeTimes, bookTeeTime, bookingLoading, bookingError, clearBookingError } = useTeeTimes();
 
   const [matches, setMatches] = useState([]);
@@ -56,7 +56,7 @@ const MyMatches = () => {
   const [bookingResult, setBookingResult] = useState(null);
 
   const authFetch = useCallback(async (url, options = {}) => {
-    const token = await getAccessTokenSilently();
+    const token = await getToken();
     const fullUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
     return fetch(fullUrl, {
       ...options,
@@ -66,7 +66,7 @@ const MyMatches = () => {
         'Content-Type': 'application/json',
       },
     });
-  }, [getAccessTokenSilently]);
+  }, [getToken]);
 
   const fetchMatches = useCallback(async (overrideStatus) => {
     setLoading(true);

--- a/frontend/src/components/signup/PlayerAvailability.jsx
+++ b/frontend/src/components/signup/PlayerAvailability.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../config/api.config';
+import { acquireAccessToken } from '../../services/authToken';
 
 const API_URL = apiConfig.baseUrl;
 
@@ -9,6 +10,10 @@ const dayNamesFull = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'S
 const PlayerAvailability = () => {
   const { getAccessTokenSilently, isAuthenticated } = useAuth0();
   const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
+  const tokenOptions = useMemo(
+    () => (AUTH0_AUDIENCE ? { authorizationParams: { audience: AUTH0_AUDIENCE } } : undefined),
+    [AUTH0_AUDIENCE],
+  );
   const [availability, setAvailability] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -45,7 +50,7 @@ const PlayerAvailability = () => {
       setLoading(true);
       let token;
       try {
-        token = await getAccessTokenSilently(AUTH0_AUDIENCE ? { authorizationParams: { audience: AUTH0_AUDIENCE } } : undefined);
+        token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
       } catch (e) {
         token = localStorage.getItem('auth_token');
       }
@@ -79,7 +84,7 @@ const PlayerAvailability = () => {
     } finally {
       setLoading(false);
     }
-  }, [getAccessTokenSilently, initializeAvailability, isAuthenticated]);
+  }, [getAccessTokenSilently, initializeAvailability, isAuthenticated, tokenOptions]);
 
   useEffect(() => {
     loadAvailability();
@@ -108,7 +113,7 @@ const PlayerAvailability = () => {
       setMatchResult(null);
       let token;
       try {
-        token = await getAccessTokenSilently(AUTH0_AUDIENCE ? { authorizationParams: { audience: AUTH0_AUDIENCE } } : undefined);
+        token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
       } catch (e) {
         token = localStorage.getItem('auth_token');
       }

--- a/frontend/src/components/signup/WgpSignupSheet.jsx
+++ b/frontend/src/components/signup/WgpSignupSheet.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useTheme } from '../../theme/Provider';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../config/api.config';
+import { acquireAccessToken } from '../../services/authToken';
 
 const API_URL = apiConfig.baseUrl;
 
@@ -86,7 +87,7 @@ export default function WgpSignupSheet() {
     if (!isAuthenticated) return;
     (async () => {
       try {
-        const token = await getAccessTokenSilently();
+        const token = await acquireAccessToken(getAccessTokenSilently);
         const resp = await fetch(`${API_URL}/players/me`, {
           headers: { Authorization: `Bearer ${token}` },
         });

--- a/frontend/src/components/ui/NotificationBell.jsx
+++ b/frontend/src/components/ui/NotificationBell.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../../hooks/useAccessToken';
 import { apiConfig } from '../../config/api.config';
 
 const API_URL = apiConfig.baseUrl;
@@ -21,7 +22,8 @@ const relativeTime = (isoStr) => {
 
 const NotificationBell = () => {
   const navigate = useNavigate();
-  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  const { isAuthenticated } = useAuth0();
+  const { getToken } = useAccessToken();
   const [notifications, setNotifications] = useState([]);
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef(null);
@@ -29,7 +31,7 @@ const NotificationBell = () => {
   const fetchNotifications = useCallback(async () => {
     if (!isAuthenticated) return;
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getToken();
       const res = await fetch(`${API_URL}/notifications?unread_only=true&limit=10`, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -40,7 +42,7 @@ const NotificationBell = () => {
     } catch {
       // silent — bell is non-critical
     }
-  }, [isAuthenticated, getAccessTokenSilently]);
+  }, [isAuthenticated, getToken]);
 
   useEffect(() => {
     fetchNotifications();
@@ -62,7 +64,7 @@ const NotificationBell = () => {
 
   const markAllRead = useCallback(async () => {
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getToken();
       await fetch(`${API_URL}/notifications/read-all`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
@@ -71,11 +73,11 @@ const NotificationBell = () => {
     } catch {
       // silent
     }
-  }, [getAccessTokenSilently]);
+  }, [getToken]);
 
   const handleNotificationClick = useCallback(async (n) => {
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getToken();
       await fetch(`${API_URL}/notifications/${n.id}/read`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
@@ -86,7 +88,7 @@ const NotificationBell = () => {
     setNotifications(prev => prev.filter(x => x.id !== n.id));
     setOpen(false);
     navigate('/account');
-  }, [getAccessTokenSilently, navigate]);
+  }, [getToken, navigate]);
 
   if (!isAuthenticated || notifications.length === 0) return null;
 

--- a/frontend/src/hooks/useAccessToken.js
+++ b/frontend/src/hooks/useAccessToken.js
@@ -16,7 +16,7 @@ export const useAccessToken = () => {
   const { getAccessTokenSilently, loginWithRedirect } = useAuth0();
 
   const getToken = useCallback(
-    () => acquireAccessToken(getAccessTokenSilently),
+    (options) => acquireAccessToken(getAccessTokenSilently, options),
     [getAccessTokenSilently],
   );
 

--- a/frontend/src/hooks/useMatchmaking.js
+++ b/frontend/src/hooks/useMatchmaking.js
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
+import { acquireAccessToken } from '../services/authToken';
 import { apiConfig } from '../config/api.config';
 
 const API_URL = apiConfig.baseUrl;
@@ -20,7 +21,7 @@ const useMatchmaking = (playerProfileId) => {
   const wsRef = useRef(null);
 
   const authFetch = useCallback(async (url, options = {}) => {
-    const token = await getAccessTokenSilently();
+    const token = await acquireAccessToken(getAccessTokenSilently);
     const fullUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
     return fetch(fullUrl, {
       ...options,

--- a/frontend/src/hooks/usePlayerProfile.js
+++ b/frontend/src/hooks/usePlayerProfile.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { apiConfig } from "../config/api.config";
+import { acquireAccessToken } from "../services/authToken";
 
 const API_URL = apiConfig.baseUrl;
 
@@ -24,7 +25,7 @@ export const usePlayerProfile = () => {
 
     try {
       setLoading(true);
-      const token = await getAccessTokenSilently();
+      const token = await acquireAccessToken(getAccessTokenSilently);
 
       const response = await fetch(`${API_URL}/players/me`, {
         headers: {
@@ -61,7 +62,7 @@ export const usePlayerProfile = () => {
       }
 
       try {
-        const token = await getAccessTokenSilently();
+        const token = await acquireAccessToken(getAccessTokenSilently);
 
         const response = await fetch(`${API_URL}/players/me/legacy-name`, {
           method: "PUT",

--- a/frontend/src/hooks/useTeeTimes.js
+++ b/frontend/src/hooks/useTeeTimes.js
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
+import { acquireAccessToken } from '../services/authToken';
 import { apiConfig } from '../config/api.config';
 
 const API_URL = apiConfig.baseUrl;
@@ -18,7 +19,7 @@ const useTeeTimes = () => {
   const clearBookingError = useCallback(() => setBookingError(null), []);
 
   const authFetch = useCallback(async (url, options = {}) => {
-    const token = await getAccessTokenSilently();
+    const token = await acquireAccessToken(getAccessTokenSilently);
     const fullUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
     return fetch(fullUrl, {
       ...options,

--- a/frontend/src/pages/AccountPage.jsx
+++ b/frontend/src/pages/AccountPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
+import { useAccessToken } from '../hooks/useAccessToken';
 import { apiConfig } from '../config/api.config';
 import { useTheme } from '../theme/Provider';
 import useTeeTimes from '../hooks/useTeeTimes';
@@ -110,7 +111,8 @@ const gatherStats = () => {
 };
 
 function AccountPage() {
-  const { user, isAuthenticated, logout, getAccessTokenSilently } = useAuth0();
+  const { user, isAuthenticated, logout } = useAuth0();
+  const { getToken } = useAccessToken();
   const theme = useTheme();
   const [editing, setEditing] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -137,7 +139,7 @@ function AccountPage() {
     setStats(gatherStats());
 
     if (isAuthenticated) {
-      getAccessTokenSilently()
+      getToken()
         .then(token => fetch(`${apiConfig.baseUrl}/players/me`, {
           headers: { Authorization: `Bearer ${token}` },
         }))
@@ -157,13 +159,13 @@ function AccountPage() {
           setDescriptionSyncError('load');
         });
     }
-  }, [user, isAuthenticated, getAccessTokenSilently]);
+  }, [user, isAuthenticated, getToken]);
 
   const handleSave = useCallback(async () => {
     saveSettings(settings);
     // Persist description to backend
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getToken();
       const resp = await fetch(`${apiConfig.baseUrl}/players/me/description`, {
         method: 'PUT',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -178,7 +180,7 @@ function AccountPage() {
     setEditing(false);
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
-  }, [settings, getAccessTokenSilently]);
+  }, [settings, getToken]);
 
   const handleChange = (field, value) => {
     setSettings(prev => ({ ...prev, [field]: value }));

--- a/frontend/src/pages/PlayerProfilePage.jsx
+++ b/frontend/src/pages/PlayerProfilePage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../config/api.config';
+import { useAccessToken } from '../hooks/useAccessToken';
 import { usePlayerProfile } from '../hooks/usePlayerProfile';
 import '../styles/clubhouse-theme.css';
 import './PlayerProfilePage.css';
@@ -31,7 +31,7 @@ const formatScore = (q) => `${q >= 0 ? '+' : ''}${q}`;
 const PlayerProfilePage = () => {
   const { playerId } = useParams();
   const navigate = useNavigate();
-  const { getAccessTokenSilently } = useAuth0();
+  const { getToken } = useAccessToken();
   const { profile: myProfile } = usePlayerProfile();
   const fileInputRef = useRef(null);
 
@@ -87,7 +87,7 @@ const PlayerProfilePage = () => {
     setUploading(true);
     setUploadError(null);
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getToken();
       const formData = new FormData();
       formData.append('file', file);
       const res = await fetch(`${API_URL}/players/me/avatar`, {
@@ -112,7 +112,7 @@ const PlayerProfilePage = () => {
     setTogglingBadgeId(badgeEarnedId);
     setShowcaseError(null);
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getToken();
       const res = await fetch(`${API_URL}/api/badges/me/${badgeEarnedId}/showcase`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },

--- a/frontend/src/pages/__tests__/PlayerProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/PlayerProfilePage.test.jsx
@@ -45,6 +45,7 @@ const renderPage = (playerId = '21') =>
 beforeEach(() => {
   mockUseAuth0.mockReturnValue({
     getAccessTokenSilently: vi.fn().mockResolvedValue('mock-token'),
+    loginWithRedirect: vi.fn(),
   });
   global.fetch = vi.fn(async (url) => {
     if (String(url).includes('/public-profile')) {

--- a/frontend/src/services/__tests__/authToken.test.js
+++ b/frontend/src/services/__tests__/authToken.test.js
@@ -69,4 +69,16 @@ describe("acquireAccessToken", () => {
       "getAccessTokenSilently is not available",
     );
   });
+
+  test("forwards Auth0 options and preserves them on cache-off retry", async () => {
+    const options = { authorizationParams: { audience: "https://example.com" } };
+    const getToken = vi
+      .fn()
+      .mockRejectedValueOnce({ error: "missing_refresh_token" })
+      .mockResolvedValueOnce("fresh-token");
+
+    await expect(acquireAccessToken(getToken, options)).resolves.toBe("fresh-token");
+    expect(getToken).toHaveBeenNthCalledWith(1, options);
+    expect(getToken).toHaveBeenNthCalledWith(2, { ...options, cacheMode: "off" });
+  });
 });

--- a/frontend/src/services/authToken.js
+++ b/frontend/src/services/authToken.js
@@ -48,22 +48,28 @@ export const isRecoverableAuthError = (error) => {
  * `/authorize` iframe.
  *
  * @param {(opts?: object) => Promise<string>} getAccessTokenSilently - Auth0 SDK fn
+ * @param {object} [options] - forwarded to getAccessTokenSilently (e.g. audience)
  * @returns {Promise<string>} access token
  */
-export const acquireAccessToken = async (getAccessTokenSilently) => {
+export const acquireAccessToken = async (getAccessTokenSilently, options = undefined) => {
   if (typeof getAccessTokenSilently !== "function") {
     throw new Error("getAccessTokenSilently is not available");
   }
 
   try {
-    return await getAccessTokenSilently();
+    return options === undefined
+      ? await getAccessTokenSilently()
+      : await getAccessTokenSilently(options);
   } catch (error) {
     if (!isRecoverableAuthError(error)) {
       throw error;
     }
     // Bypass the cache so the SDK re-mints a token via the refresh-token
     // fallback rather than reusing the missing/expired one.
-    return await getAccessTokenSilently({ cacheMode: "off" });
+    const retryOptions = options === undefined
+      ? { cacheMode: "off" }
+      : { ...options, cacheMode: "off" };
+    return await getAccessTokenSilently(retryOptions);
   }
 };
 


### PR DESCRIPTION
## Summary
- Extends the #307 resilient Auth0 token helper (`acquireAccessToken` / `useAccessToken`) to the remaining authenticated surfaces that still called `getAccessTokenSilently` directly.
- Covers account, player profile, signup/matchmaking/tee-times hooks, LivSow team edit, GroupMe chat, and the notification bell.
- Preserves Auth0 options (e.g. audience) across the cache-off retry path.

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `npx vitest run` for authToken, AuthContext, PlayerProfilePage, PlayerAvailability, useAuth (49 passed)
- [ ] Manually: sign in with a session that lacks a refresh token, hit `/account`, `/signup`, `/players/:id`, `/livsow/teams/:slug`, and `/chat` — actions should recover instead of throwing Missing Refresh Token
- [ ] Confirm score submit on home (`PostRoundForm`) still works after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication reliability across chat, matchmaking, team editing, player profiles, account updates, signups, tee times, and notifications.
  - Preserved required access settings when refreshing expired or unavailable login sessions.
  - Improved consistency when loading and saving player availability, profiles, and team information.
- **Tests**
  - Added coverage to verify authentication recovery retains required access settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->