### PR TITLE
feat(home): prioritize signup, standings, and group score attestation

### DIFF
--- a/backend/app/routers/member_rounds.py
+++ b/backend/app/routers/member_rounds.py
@@ -27,6 +27,7 @@ from ..models import LegacyRound, PlayerProfile
 from ..services.auth_service import get_current_user
 from ..services.email_service import get_email_service
 from ..services.legacy_player_service import get_canonical_name
+from ..services.notification_service import get_notification_service
 from ..utils.time import utc_now
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ def _serialize(r: LegacyRound) -> dict[str, Any]:
     """Render a round in the pinned response shape."""
     return {
         "id": r.id,
+        "round_code": f"WGP-{r.id}",
         "date": r.date,
         "score": r.score,
         "member": r.member,
@@ -63,24 +65,56 @@ def _serialize(r: LegacyRound) -> dict[str, Any]:
 
 
 def _notify_foursome(db: Session, round_row: LegacyRound, poster: PlayerProfile) -> None:
-    """Email each foursome member that has a PlayerProfile+email an attestation
-    request. Best-effort: any email failure must NOT fail the request."""
+    """Email + in-app notify each foursome member that can attest.
+
+    Best-effort: any notify failure must NOT fail the request.
+    """
     try:
         email_service = get_email_service()
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("Could not get email service for attestation request: %s", e)
-        return
+        email_service = None
+
+    try:
+        notification_service = get_notification_service()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Could not get notification service for attestation: %s", e)
+        notification_service = None
+
+    poster_name = poster.legacy_name or poster.name or "A member"
+    round_code = f"WGP-{round_row.id}"
 
     for name in round_row.foursome or []:
         try:
             profile = db.query(PlayerProfile).filter(func.lower(PlayerProfile.legacy_name) == name.lower()).first()
-            if profile and profile.email:
+            if not profile:
+                continue
+
+            if email_service and profile.email:
                 email_service.send_attestation_request(
                     to_email=profile.email,
                     attester_name=profile.name or name,
-                    poster_name=poster.legacy_name or poster.name or "A member",
+                    poster_name=poster_name,
                     round_date=round_row.date,
                     score=round_row.score,
+                )
+
+            if notification_service:
+                notification_service.send_notification(
+                    player_id=profile.id,
+                    notification_type="round_attestation",
+                    message=(
+                        f"{poster_name} posted round {round_code} for {round_row.date} "
+                        f"({round_row.score:+d} quarters). Tap to attest."
+                    ),
+                    db=db,
+                    data={
+                        "round_id": round_row.id,
+                        "round_code": round_code,
+                        "date": round_row.date,
+                        "poster": poster_name,
+                        "score": round_row.score,
+                    },
                 )
         except Exception as e:
             logger.warning("Failed to send attestation request to '%s': %s", name, e)

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -114,6 +114,7 @@ class NotificationService:
                 "match_accepted",
                 "match_declined",
                 "match_confirmed",
+                "round_attestation",
             ]
 
             if notification_type not in valid_types:

--- a/backend/tests/unit/routers/test_member_rounds_router.py
+++ b/backend/tests/unit/routers/test_member_rounds_router.py
@@ -74,13 +74,18 @@ def client(db_session, monkeypatch):
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[require_admin] = lambda: None
 
-    # No real emails.
+    # No real emails / in-app notifications.
     fake_email = MagicMock()
     fake_email.send_attestation_request.return_value = True
     monkeypatch.setattr(member_rounds_module, "get_email_service", lambda: fake_email)
 
+    fake_notify = MagicMock()
+    fake_notify.send_notification.return_value = {"id": 1}
+    monkeypatch.setattr(member_rounds_module, "get_notification_service", lambda: fake_notify)
+
     test_client = TestClient(app)
     test_client.fake_email = fake_email  # type: ignore[attr-defined]
+    test_client.fake_notify = fake_notify  # type: ignore[attr-defined]
     yield test_client
 
     app.dependency_overrides.pop(get_db, None)
@@ -119,7 +124,9 @@ def test_post_creates_pending_round(client):
     assert data["foursome"] == ["Jeff Smith", "Bob Jones"]
     assert data["attested_by"] is None
     assert data["attested_at"] is None
+    assert data["round_code"] == f"WGP-{data['id']}"
     client.fake_email.send_attestation_request.assert_called()
+    assert client.fake_notify.send_notification.call_count == 2
 
 
 def test_post_without_legacy_name_returns_400(client):

