### PR TITLE
refactor: make typed client test-mockable; migrate availability views

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,6 +14,12 @@ import { apiConfig } from '../config/api.config';
  * with a token acquired via Auth0 (`acquireAccessToken`). Keeping auth out of the
  * client leaves it stateless and trivially testable.
  */
-export const api = createClient<paths>({ baseUrl: apiConfig.baseUrl });
+export const api = createClient<paths>({
+  baseUrl: apiConfig.baseUrl,
+  // Resolve `fetch` per request rather than capturing globalThis.fetch at client
+  // creation. This keeps prod behavior identical while letting tests that swap
+  // `global.fetch` (after this module is imported) intercept the client's calls.
+  fetch: (input: Request) => globalThis.fetch(input),
+});
 
 export default api;

--- a/frontend/src/components/signup/AllPlayersAvailability.jsx
+++ b/frontend/src/components/signup/AllPlayersAvailability.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { apiConfig } from '../../config/api.config';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
 
 const AllPlayersAvailability = () => {
   const navigate = useNavigate();
@@ -17,10 +15,9 @@ const AllPlayersAvailability = () => {
   const loadAllAvailability = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`${API_URL}/players/availability/all`);
+      const { data } = await api.GET('/players/availability/all');
 
-      if (response.ok) {
-        const data = await response.json();
+      if (data) {
         setPlayersAvailability(data);
       } else {
         throw new Error('Failed to load availability data');

--- a/frontend/src/components/signup/PlayerAvailability.jsx
+++ b/frontend/src/components/signup/PlayerAvailability.jsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { apiConfig } from '../../config/api.config';
 import { acquireAccessToken } from '../../services/authToken';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
+import { errorDetail } from '../../api/http';
 
 const dayNamesFull = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
@@ -40,6 +39,18 @@ const PlayerAvailability = () => {
     }));
   }, []);
 
