### PR TITLE
fix(signup): default Sign up to play to the day-by-day sheet

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -427,7 +427,7 @@ function App() {
               <Route path="/badges" element={<BadgesPage />} />
               <Route path="/scorecard-scan" element={<ScorecardScanPage />} />
               <Route path="/ask" element={<AskPage />} />
-              <Route path="/tee-sheet" element={<Navigate to="/signup?tab=wgp-signup" />} />
+              <Route path="/tee-sheet" element={<Navigate to="/signup?tab=calendar" />} />
               <Route path="/find-a-game" element={<FindAGamePage />} />
               <Route path="/players" element={<PlayersRosterPage />} />
               <Route path="/players/:playerId" element={<PlayerProfilePage />} />

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -81,12 +81,12 @@ function HomePage() {
           <button
             type="button"
             className="wgp-home__pillar"
-            onClick={() => navigate('/signup?tab=wgp-signup')}
+            onClick={() => navigate('/signup?tab=calendar')}
           >
             <span className="wgp-home__pillar-kicker">This week</span>
             <h2 className="wgp-home__pillar-title">Sign up to play</h2>
             <p className="wgp-home__pillar-copy">
-              Claim an upcoming day and see who else is already on the sheet.
+              Day-by-day sheet — claim a date and see who else is already in.
             </p>
           </button>
 
@@ -180,7 +180,7 @@ function HomePage() {
             <button
               type="button"
               className="wgp-home__btn wgp-home__btn--ghost"
-              onClick={() => navigate('/signup?tab=wgp-signup')}
+              onClick={() => navigate('/signup?tab=calendar')}
             >
               Open this week&apos;s sign-up
             </button>

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useSearchParams } from 'react-router-dom';
 import ForeTeesTeeSheet from '../components/foretees/ForeTeesTeeSheet';
+import DailySignupView from '../components/signup/DailySignupView';
 import WgpSignupSheet from '../components/signup/WgpSignupSheet';
 import '../styles/mobile-touch.css';
 
@@ -9,8 +10,8 @@ const SignupPage = () => {
   const { user, isAuthenticated, loginWithRedirect } = useAuth0();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Default to 'calendar' (day view) - this is the primary view
-  const [activeTab, setActiveTab] = useState(searchParams.get('tab') || 'wgp-signup');
+  // Day-by-day weekly sheet is the familiar primary view.
+  const [activeTab, setActiveTab] = useState(searchParams.get('tab') || 'calendar');
   const isUserNavigation = useRef(false);
 
   // Handle tab click: update state and URL together to avoid effect loops
@@ -34,10 +35,10 @@ const SignupPage = () => {
     }
   }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Tab configuration - Day view is first and default
   const tabs = [
-    { id: 'wgp-signup', label: '⛳ WGP Sign Up', icon: '⛳' },
-    { id: 'calendar', label: '📅 Book Tee Time', icon: '📅' },
+    { id: 'calendar', label: '📅 Daily Sign-ups', icon: '📅' },
+    { id: 'wgp-signup', label: '⛳ WGP Tee Sheet', icon: '⛳' },
+    { id: 'tee-times', label: '🏌️ Book Tee Time', icon: '🏌️' },
   ];
 
   if (!isAuthenticated) {
@@ -62,7 +63,7 @@ const SignupPage = () => {
             ⛳ Sign Up to Play
           </h2>
           <p style={{ color: '#6c757d', marginBottom: '30px', lineHeight: 1.5 }}>
-            Sign up for a day's game or book a tee time.
+            Sign up for a day's game and see who else is playing.
           </p>
           <button
             onClick={() => loginWithRedirect()}
@@ -98,7 +99,7 @@ const SignupPage = () => {
           fontSize: '24px',
           fontWeight: '700'
         }}>
-          WGP Tee Sheet
+          Sign Up to Play
         </h1>
         {user && (
           <div style={{
@@ -139,11 +140,15 @@ const SignupPage = () => {
 
       {/* Tab Content */}
       <div style={{ minHeight: '500px' }}>
+        {activeTab === 'calendar' && (
+          <DailySignupView />
+        )}
+
         {activeTab === 'wgp-signup' && (
           <WgpSignupSheet />
         )}
 
-        {activeTab === 'calendar' && (
+        {activeTab === 'tee-times' && (
           <ForeTeesTeeSheet />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Makes the familiar day-by-day weekly signup sheet (`DailySignupView`) the default signup tab again.
- Points home **Sign up to play** and `/tee-sheet` at `/signup?tab=calendar`.
- Keeps WGP Tee Sheet and Book Tee Time as secondary tabs.

## Test plan
- [x] `npm run typecheck` (frontend)
- [ ] Click **Sign up to play** on home → lands on Daily Sign-ups with week strip + who's playing
- [ ] `/signup` with no tab param defaults to Daily Sign-ups
- [ ] WGP Tee Sheet and Book Tee Time tabs still switch correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated tee-times browsing tab to the signup experience.
  * Added calendar-based daily signup viewing alongside existing signup options.
  * Set the calendar view as the default signup tab.

* **Improvements**
  * Updated links throughout the app to open the calendar signup view.
  * Refined signup descriptions and prompts to better reflect day-by-day participation and game selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->