--- a/frontend/src/components/rounds/PostRoundForm.jsx
+++ b/frontend/src/components/rounds/PostRoundForm.jsx
@@ -133,7 +133,7 @@ const PostRoundForm = ({ onPosted, compact = false }) => {
     }
 
     try {
-      await postMyRound(getToken, {
+      const posted = await postMyRound(getToken, {
         date: form.date,
         score: Number(form.score),
         location: form.location.trim() || undefined,
@@ -141,10 +141,13 @@ const PostRoundForm = ({ onPosted, compact = false }) => {
         duration: form.duration.trim() || undefined,
         foursome: form.foursome,
       });
+      const roundCode = posted?.round_code || (posted?.id != null ? `WGP-${posted.id}` : null);
       setSubmitState({
         loading: false,
         error: "",
-        success: "Round posted for attestation.",
+        success: roundCode
+          ? `Round ${roundCode} posted for attestation. Your partners will get a notification to confirm.`
+          : "Round posted for attestation. Your partners will get a notification to confirm.",
         canRetry: false,
         needsReauth: false,
       });

--- a/frontend/src/components/ui/Navigation.jsx
+++ b/frontend/src/components/ui/Navigation.jsx
@@ -46,20 +46,20 @@ const Navigation = () => {
   const bottomTabItems = [
     { path: '/', label: 'Home', icon: '🏠' },
     { path: '/signup', label: 'Sign Up', icon: '📅' },
-    { path: '/game', label: 'Game', icon: '⚔️' },
+    { path: '/leaderboard', label: 'Standings', icon: '📊' },
     { path: '/account', label: 'Account', icon: '👤' },
   ];
 
   // "More" sheet items
   const moreItems = [
+    { path: '/rounds/post', label: 'Post / Attest Round', icon: '📝' },
+    { path: '/game', label: 'Live Game', icon: '⚔️' },
     { path: '/players', label: 'Players', icon: '👥' },
     { path: '/scorecard-scan', label: 'Scan Scorecard', icon: '📷' },
     { path: '/join', label: 'Join with Code', icon: '🔗' },
     { path: '/games/active', label: 'Active Games', icon: '🎮' },
     { path: '/games/completed', label: 'Game History', icon: '🏆' },
-    { path: '/rounds/post', label: 'Post a Round', icon: '📝' },
     { path: '/badges', label: 'Badges', icon: '🏅' },
-    { path: '/leaderboard', label: 'WGP Leaderboard', icon: '📊' },
     { path: '/livsow', label: 'LivSow', icon: '⛳' },
     { path: '/chat', label: 'League Chat', icon: '💬' },
     { path: '/tutorial', label: 'Tutorial', icon: '🎓' },
@@ -76,15 +76,15 @@ const Navigation = () => {
   const allNavLinks = [
     { path: '/', label: '🏠 Home', primary: true },
     { path: '/signup', label: '📅 Sign Up', primary: true },
-    { path: '/game', label: '⚔️ Game', primary: true },
-    { path: '/games/active', label: '🎮 Active', primary: true },
+    { path: '/leaderboard', label: '📊 Standings', primary: true },
+    { path: '/rounds/post', label: '📝 Scores', primary: true },
+    { path: '/game', label: '⚔️ Live Game', primary: false },
+    { path: '/games/active', label: '🎮 Active', primary: false },
     { path: '/players', label: '👥 Players', primary: false },
     { path: '/scorecard-scan', label: '📷 Scan Scorecard', primary: false },
     { path: '/join', label: '🔗 Join with Code', primary: false },
     { path: '/games/completed', label: '🏆 History', primary: false },
-    { path: '/rounds/post', label: '📝 Post Round', primary: false },
     { path: '/badges', label: '🏅 Badges', primary: false },
-    { path: '/leaderboard', label: '📊 WGP Leaderboard', primary: false },
     { path: '/livsow', label: '⛳ LivSow', primary: false },
     { path: '/chat', label: '💬 Chat', primary: false },
     { path: '/tutorial', label: '🎓 Tutorial', primary: false },

--- a/frontend/src/components/ui/NotificationBell.jsx
+++ b/frontend/src/components/ui/NotificationBell.jsx
@@ -8,6 +8,8 @@ const API_URL = apiConfig.baseUrl;
 const POLL_INTERVAL_MS = 60_000;
 
 const MATCH_TYPES = new Set(['match_found', 'match_accepted', 'match_declined', 'match_confirmed']);
+const ATTESTATION_TYPES = new Set(['round_attestation']);
+const BELL_TYPES = new Set([...MATCH_TYPES, ...ATTESTATION_TYPES]);
 
 const relativeTime = (isoStr) => {
   if (!isoStr) return '';
@@ -37,7 +39,7 @@ const NotificationBell = () => {
       });
       if (res.ok) {
         const data = await res.json();
-        setNotifications(data.filter(n => MATCH_TYPES.has(n.notification_type)));
+        setNotifications(data.filter(n => BELL_TYPES.has(n.notification_type)));
       }
     } catch {
       // silent — bell is non-critical
@@ -87,6 +89,10 @@ const NotificationBell = () => {
     }
     setNotifications(prev => prev.filter(x => x.id !== n.id));
     setOpen(false);
+    if (ATTESTATION_TYPES.has(n.notification_type)) {
+      navigate('/rounds/post');
+      return;
+    }
     navigate('/account');
   }, [getToken, navigate]);
 
@@ -151,7 +157,7 @@ const NotificationBell = () => {
             borderBottom: '1px solid #e5e7eb',
           }}>
             <span style={{ fontWeight: 700, fontSize: 14, color: '#1f2937' }}>
-              Match Notifications
+              Notifications
             </span>
             <button
               onClick={markAllRead}
@@ -186,7 +192,8 @@ const NotificationBell = () => {
               >
                 <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
                   <span style={{ fontSize: 20, flexShrink: 0 }}>
-                    {n.notification_type === 'match_found' ? '⛳' :
+                    {n.notification_type === 'round_attestation' ? '📝' :
+                     n.notification_type === 'match_found' ? '⛳' :
                      n.notification_type === 'match_confirmed' ? '✅' :
                      n.notification_type === 'match_accepted' ? '👍' : '📬'}
                   </span>
@@ -195,7 +202,10 @@ const NotificationBell = () => {
                       {n.message}
                     </div>
                     <div style={{ fontSize: 11, color: '#9ca3af', marginTop: 4 }}>
-                      {relativeTime(n.created_at)} · tap to view in Account
+                      {relativeTime(n.created_at)}
+                      {ATTESTATION_TYPES.has(n.notification_type)
+                        ? ' · tap to attest'
+                        : ' · tap to view in Account'}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -1,0 +1,366 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap');
+
+/* Home — course hero + three primary jobs; advanced tools stay collapsed. */
+
+.wgp-home {
+  --home-ink: #f8fafc;
+  --home-ink-muted: rgba(248, 250, 252, 0.82);
+  --home-panel: rgba(255, 253, 248, 0.96);
+  --home-panel-ink: #1f2937;
+  --home-panel-muted: #57534e;
+  --home-green: #065f46;
+  --home-green-bright: #047857;
+  --home-brass: #b45309;
+  --home-rule: rgba(6, 95, 70, 0.16);
+  min-height: 100vh;
+  color: var(--home-ink);
+  background-image:
+    linear-gradient(180deg, rgba(6, 78, 59, 0.55) 0%, rgba(4, 47, 36, 0.72) 42%, rgba(4, 47, 36, 0.88) 100%),
+    url('https://www.wingpointgolf.com/_filelib/ImageGallery/2020_Images/DJI_0093.jpeg');
+  background-size: cover;
+  background-position: center top;
+  background-attachment: fixed;
+}
+
+.wgp-home__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 28px 16px 72px;
+}
+
+.wgp-home__hero {
+  padding: 28px 8px 8px;
+  text-align: center;
+  animation: wgp-home-rise 0.55s ease both;
+}
+
+.wgp-home__brand {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: clamp(2.4rem, 7vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin: 0 0 10px;
+  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.45);
+}
+
+.wgp-home__tagline {
+  margin: 0 auto 8px;
+  max-width: 28rem;
+  font-size: clamp(1rem, 2.6vw, 1.2rem);
+  color: var(--home-ink-muted);
+  font-style: italic;
+}
+
+.wgp-home__place {
+  margin: 0 0 22px;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 253, 248, 0.72);
+}
+
+.wgp-home__welcome {
+  margin: 0 auto 20px;
+  max-width: 28rem;
+  font-size: 1.05rem;
+  color: var(--home-ink-muted);
+}
+
+.wgp-home__login {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+  padding: 18px 22px;
+  border-radius: 14px;
+  background: rgba(255, 253, 248, 0.12);
+  border: 1px solid rgba(255, 253, 248, 0.22);
+  backdrop-filter: blur(8px);
+}
+
+.wgp-home__login p {
+  margin: 0;
+  color: var(--home-ink-muted);
+  font-size: 0.95rem;
+}
+
+.wgp-home__pillars {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin: 18px 0 20px;
+  animation: wgp-home-rise 0.65s ease both;
+  animation-delay: 0.08s;
+}
+
+@media (min-width: 720px) {
+  .wgp-home__pillars {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.wgp-home__pillar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  width: 100%;
+  min-height: 148px;
+  padding: 18px 16px;
+  border: 1px solid rgba(255, 253, 248, 0.28);
+  border-radius: 14px;
+  background: rgba(255, 253, 248, 0.94);
+  color: var(--home-panel-ink);
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+}
+
+.wgp-home__pillar:hover,
+.wgp-home__pillar:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.24);
+  outline: none;
+}
+
+.wgp-home__pillar-kicker {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--home-green);
+}
+
+.wgp-home__pillar-title {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--home-panel-ink);
+}
+
+.wgp-home__pillar-copy {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  color: var(--home-panel-muted);
+}
+
+.wgp-home__panel {
+  background: var(--home-panel);
+  color: var(--home-panel-ink);
+  border: 1px solid rgba(180, 83, 9, 0.28);
+  border-radius: 14px;
+  padding: 20px 18px;
+  margin-bottom: 14px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
+  animation: wgp-home-rise 0.55s ease both;
+}
+
+.wgp-home__panel h2 {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 1.25rem;
+  margin: 0 0 8px;
+  color: var(--home-green);
+}
+
+.wgp-home__panel > p {
+  margin: 0 0 14px;
+  color: var(--home-panel-muted);
+  line-height: 1.5;
+}
+
+.wgp-home__steps {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.wgp-home__steps li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(6, 95, 70, 0.06);
+  border: 1px solid var(--home-rule);
+}
+
+.wgp-home__step-num {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: white;
+  background: var(--home-green-bright);
+}
+
+.wgp-home__steps strong {
+  display: block;
+  color: var(--home-panel-ink);
+  margin-bottom: 2px;
+}
+
+.wgp-home__steps span {
+  color: var(--home-panel-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.wgp-home__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.wgp-home__btn {
+  appearance: none;
+  border: none;
+  border-radius: 10px;
+  padding: 11px 16px;
+  font-size: 0.95rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.wgp-home__btn:hover {
+  transform: translateY(-1px);
+}
+
+.wgp-home__btn--primary {
+  background: var(--home-green-bright);
+  color: white;
+}
+
+.wgp-home__btn--ghost {
+  background: transparent;
+  color: var(--home-green);
+  border: 1px solid var(--home-green);
+}
+
+.wgp-home__resume {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  margin-bottom: 14px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #d97706, #b45309);
+  color: white;
+  box-shadow: 0 8px 18px rgba(180, 83, 9, 0.35);
+}
+
+.wgp-home__resume p {
+  margin: 4px 0 0;
+  opacity: 0.92;
+  font-size: 0.92rem;
+}
+
+.wgp-home__resume strong {
+  font-weight: 700;
+}
+
+.wgp-home__resume button {
+  appearance: none;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 18px;
+  background: white;
+  color: #b45309;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.wgp-home__more {
+  margin-top: 8px;
+}
+
+.wgp-home__more > summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(255, 253, 248, 0.14);
+  border: 1px solid rgba(255, 253, 248, 0.24);
+  color: var(--home-ink);
+  font-weight: 650;
+}
+
+.wgp-home__more > summary::-webkit-details-marker {
+  display: none;
+}
+
+.wgp-home__more[open] > summary {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.wgp-home__more-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  padding: 12px;
+  background: rgba(255, 253, 248, 0.96);
+  border: 1px solid rgba(255, 253, 248, 0.24);
+  border-top: none;
+  border-radius: 0 0 12px 12px;
+}
+
+@media (min-width: 640px) {
+  .wgp-home__more-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.wgp-home__more-grid button,
+.wgp-home__more-grid a {
+  appearance: none;
+  display: block;
+  width: 100%;
+  padding: 12px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--home-rule);
+  background: #fffdf8;
+  color: var(--home-panel-ink);
+  text-decoration: none;
+  text-align: center;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wgp-home__more-grid button:hover,
+.wgp-home__more-grid a:hover {
+  border-color: rgba(6, 95, 70, 0.35);
+  background: rgba(6, 95, 70, 0.06);
+}
+
+@keyframes wgp-home-rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 720px) {
+  .wgp-home {
+    background-attachment: scroll;
+  }
+}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,833 +1,233 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { LoginButton, AuthHealthCheck } from '../components/auth';
 import StaleGameBanner from '../components/game/StaleGameBanner';
-import PostRoundForm from '../components/rounds/PostRoundForm';
+import './HomePage.css';
+
+const ADVANCED_TOOLS = [
+  { path: '/game', label: 'Live game' },
+  { path: '/join', label: 'Join with code' },
+  { path: '/games/active', label: 'Active games' },
+  { path: '/scorecard-scan', label: 'Scan scorecard' },
+  { path: '/game-scorer', label: 'Hole-by-hole scorer' },
+  { path: '/games/completed', label: 'Game history' },
+  { path: '/tutorial', label: 'Tutorial' },
+  { path: '/livsow', label: 'LivSow' },
+  { path: '/chat', label: 'League chat' },
+  { path: '/find-a-game', label: 'Find a game' },
+];
 
 function HomePage() {
   const navigate = useNavigate();
   const { isAuthenticated, user } = useAuth0();
   const [activeGameSession, setActiveGameSession] = useState(null);
 
-  // Check for active game session on mount
-  React.useEffect(() => {
+  useEffect(() => {
     const currentGameId = localStorage.getItem('wgp_current_game');
-    if (currentGameId) {
-      const sessionKey = `wgp_session_${currentGameId}`;
-      const sessionData = localStorage.getItem(sessionKey);
-      if (sessionData) {
-        try {
-          const session = JSON.parse(sessionData);
-          // Only show if session is recent (within 24 hours)
-          const isRecent = (Date.now() - session.timestamp) < 24 * 60 * 60 * 1000;
-          if (isRecent && session.status !== 'completed') {
-            setActiveGameSession(session);
-          } else {
-            // Clean up old session
-            localStorage.removeItem(sessionKey);
-            localStorage.removeItem('wgp_current_game');
-          }
-        } catch (err) {
-          console.error('Error parsing session data:', err);
-        }
+    if (!currentGameId) return;
+
+    const sessionKey = `wgp_session_${currentGameId}`;
+    const sessionData = localStorage.getItem(sessionKey);
+    if (!sessionData) return;
+
+    try {
+      const session = JSON.parse(sessionData);
+      const isRecent = Date.now() - session.timestamp < 24 * 60 * 60 * 1000;
+      if (isRecent && session.status !== 'completed') {
+        setActiveGameSession(session);
+      } else {
+        localStorage.removeItem(sessionKey);
+        localStorage.removeItem('wgp_current_game');
       }
+    } catch (err) {
+      console.error('Error parsing session data:', err);
     }
   }, []);
-  
-  // Add responsive styles
-  React.useEffect(() => {
-    const styleSheet = document.createElement('style');
-    styleSheet.textContent = `
-      @media (max-width: 768px) {
-        .wgp-main-title {
-          font-size: 2.5rem !important;
-        }
-        .wgp-subtitle {
-          font-size: 1.2rem !important;
-        }
-        .wgp-header-container {
-          padding: 25px 15px !important;
-        }
-        .wgp-box-grid {
-          grid-template-columns: repeat(2, 1fr) !important;
-        }
-        .wgp-join-title {
-          font-size: 1.8rem !important;
-        }
-        .wgp-join-description {
-          font-size: 1.1rem !important;
-        }
-      }
-      @media (max-width: 480px) {
-        .wgp-main-title {
-          font-size: 2rem !important;
-        }
-        .wgp-subtitle {
-          font-size: 1rem !important;
-        }
-        .wgp-box-grid {
-          grid-template-columns: repeat(2, 1fr) !important;
-        }
-        .wgp-join-title {
-          font-size: 1.5rem !important;
-        }
-        .wgp-join-description {
-          font-size: 1rem !important;
-        }
-      }
-    `;
-    document.head.appendChild(styleSheet);
-    return () => document.head.removeChild(styleSheet);
-  }, []);
-  
+
   return (
-    <div style={{ 
-      minHeight: '100vh',
-      backgroundImage: `linear-gradient(rgba(6, 78, 59, 0.3), rgba(4, 120, 87, 0.4)), url('https://www.wingpointgolf.com/_filelib/ImageGallery/2020_Images/DJI_0093.jpeg')`,
-      backgroundSize: 'cover',
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-      backgroundAttachment: 'fixed',
-      padding: '20px',
-      position: 'relative'
-    }}>
-      {/* Main Content */}
-      <div style={{ maxWidth: '1200px', margin: '0 auto', paddingTop: '40px' }}>
-        {/* Header */}
-        <div className="wgp-header-container" style={{ 
-          textAlign: 'center', 
-          marginBottom: '40px',
-          background: 'linear-gradient(135deg, rgba(6, 78, 59, 0.8), rgba(4, 120, 87, 0.7))',
-          padding: '40px 20px',
-          borderRadius: '16px',
-          backdropFilter: 'blur(10px)'
-        }}>
-          <h1 className="wgp-main-title" style={{ 
-            fontSize: '4rem', 
-            fontWeight: 'bold',
-            color: 'white',
-            marginBottom: '16px',
-            textShadow: '2px 2px 4px rgba(0, 0, 0, 0.8)',
-            letterSpacing: '1px'
-          }}>
-            Welcome to Wolf Goat Pig
-          </h1>
-          <p className="wgp-subtitle" style={{ 
-            fontSize: '1.5rem', 
-            color: 'white',
-            fontStyle: 'italic',
-            textShadow: '1px 1px 3px rgba(0, 0, 0, 0.8)',
-            marginBottom: '20px'
-          }}>
-            "We accept bad golf, but not bad betting"
-          </p>
-          <p style={{
-            fontSize: '1.2rem',
-            color: 'rgba(255, 255, 255, 0.95)',
-            marginBottom: '30px',
-            fontWeight: '500'
-          }}>
-            🏌️ Wing Point Golf & Country Club • Est. 1903
-          </p>
-          
+    <div className="wgp-home">
+      <div className="wgp-home__inner">
+        <header className="wgp-home__hero">
+          <h1 className="wgp-home__brand">Wolf Goat Pig</h1>
+          <p className="wgp-home__tagline">We accept bad golf, but not bad betting</p>
+          <p className="wgp-home__place">Wing Point Golf &amp; Country Club</p>
+
           {!isAuthenticated ? (
-            <div style={{
-              background: 'rgba(255, 255, 255, 0.95)',
-              borderRadius: '16px',
-              padding: '40px',
-              marginTop: '30px',
-              boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.3)'
-            }}>
-              <h2 className="wgp-join-title" style={{
-                fontSize: '2.2rem',
-                fontWeight: 'bold',
-                color: '#1F2937',
-                marginBottom: '20px',
-                textShadow: 'none'
-              }}>
-                🔐 Join the Game
-              </h2>
-              <p className="wgp-join-description" style={{
-                color: '#4B5563',
-                fontSize: '1.3rem',
-                marginBottom: '30px',
-                lineHeight: '1.6'
-              }}>
-                Sign in to track your Wolf Goat Pig stats, compete in tournaments, and join the Wing Point leaderboard.
-              </p>
-              <LoginButton style={{ 
-                fontSize: '20px', 
-                padding: '16px 40px',
-                background: '#047857',
-                color: 'white',
-                border: 'none',
-                borderRadius: '12px',
-                cursor: 'pointer',
-                fontWeight: '700',
-                boxShadow: '0 10px 15px -3px rgba(4, 120, 87, 0.5)',
-                transform: 'translateY(0)',
-                transition: 'all 0.3s ease'
-              }} />
-              <p style={{
-                color: '#6B7280',
-                fontSize: '1rem',
-                marginTop: '20px'
-              }}>
-                New to Wing Point? Your first login creates your account automatically.
-              </p>
+            <div className="wgp-home__login">
+              <p>Sign in to post for upcoming days, check standings, and record scores.</p>
+              <LoginButton
+                style={{
+                  fontSize: '17px',
+                  padding: '12px 28px',
+                  background: '#047857',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '10px',
+                  cursor: 'pointer',
+                  fontWeight: 700,
+                }}
+              />
             </div>
           ) : (
-            <div style={{
-              background: 'linear-gradient(135deg, rgba(4, 120, 87, 0.95), rgba(6, 95, 70, 0.9))',
-              borderRadius: '16px',
-              padding: '30px',
-              marginTop: '30px',
-              boxShadow: '0 20px 25px -5px rgba(4, 120, 87, 0.4)'
-            }}>
-              <h2 style={{
-                fontSize: '1.8rem',
-                fontWeight: 'bold',
-                color: 'white',
-                marginBottom: '10px',
-                textShadow: '1px 1px 3px rgba(0, 0, 0, 0.3)'
-              }}>
-                Welcome back, {user?.name || 'Player'}! 👋
-              </h2>
-              <p style={{
-                color: 'rgba(255, 255, 255, 0.9)',
-                fontSize: '1.1rem'
-              }}>
-                Ready to play some Wolf Goat Pig?
-              </p>
-            </div>
-          )}
-        </div>
-        
-        {/* Submit a Score - key capability, available right on the home page */}
-        {isAuthenticated && (
-          <div style={{
-            background: 'rgba(255, 255, 255, 0.98)',
-            borderRadius: '16px',
-            padding: '32px',
-            marginBottom: '30px',
-            boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.2)',
-            backdropFilter: 'blur(10px)',
-            border: '2px solid rgba(4, 120, 87, 0.3)'
-          }}>
-            <h3 style={{
-              fontSize: '2rem',
-              fontWeight: 'bold',
-              color: '#1F2937',
-              marginBottom: '8px',
-              textAlign: 'center'
-            }}>
-              📝 Submit a Score
-            </h3>
-            <p style={{
-              color: '#6B7280',
-              fontSize: '1.1rem',
-              textAlign: 'center',
-              marginBottom: '20px'
-            }}>
-              Post today's Wolf-Goat-Pig quarters right here — no extra navigation.
+            <p className="wgp-home__welcome">
+              Welcome back{user?.name ? `, ${user.name.split(' ')[0]}` : ''}. Pick what you need —
+              the rest stays out of the way.
             </p>
-            <PostRoundForm compact />
-            <div style={{ textAlign: 'center', marginTop: '16px' }}>
-              <button
-                onClick={() => navigate('/rounds/post')}
-                style={{
-                  padding: '10px 24px',
-                  background: 'transparent',
-                  color: '#047857',
-                  border: '1px solid #047857',
-                  borderRadius: '8px',
-                  fontSize: '14px',
-                  fontWeight: '600',
-                  cursor: 'pointer',
-                  transition: 'all 0.2s'
-                }}
-                onMouseEnter={(e) => {
-                  e.target.style.background = '#047857';
-                  e.target.style.color = 'white';
-                }}
-                onMouseLeave={(e) => {
-                  e.target.style.background = 'transparent';
-                  e.target.style.color = '#047857';
-                }}
-              >
-                View my rounds &amp; attestation queue
-              </button>
-            </div>
-          </div>
-        )}
+          )}
+        </header>
 
-        {/* Player Sign-Up & Availability - Primary CTA */}
-        <div style={{
-          background: 'rgba(255, 255, 255, 0.98)',
-          borderRadius: '16px',
-          padding: '40px',
-          marginBottom: '30px',
-          boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.2)',
-          backdropFilter: 'blur(10px)',
-          border: '2px solid rgba(4, 120, 87, 0.3)'
-        }}>
-          <h3 style={{
-            fontSize: '2rem',
-            fontWeight: 'bold',
-            color: '#1F2937',
-            marginBottom: '8px',
-            textAlign: 'center'
-          }}>
-            Mark Your Availability
-          </h3>
-          <p style={{
-            color: '#6B7280',
-            fontSize: '1.1rem',
-            textAlign: 'center',
-            marginBottom: '24px'
-          }}>
-            Sign up for daily games, see who's playing, and set your schedule
+        <section className="wgp-home__pillars" aria-label="Primary actions">
+          <button
+            type="button"
+            className="wgp-home__pillar"
+            onClick={() => navigate('/signup?tab=wgp-signup')}
+          >
+            <span className="wgp-home__pillar-kicker">This week</span>
+            <h2 className="wgp-home__pillar-title">Sign up to play</h2>
+            <p className="wgp-home__pillar-copy">
+              Claim an upcoming day and see who else is already on the sheet.
+            </p>
+          </button>
+
+          <button
+            type="button"
+            className="wgp-home__pillar"
+            onClick={() => navigate('/leaderboard')}
+          >
+            <span className="wgp-home__pillar-kicker">Standings</span>
+            <h2 className="wgp-home__pillar-title">Leaderboard</h2>
+            <p className="wgp-home__pillar-copy">
+              Season quarters and where you sit against the field.
+            </p>
+          </button>
+
+          <button
+            type="button"
+            className="wgp-home__pillar"
+            onClick={() => navigate('/rounds/post')}
+          >
+            <span className="wgp-home__pillar-kicker">After the round</span>
+            <h2 className="wgp-home__pillar-title">Record a score</h2>
+            <p className="wgp-home__pillar-copy">
+              One person posts for the group; partners attest from their accounts.
+            </p>
+          </button>
+        </section>
+
+        <section className="wgp-home__panel">
+          <h2>How scoring works</h2>
+          <p>
+            You are not creating throwaway players. Pick real Wing Point profiles, post the
+            group result once, and give everyone a shareable round link. Partners get notified
+            to attest.
           </p>
-
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-            gap: '16px',
-            marginBottom: '24px'
-          }}>
-            <button
-              onClick={() => navigate('/signup?tab=calendar')}
-              style={{
-                padding: '24px 20px',
-                background: 'linear-gradient(135deg, #047857, #065F46)',
-                color: 'white',
-                border: 'none',
-                borderRadius: '12px',
-                fontSize: '16px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                transition: 'all 0.3s ease',
-                boxShadow: '0 4px 6px rgba(4, 120, 87, 0.3)'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-3px)';
-                e.currentTarget.style.boxShadow = '0 8px 15px rgba(4, 120, 87, 0.4)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.boxShadow = '0 4px 6px rgba(4, 120, 87, 0.3)';
-              }}
-            >
-              <div style={{ fontSize: '2rem', marginBottom: '8px' }}>📅</div>
-              <div style={{ fontSize: '1.1rem' }}>Daily Sign-ups</div>
-              <div style={{ fontSize: '0.85rem', opacity: 0.9, marginTop: '6px' }}>
-                Sign up for today or this week
+          <ol className="wgp-home__steps">
+            <li>
+              <span className="wgp-home__step-num" aria-hidden="true">1</span>
+              <div>
+                <strong>Post for the group</strong>
+                <span>
+                  Stuart plays with Terry, Steve, and Brett — select their existing profiles and
+                  enter the quarters result.
+                </span>
               </div>
-            </button>
-            <button
-              onClick={() => navigate('/signup?tab=availability')}
-              style={{
-                padding: '24px 20px',
-                background: 'linear-gradient(135deg, #0369A1, #075985)',
-                color: 'white',
-                border: 'none',
-                borderRadius: '12px',
-                fontSize: '16px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                transition: 'all 0.3s ease',
-                boxShadow: '0 4px 6px rgba(3, 105, 161, 0.3)'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-3px)';
-                e.currentTarget.style.boxShadow = '0 8px 15px rgba(3, 105, 161, 0.4)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.boxShadow = '0 4px 6px rgba(3, 105, 161, 0.3)';
-              }}
-            >
-              <div style={{ fontSize: '2rem', marginBottom: '8px' }}>🕒</div>
-              <div style={{ fontSize: '1.1rem' }}>My Availability</div>
-              <div style={{ fontSize: '0.85rem', opacity: 0.9, marginTop: '6px' }}>
-                Set your weekly schedule
+            </li>
+            <li>
+              <span className="wgp-home__step-num" aria-hidden="true">2</span>
+              <div>
+                <strong>Get a round ID</strong>
+                <span>
+                  Each post gets a unique round ID so the result is findable and shareable —
+                  same idea as a join code for live games.
+                </span>
               </div>
-            </button>
-            <button
-              onClick={() => navigate('/signup?tab=all-availability')}
-              style={{
-                padding: '24px 20px',
-                background: 'linear-gradient(135deg, #7C2D12, #9A3412)',
-                color: 'white',
-                border: 'none',
-                borderRadius: '12px',
-                fontSize: '16px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                transition: 'all 0.3s ease',
-                boxShadow: '0 4px 6px rgba(124, 45, 18, 0.3)'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-3px)';
-                e.currentTarget.style.boxShadow = '0 8px 15px rgba(124, 45, 18, 0.4)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.boxShadow = '0 4px 6px rgba(124, 45, 18, 0.3)';
-              }}
-            >
-              <div style={{ fontSize: '2rem', marginBottom: '8px' }}>👥</div>
-              <div style={{ fontSize: '1.1rem' }}>Who's Playing</div>
-              <div style={{ fontSize: '0.85rem', opacity: 0.9, marginTop: '6px' }}>
-                See all player availability
+            </li>
+            <li>
+              <span className="wgp-home__step-num" aria-hidden="true">3</span>
+              <div>
+                <strong>Partners attest</strong>
+                <span>
+                  Terry, Steve, and Brett see a notification when they open the app and confirm
+                  the round from earlier today.
+                </span>
               </div>
+            </li>
+          </ol>
+          <div className="wgp-home__actions">
+            {isAuthenticated ? (
+              <button
+                type="button"
+                className="wgp-home__btn wgp-home__btn--primary"
+                onClick={() => navigate('/rounds/post')}
+              >
+                Post or attest a round
+              </button>
+            ) : (
+              <LoginButton
+                style={{
+                  fontSize: '15px',
+                  padding: '11px 16px',
+                  background: '#047857',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '10px',
+                  cursor: 'pointer',
+                  fontWeight: 650,
+                }}
+              />
+            )}
+            <button
+              type="button"
+              className="wgp-home__btn wgp-home__btn--ghost"
+              onClick={() => navigate('/signup?tab=wgp-signup')}
+            >
+              Open this week&apos;s sign-up
             </button>
           </div>
+        </section>
 
-          <div style={{ textAlign: 'center' }}>
-            <button
-              onClick={() => navigate('/signup?tab=matchmaking')}
-              style={{
-                padding: '10px 24px',
-                background: 'transparent',
-                color: '#047857',
-                border: '1px solid #047857',
-                borderRadius: '8px',
-                fontSize: '14px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                transition: 'all 0.2s'
-              }}
-              onMouseEnter={(e) => {
-                e.target.style.background = '#047857';
-                e.target.style.color = 'white';
-              }}
-              onMouseLeave={(e) => {
-                e.target.style.background = 'transparent';
-                e.target.style.color = '#047857';
-              }}
-            >
-              View Matchmaking Suggestions
-            </button>
-          </div>
-        </div>
-
-        {/* Stale Game Nudge - shown if user has games idle 24+ hours */}
         <StaleGameBanner isAuthenticated={isAuthenticated} />
 
-        {/* Resume Game Banner - shown if active session exists */}
         {activeGameSession && (
-          <div style={{
-            background: 'linear-gradient(135deg, #F59E0B, #D97706)',
-            borderRadius: '12px',
-            padding: '20px',
-            marginBottom: '30px',
-            boxShadow: '0 4px 6px rgba(245, 158, 11, 0.3)'
-          }}>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              gap: '16px'
-            }}>
-              <div style={{ flex: 1, minWidth: '200px' }}>
-                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'white', marginBottom: '8px' }}>
-                  Active Game Found
-                </div>
-                <div style={{ color: 'rgba(255, 255, 255, 0.95)', fontSize: '1rem' }}>
-                  Playing as <strong>{activeGameSession.playerName}</strong>
-                </div>
-                <div style={{ color: 'rgba(255, 255, 255, 0.85)', fontSize: '0.9rem', marginTop: '4px' }}>
-                  Join Code: <strong>{activeGameSession.joinCode}</strong>
-                </div>
-              </div>
-              <button
-                onClick={() => navigate(`/game/${activeGameSession.gameId}`)}
-                style={{
-                  padding: '16px 32px',
-                  background: 'white',
-                  color: '#D97706',
-                  border: 'none',
-                  borderRadius: '8px',
-                  fontSize: '16px',
-                  fontWeight: '700',
-                  cursor: 'pointer',
-                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-                  transition: 'all 0.2s'
-                }}
-                onMouseEnter={(e) => e.target.style.transform = 'scale(1.05)'}
-                onMouseLeave={(e) => e.target.style.transform = 'scale(1)'}
-              >
-                Resume Game
-              </button>
+          <div className="wgp-home__resume">
+            <div>
+              <strong>Active live game</strong>
+              <p>
+                Playing as <strong>{activeGameSession.playerName}</strong>
+                {activeGameSession.joinCode ? (
+                  <>
+                    {' '}
+                    · Join code <strong>{activeGameSession.joinCode}</strong>
+                  </>
+                ) : null}
+              </p>
             </div>
