### PR TITLE
refactor: migrate matchmaking components to the typed API client

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -729,12 +729,26 @@
             "title": "Notes"
           },
           "player_name": {
-            "title": "Player Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Player Name"
           },
           "player_profile_id": {
-            "title": "Player Profile Id",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Player Profile Id"
           },
           "preferred_start_time": {
             "anyOf": [
@@ -749,9 +763,7 @@
           }
         },
         "required": [
-          "date",
-          "player_profile_id",
-          "player_name"
+          "date"
         ],
         "title": "DailySignupCreate",
         "type": "object"
@@ -14114,7 +14126,7 @@
         ]
       },
       "post": {
-        "description": "Create a daily sign-up for a player.",
+        "description": "Create a daily sign-up for the authenticated player.",
         "operationId": "create_signup_signups_post",
         "requestBody": {
           "content": {
@@ -14148,6 +14160,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Create Signup",
         "tags": [
           "signups"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,10 @@
 # Core FastAPI and server dependencies
-fastapi>=0.110.0,<1.0
+# fastapi is PINNED (exact) because it generates the OpenAPI schema committed at
+# backend/openapi.json — different FastAPI versions emit subtly different schemas
+# (e.g. Optional fields as `anyOf: [T, null]`), which would drift the committed
+# contract and fail the openapi-contract CI check. Bump deliberately and run
+# `python scripts/export_openapi.py` + `npm run gen:api` in the same change.
+fastapi==0.140.0
 uvicorn[standard]>=0.29.0
 python-multipart>=0.0.9
 
@@ -13,7 +18,11 @@ python-dotenv>=1.0.1
 requests>=2.31.0
 
 # Data validation and serialization
-pydantic>=2.6.0,<3.0
+# pydantic is PINNED (exact) for the same reason as fastapi — it drives JSON
+# Schema serialization for the committed OpenAPI contract. Bump deliberately and
+# regenerate the spec + frontend types in the same change. (pydantic pins its own
+# compatible pydantic-core, so that stays deterministic too.)
+pydantic==2.13.4
 
 # SQL parsing — Commissioner read-only SQL validator (_validate_sql) uses
 # sqlglot's AST to enumerate table refs, closing regex-based bypasses.

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,18 @@
+/**
+ * Small helpers for working with the typed API client (`src/api/client`).
+ */
+
+/**
+ * Extract a human-readable message from a FastAPI error body.
+ *
+ * FastAPI errors come back as `{ detail: string | ValidationError[] }`; this
+ * returns the string form and `undefined` for the array/500 cases so callers
+ * can fall back to their own message.
+ */
+export function errorDetail(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'detail' in error) {
+    const detail = (error as { detail?: unknown }).detail;
+    if (typeof detail === 'string') return detail;
+  }
+  return undefined;
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4301,7 +4301,7 @@ export interface paths {
         put?: never;
         /**
          * Create Signup
-         * @description Create a daily sign-up for a player.
+         * @description Create a daily sign-up for the authenticated player.
          */
         post: operations["create_signup_signups_post"];
         delete?: never;
@@ -5011,9 +5011,9 @@ export interface components {
             /** Notes */
             notes?: string | null;
             /** Player Name */
-            player_name: string;
+            player_name?: string | null;
             /** Player Profile Id */
-            player_profile_id: number;
+            player_profile_id?: number | null;
             /** Preferred Start Time */
             preferred_start_time?: string | null;
         };

--- a/frontend/src/components/signup/MatchmakingSuggestions.jsx
+++ b/frontend/src/components/signup/MatchmakingSuggestions.jsx
@@ -2,9 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useTeeTimes from '../../hooks/useTeeTimes';
 import BookingModal from '../foretees/BookingModal';
-import { apiConfig } from '../../config/api.config';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
 
 // Get the next occurrence of a day-of-week (0=Mon, 6=Sun)
 const getNextDateForDay = (dayOfWeek) => {
@@ -64,15 +62,15 @@ const MatchmakingSuggestions = () => {
   const loadMatches = useCallback(async () => {
     try {
       setLoading(true);
-      const params = new URLSearchParams();
-      params.append('min_overlap_hours', minOverlapHours);
-      if (selectedDays.length > 0) {
-        params.append('preferred_days', selectedDays.join(','));
-      }
-
-      const response = await fetch(`${API_URL}/matchmaking/suggestions?${params}`);
-      if (response.ok) {
-        const data = await response.json();
+      const { data } = await api.GET('/matchmaking/suggestions', {
+        params: {
+          query: {
+            min_overlap_hours: minOverlapHours,
+            ...(selectedDays.length > 0 ? { preferred_days: selectedDays.join(',') } : {}),
+          },
+        },
+      });
+      if (data) {
         setMatches(data.matches || []);
       } else {
         throw new Error('Failed to load match suggestions');
@@ -100,13 +98,9 @@ const MatchmakingSuggestions = () => {
   const sendAllNotifications = async () => {
     try {
       setSendingNotifications(true);
-      const response = await fetch(`${API_URL}/matchmaking/create-and-notify`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
-      });
+      const { data: result } = await api.POST('/matchmaking/create-and-notify', {});
 
-      if (response.ok) {
-        const result = await response.json();
+      if (result) {
         alert(`Sent ${result.notifications_sent} notifications for ${result.matches_created} matches!`);
         loadMatches();
       } else {

--- a/frontend/src/components/signup/MyMatches.jsx
+++ b/frontend/src/components/signup/MyMatches.jsx
@@ -3,9 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useAccessToken } from '../../hooks/useAccessToken';
 import useTeeTimes from '../../hooks/useTeeTimes';
 import BookingModal from '../foretees/BookingModal';
-import { apiConfig } from '../../config/api.config';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
+import { errorDetail } from '../../api/http';
 
 const dayNamesFull = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
@@ -55,17 +54,9 @@ const MyMatches = () => {
   const [bookingSlot, setBookingSlot] = useState(null);
   const [bookingResult, setBookingResult] = useState(null);
 
-  const authFetch = useCallback(async (url, options = {}) => {
+  const authHeaders = useCallback(async () => {
     const token = await getToken();
-    const fullUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
-    return fetch(fullUrl, {
-      ...options,
-      headers: {
-        ...options.headers,
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    });
+    return { Authorization: `Bearer ${token}` };
   }, [getToken]);
 
   const fetchMatches = useCallback(async (overrideStatus) => {
@@ -73,20 +64,21 @@ const MyMatches = () => {
     setError(null);
     try {
       const filter = overrideStatus !== undefined ? overrideStatus : statusFilter;
-      const params = filter ? `?status=${filter}` : '';
-      const resp = await authFetch(`/matchmaking/my-matches${params}`);
-      if (resp.ok) {
-        setMatches(await resp.json());
+      const { data, error: apiError } = await api.GET('/matchmaking/my-matches', {
+        params: { query: filter ? { status: filter } : {} },
+        headers: await authHeaders(),
+      });
+      if (data) {
+        setMatches(data);
       } else {
-        const err = await resp.json();
-        setError(err.detail || 'Failed to load matches');
+        setError(errorDetail(apiError) || 'Failed to load matches');
       }
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
-  }, [authFetch, statusFilter]);
+  }, [authHeaders, statusFilter]);
 
   useEffect(() => { fetchMatches(); }, [fetchMatches]);
 
@@ -100,13 +92,13 @@ const MyMatches = () => {
   const handleRespond = async (matchId, response) => {
     setRespondingTo(matchId);
     try {
-      const resp = await authFetch(`/matchmaking/matches/${matchId}/respond`, {
-        method: 'POST',
-        body: JSON.stringify({ response }),
+      const { data, error: apiError } = await api.POST('/matchmaking/matches/{match_id}/respond', {
+        params: { path: { match_id: matchId } },
+        body: { response },
+        headers: await authHeaders(),
       });
-      const data = await resp.json();
-      if (!resp.ok) {
-        setError(data.detail || `Failed to ${response}`);
+      if (!data) {
+        setError(errorDetail(apiError) || `Failed to ${response}`);
       } else if (data.all_accepted) {
         // All players accepted — switch to "accepted" filter so the user
         // can see the "Book Tee Time" button that just became available.


### PR DESCRIPTION
## Summary

First incremental batch of call-site migrations onto the typed API client from #314, plus a fix for a contract-drift problem this PR surfaced.

### Matchmaking migration (the headline change)
Completes the **matchmaking vertical**: the `useMatchmaking` hook (from #314) plus both matchmaking components now go through the generated typed client, so paths, params, bodies, and responses are checked against the OpenAPI contract.

- **`src/api/http.ts`** (new) — shared typed `errorDetail()` helper for FastAPI's `{ detail }` error bodies.
- **`MyMatches.jsx`** — `/matchmaking/my-matches` + `/matchmaking/matches/{match_id}/respond` via the typed client; per-request `Bearer` auth preserved.
- **`MatchmakingSuggestions.jsx`** — `/matchmaking/suggestions` + `/matchmaking/create-and-notify`; unauthenticated calls preserved.

### Contract-drift fix (surfaced by this PR's CI)
The `contract-in-sync` check failed on the first push — not from the frontend changes, but because:
1. **The committed spec on `main` was stale**: `POST /signups` had gained `HTTPBearer` auth and optional fields, but `openapi.json` was never regenerated when that backend change merged (parallel-merge race with #314 introducing the check).
2. **FastAPI/Pydantic floated**: CI installed a newer FastAPI (0.140.0) that emits `Optional` fields as `anyOf: [T, null]`, so the generated schema wasn't byte-deterministic.

Fixes:
- **Regenerated** `backend/openapi.json` + `frontend/src/api/schema.d.ts` against current backend code (diff localized to `/signups`).
- **Pinned** `fastapi==0.140.0` and `pydantic==2.13.4` in `requirements.txt` (with inline rationale) so spec generation is reproducible across local/CI/prod. Bumping either is now a deliberate change that regenerates the spec + types in the same PR.

## Verification
- **Frontend:** `npm run typecheck` ✅ · `vitest run` ✅ (563 passed) · `npm run build` ✅
- **Contract:** `export_openapi.py --check` ✅ · `gen:api` no-diff ✅ · pip resolves with the pins ✅

## Follow-up
Signup cluster (`DailySignupView`, `SignupCalendar`, `WgpSignupSheet`, `PlayerAvailability`, `AllPlayersAvailability`, `EmailPreferences`) migrates as the next batch — endpoints already verified against the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVoeDseEgTJbNf9dTPB21t