+  // Auth header for /players/me requests: Auth0 token, falling back to a
+  // stored token if the silent acquisition fails.
+  const getAuthHeader = useCallback(async () => {
+    let token;
+    try {
+      token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
+    } catch {
+      token = localStorage.getItem('auth_token');
+    }
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }, [getAccessTokenSilently, tokenOptions]);
+
   const loadAvailability = useCallback(async () => {
     if (!isAuthenticated) {
       setLoading(false);
@@ -48,18 +59,11 @@ const PlayerAvailability = () => {
 
     try {
       setLoading(true);
-      let token;
-      try {
-        token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
-      } catch (e) {
-        token = localStorage.getItem('auth_token');
-      }
+      const { data } = await api.GET('/players/me/availability', {
+        headers: await getAuthHeader(),
+      });
 
-      const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
-      const response = await fetch(`${API_URL}/players/me/availability`, { headers });
-
-      if (response.ok) {
-        const data = await response.json();
+      if (data) {
         const completeAvailability = initializeAvailability();
         data.forEach(item => {
           if (item.day_of_week >= 0 && item.day_of_week <= 6) {
@@ -84,7 +88,7 @@ const PlayerAvailability = () => {
     } finally {
       setLoading(false);
     }
-  }, [getAccessTokenSilently, initializeAvailability, isAuthenticated, tokenOptions]);
+  }, [getAuthHeader, initializeAvailability, isAuthenticated]);
 
   useEffect(() => {
     loadAvailability();
@@ -111,35 +115,21 @@ const PlayerAvailability = () => {
     try {
       setSaving(true);
       setMatchResult(null);
-      let token;
-      try {
-        token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
-      } catch (e) {
-        token = localStorage.getItem('auth_token');
-      }
-
-      const headers = { 'Content-Type': 'application/json' };
-      if (token) headers['Authorization'] = `Bearer ${token}`;
-
-      const response = await fetch(`${API_URL}/players/me/availability`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
+      const { data: result, error: apiError } = await api.POST('/players/me/availability', {
+        headers: await getAuthHeader(),
+        body: {
           player_profile_id: 0,
           day_of_week: dayData.day_of_week,
           is_available: dayData.is_available,
           available_from_time: dayData.available_from_time || null,
           available_to_time: dayData.available_to_time || null,
-          notes: dayData.notes || null
-        })
+          notes: dayData.notes || null,
+        },
       });
 
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to save');
+      if (!result) {
+        throw new Error(errorDetail(apiError) || 'Failed to save');
       }
-
-      const result = await response.json();
 
       // The response now includes availability + match results
       const updatedAvail = result.availability || result;

--- a/frontend/src/components/signup/__tests__/PlayerAvailability.test.jsx
+++ b/frontend/src/components/signup/__tests__/PlayerAvailability.test.jsx
@@ -145,19 +145,14 @@ describe('PlayerAvailability', () => {
     const saveButton = screen.getAllByText('Save')[0];
     fireEvent.click(saveButton);
 
-    await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/players/me/availability'),
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer mock-token'
-          }),
-          body: expect.stringContaining('Updated note')
-        })
-      );
-    });
+    // The typed client calls fetch with a single Request object.
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const request = fetch.mock.calls.at(-1)[0];
+    expect(request.url).toContain('/players/me/availability');
+    expect(request.method).toBe('POST');
+    expect(request.headers.get('Authorization')).toBe('Bearer mock-token');
+    expect(request.headers.get('Content-Type')).toContain('application/json');
+    expect(await request.clone().text()).toContain('Updated note');
   });
 
   test('handles save errors', async () => {

--- a/frontend/src/test-utils/mockFactories.jsx
+++ b/frontend/src/test-utils/mockFactories.jsx
@@ -538,15 +538,15 @@ export const createMockEvent = (type = 'click', properties = {}) => ({
  * @returns {Promise} Mock fetch response
  */
 export const createMockFetchResponse = (data, options = {}) => {
-  return Promise.resolve({
-    ok: true,
-    status: 200,
-    statusText: 'OK',
-    json: async () => data,
-    text: async () => JSON.stringify(data),
-    headers: new Headers(options.headers || {}),
-    ...options
-  });
+  const { status = 200, headers = {} } = options;
+  // Return a real Response so both plain `fetch(...).json()` callers and the
+  // typed client (openapi-fetch, which inspects headers/clones the body) work.
+  return Promise.resolve(
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'Content-Type': 'application/json', ...headers },
+    })
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary

Batch 2 of the typed-client migration (signup cluster) — this first slice ships a **test-infrastructure unblock** plus the two availability views. The infra fix matters beyond this batch: it's required to migrate any component that has tests, so it unblocks the rest of the migration.

## The test-infra discovery

Converting the availability components surfaced two incompatibilities between `openapi-fetch` and the existing test setup (they didn't appear in Batch 1 because `useMatchmaking`/`MyMatches`/`MatchmakingSuggestions` have no fetch-mocking tests):

1. **The client captured `globalThis.fetch` at creation.** `openapi-fetch` binds `fetch` when `createClient` runs (module import), so tests that set `global.fetch = vi.fn()` *after* import never intercepted the client's calls — it hit a real fetch and threw. **Fix:** `client.ts` now resolves `fetch` per request (`fetch: (input) => globalThis.fetch(input)`). Prod behavior is identical.
2. **The mock factory returned a plain object.** `createMockFetchResponse` returned `{ ok, json, ... }`, which `openapi-fetch` can't parse (it needs a real `Response` with headers/body). **Fix:** it now returns a real `Response`. Only two test files use it; both pass.

## Migrations

- **`AllPlayersAvailability`** — `GET /players/availability/all`.
- **`PlayerAvailability`** — `GET`/`POST /players/me/availability`, preserving the Auth0-token-with-localStorage-fallback auth. Its save test now asserts the typed client's single-`Request` `fetch` call instead of the old `(url, options)` shape.

## Verification

- **Frontend:** `npm run typecheck` ✅ · `vitest run` ✅ (563 passed) · `npm run build` ✅

## Follow-up (rest of the signup cluster)

`DailySignupView`, `SignupCalendar`, `WgpSignupSheet`, `EmailPreferences` land next. `DailySignupView`'s test routes its `fetch` mock by URL string, which needs reworking for the `Request`-based call — done carefully in the follow-up rather than rushed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVoeDseEgTJbNf9dTPB21t

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVoeDseEgTJbNf9dTPB21t)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved player availability loading and saving for more consistent results.
  - Strengthened authentication handling for availability updates.
  - Improved error messages when availability requests fail.
  - Preserved availability updates, notes, and match notifications during saves.
  - Improved handling of availability data across player views.

- **Tests**
  - Expanded coverage for availability requests, authentication, payloads, and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->