+            <button type="button" onClick={() => navigate(`/game/${activeGameSession.gameId}`)}>
+              Resume
+            </button>
           </div>
         )}
 
-        {/* Quick Actions Grid */}
-        <div className="wgp-box-grid" style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-          gap: '16px',
-          marginBottom: '30px'
-        }}>
-          <button
-            onClick={() => navigate('/scorecard-scan')}
-            style={{
-              padding: '20px 16px',
-              background: 'linear-gradient(135deg, rgba(2, 132, 199, 0.9), rgba(3, 105, 161, 0.95))',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(2, 132, 199, 0.3)',
-              textAlign: 'center',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(2, 132, 199, 0.4)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(2, 132, 199, 0.3)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>📷</div>
-            <div>Scan Scorecard</div>
-          </button>
-          <button
-            onClick={() => navigate('/game')}
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)'
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(0, 0, 0, 0.12)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.08)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>⚔️</div>
-            <div>New Game</div>
-          </button>
-          <button
-            onClick={() => navigate('/join')}
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)'
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(0, 0, 0, 0.12)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.08)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>🔗</div>
-            <div>Join Game</div>
-          </button>
-          <button
-            onClick={() => navigate('/games/active')}
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)'
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(0, 0, 0, 0.12)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.08)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>🎮</div>
-            <div>Active Games</div>
-          </button>
-          <button
-            onClick={() => navigate('/games/completed')}
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)'
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(0, 0, 0, 0.12)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.08)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>🏆</div>
-            <div>History</div>
-          </button>
-          <button
-            onClick={() => navigate('/rounds/post')}
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)'
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(0, 0, 0, 0.12)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.08)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>📝</div>
-            <div>Post Round</div>
-          </button>
-          <button
-            onClick={() => navigate('/game-scorer')}
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)'
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(0, 0, 0, 0.12)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.08)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>📝</div>
-            <div>Score Rounds</div>
-          </button>
-          <button
-            onClick={() => navigate('/tutorial')}
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)'
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 15px rgba(0, 0, 0, 0.12)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.08)';
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>🎓</div>
-            <div>Tutorial</div>
-          </button>
-        </div>
-        
-        {/* Legacy Pages */}
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-          gap: '16px',
-          marginBottom: '30px'
-        }}>
-          <a
-            href="https://thousand-cranes.com/WolfGoatPig/wgp_tee_sheet.cgi"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)',
-              textDecoration: 'none',
-              display: 'block'
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>📋</div>
-            <div>Legacy Sign Up</div>
-            <div style={{ fontSize: '0.8rem', color: '#6B7280', marginTop: '4px', fontWeight: '400' }}>
-              Original tee sheet
-            </div>
-          </a>
-          <a
-            href="https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              padding: '20px 16px',
-              background: 'rgba(255, 255, 255, 0.95)',
-              color: '#1F2937',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '15px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.3s ease',
-              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.08)',
-              textAlign: 'center',
-              backdropFilter: 'blur(10px)',
-              textDecoration: 'none',
-              display: 'block'
-            }}
-          >
-            <div style={{ fontSize: '1.8rem', marginBottom: '8px' }}>📊</div>
-            <div>Legacy Standings</div>
-            <div style={{ fontSize: '0.8rem', color: '#6B7280', marginTop: '4px', fontWeight: '400' }}>
-              Spreadsheet standings
-            </div>
-          </a>
-        </div>
-
-        {/* Auth Status Check for Development */}
-        <AuthHealthCheck />
-        
-        {/* About Section */}
-        <div style={{
-          background: 'rgba(255, 255, 255, 0.98)',
-          borderRadius: '16px',
-          padding: '40px',
-          boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.2)',
-          backdropFilter: 'blur(10px)'
-        }}>
-          <h3 style={{
-            fontSize: '2rem',
-            fontWeight: 'bold',
-            color: '#1F2937',
-            marginBottom: '20px',
-            textAlign: 'center'
-          }}>
-            About Wolf Goat Pig 🐺🐐🐷
-          </h3>
-          <p style={{
-            color: '#4B5563',
-            fontSize: '1.1rem',
-            lineHeight: '1.8',
-            marginBottom: '20px'
-          }}>
-            Wolf Goat Pig is a sophisticated golf betting game where strategy meets skill. 
-            Players take turns as the "Captain" and must decide whether to:
-          </p>
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-            gap: '20px',
-            marginBottom: '20px'
-          }}>
-            <div style={{
-              background: 'rgba(240, 253, 250, 0.8)',
-              padding: '20px',
-              borderRadius: '12px',
-              borderLeft: '4px solid #047857'
-            }}>
-              <strong style={{ color: '#065F46' }}>🤝 Request a Partner</strong>
-              <p style={{ marginTop: '8px', color: '#6B7280' }}>
-                Team up for a traditional best-ball format
-              </p>
-            </div>
-            <div style={{
-              background: 'rgba(254, 242, 242, 0.8)',
-              padding: '20px',
-              borderRadius: '12px',
-              borderLeft: '4px solid #B45309'
-            }}>
-              <strong style={{ color: '#92400E' }}>🎯 Go Solo</strong>
-              <p style={{ marginTop: '8px', color: '#6B7280' }}>
-                Face all three players alone (doubles the wager!)
-              </p>
-            </div>
+        <details className="wgp-home__more">
+          <summary>More tools — live games, scanning, history</summary>
+          <div className="wgp-home__more-grid">
+            {ADVANCED_TOOLS.map((tool) => (
+              <button key={tool.path} type="button" onClick={() => navigate(tool.path)}>
+                {tool.label}
+              </button>
+            ))}
+            <a
+              href="https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Legacy standings
+            </a>
           </div>
-          <p style={{
-            color: '#4B5563',
-            fontSize: '1.1rem',
-            lineHeight: '1.8'
-          }}>
-            With doubling opportunities, the Float, the Option, and complex scoring rules like 
-            the Karl Marx principle, Wolf Goat Pig rewards both golf skill and betting acumen.
-          </p>
-        </div>
+        </details>
+
+        <AuthHealthCheck />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Restructures the home landing page around three primary jobs: sign up for upcoming days, check the leaderboard, and record/attest group scores.
- Explains the group scoring model on home: pick existing profiles, post once, get a navigable `WGP-{id}`, partners attest from notifications.
- Buries advanced tools (live game, scan, history, LivSow, etc.) under a collapsed "More tools" section.
- Adds in-app `round_attestation` notifications when a round is posted; the bell routes those to `/rounds/post`.
- Promotes Standings / Scores in primary nav and demotes live-game entry points.

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `pytest tests/unit/routers/test_member_rounds_router.py` (18 passed)
- [ ] Open `/` signed out — brand + sign-in + three pillars visible; advanced tools collapsed
- [ ] Open `/` signed in — pillars route to signup, leaderboard, and `/rounds/post`
- [ ] Post a round with 2–3 foursome members — success shows `WGP-{id}`; partners receive email + in-app notification
- [ ] Tap attestation notification — lands on `/rounds/post` attestation queue
- [ ] Mobile bottom tabs show Home / Sign Up / Standings / Account

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added round codes in the format `WGP-####` when posting scores.
  * Added in-app attestation notifications alongside email requests.
  * Notification bell now highlights attestation requests and links directly to posting/attesting a round.
  * Redesigned the home page with clearer actions, scoring guidance, resume-game access, and responsive layouts.
  * Updated navigation to make Standings and account access easier to find.

* **Improvements**
  * Post-round confirmation now displays the round code and notification status.
  * Updated notification labels and icons for clearer attestation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->