### PR TITLE
refactor: migrate remaining signup views to the typed API client

### DIFF
--- a/frontend/src/components/signup/DailySignupView.jsx
+++ b/frontend/src/components/signup/DailySignupView.jsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import '../../styles/mobile-touch.css';
-import { apiConfig } from '../../config/api.config';
 import { calculateCourseHandicap } from '../../utils';
 import { usePlayerProfile } from '../../hooks/usePlayerProfile';
 import { acquireAccessToken } from '../../services/authToken';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
+import { errorDetail } from '../../api/http';
 
 function getSignupButtonLabel({
   confirmingSignup,
@@ -64,9 +63,10 @@ const DailySignupView = ({ selectedDate: initialDate, onBack }) => {
     if (!weekStart) return;
     try {
       setLoading(true);
-      const response = await fetch(`${API_URL}/signups/weekly-with-messages?week_start=${weekStart}`);
-      if (response.ok) {
-        const data = await response.json();
+      const { data } = await api.GET('/signups/weekly-with-messages', {
+        params: { query: { week_start: weekStart } },
+      });
+      if (data) {
         setWeekData(data);
       } else {
         setWeekData({ daily_summaries: [] });
@@ -93,9 +93,10 @@ const DailySignupView = ({ selectedDate: initialDate, onBack }) => {
     try {
       setPairingsLoading(true);
       setPairingsError(null);
-      const response = await fetch(`${API_URL}/pairings/${date}`);
-      if (response.ok) {
-        const data = await response.json();
+      const { data, response } = await api.GET('/pairings/{date}', {
+        params: { path: { date } },
+      });
+      if (data) {
         setGeneratedPairings(data.exists ? data : null);
       } else {
         // 404 means no pairings generated yet — anything else is an error
@@ -203,25 +204,20 @@ const DailySignupView = ({ selectedDate: initialDate, onBack }) => {
     try {
       setSigningUp(true);
       const token = await acquireAccessToken(getAccessTokenSilently);
-      const response = await fetch(`${API_URL}/signups`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
+      const { data, error: apiError } = await api.POST('/signups', {
+        headers: { Authorization: `Bearer ${token}` },
+        body: {
           date: selectedDate,
           preferred_start_time: null,
-          notes: null
-        })
+          notes: null,
+        },
       });
-      if (response.ok) {
+      if (data) {
         await loadWeeklyData(currentWeekStart);
         setError(null);
         setConfirmingSignup(false);
       } else {
-        const errData = await response.json();
-        throw new Error(errData.detail || 'Failed to sign up');
+        throw new Error(errorDetail(apiError) || 'Failed to sign up');
       }
     } catch (err) {
       console.error('Signup error:', err);
@@ -241,15 +237,13 @@ const DailySignupView = ({ selectedDate: initialDate, onBack }) => {
     try {
       setLegacyReplicating(true);
       setLegacyResult(null);
-      const response = await fetch(`${API_URL}/signups/${userSignup.id}/replicate-legacy`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
+      const { data, error: apiError } = await api.POST('/signups/{signup_id}/replicate-legacy', {
+        params: { path: { signup_id: userSignup.id } },
       });
-      const data = await response.json();
-      if (response.ok) {
+      if (data) {
         setLegacyResult({ success: true, message: data.message || 'Replicated to legacy signup page' });
       } else {
-        setLegacyResult({ success: false, message: data.detail || 'Failed to replicate' });
+        setLegacyResult({ success: false, message: errorDetail(apiError) || 'Failed to replicate' });
       }
     } catch (err) {
       console.error('Legacy replicate error:', err);
@@ -262,7 +256,9 @@ const DailySignupView = ({ selectedDate: initialDate, onBack }) => {
   // Handle cancel signup
   const handleCancelSignup = async (signupId) => {
     try {
-      const response = await fetch(`${API_URL}/signups/${signupId}`, { method: 'DELETE' });
+      const { response } = await api.DELETE('/signups/{signup_id}', {
+        params: { path: { signup_id: signupId } },
+      });
       if (response.ok) {
         loadWeeklyData(currentWeekStart);
         setError(null);

--- a/frontend/src/components/signup/EmailPreferences.jsx
+++ b/frontend/src/components/signup/EmailPreferences.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { apiConfig } from '../../config/api.config';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
+import { errorDetail } from '../../api/http';
 
 const EmailPreferences = () => {
   const { user } = useAuth0();
@@ -36,12 +35,11 @@ const EmailPreferences = () => {
   const loadPreferences = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`${API_URL}/players/me/email-preferences`, {
-        headers: { 'Authorization': `Bearer ${localStorage.getItem('auth_token')}` }
+      const { data } = await api.GET('/players/me/email-preferences', {
+        headers: { Authorization: `Bearer ${localStorage.getItem('auth_token')}` },
       });
 
-      if (response.ok) {
-        const data = await response.json();
+      if (data) {
         setPreferences(data);
       }
       setError(null);
@@ -67,21 +65,15 @@ const EmailPreferences = () => {
       setSaving(true);
       setError(null);
 
-      const response = await fetch(`${API_URL}/players/me/email-preferences`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${localStorage.getItem('auth_token')}`
-        },
-        body: JSON.stringify(preferences)
+      const { data: updatedPreferences, error: apiError } = await api.PUT('/players/me/email-preferences', {
+        headers: { Authorization: `Bearer ${localStorage.getItem('auth_token')}` },
+        body: preferences,
       });
 
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to save');
+      if (!updatedPreferences) {
+        throw new Error(errorDetail(apiError) || 'Failed to save');
       }
 
-      const updatedPreferences = await response.json();
       setPreferences(updatedPreferences);
       setSuccess(true);
       setTimeout(() => setSuccess(false), 3000);

--- a/frontend/src/components/signup/SignupCalendar.jsx
+++ b/frontend/src/components/signup/SignupCalendar.jsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import '../../styles/mobile-touch.css';
-import { apiConfig } from '../../config/api.config';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
+import { errorDetail } from '../../api/http';
 
 const SignupCalendar = ({ onSignupChange, onDateSelect }) => {
   const { user, isAuthenticated } = useAuth0();
@@ -48,13 +47,14 @@ const SignupCalendar = ({ onSignupChange, onDateSelect }) => {
   const loadWeeklyData = async (weekStart) => {
     try {
       setLoading(true);
-      const response = await fetch(`${API_URL}/signups/weekly-with-messages?week_start=${weekStart}`);
+      const { data, response } = await api.GET('/signups/weekly-with-messages', {
+        params: { query: { week_start: weekStart } },
+      });
 
       if (!response.ok) {
         throw new Error(`Failed to load data: ${response.status}`);
       }
 
-      const data = await response.json();
       setWeekData(data);
       setError(null);
     } catch (err) {
@@ -88,21 +88,18 @@ const SignupCalendar = ({ onSignupChange, onDateSelect }) => {
     }
 
     try {
-      const response = await fetch(`${API_URL}/signups`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+      const { data, error: apiError } = await api.POST('/signups', {
+        body: {
           date,
           player_profile_id: 1,
           player_name: user.name || user.email,
           preferred_start_time: null,
-          notes: null
-        })
+          notes: null,
+        },
       });
 
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to sign up');
+      if (!data) {
+        throw new Error(errorDetail(apiError) || 'Failed to sign up');
       }
 
       loadWeeklyData(currentWeekStart);
@@ -114,7 +111,9 @@ const SignupCalendar = ({ onSignupChange, onDateSelect }) => {
 
   const handleCancelSignup = async (signupId) => {
     try {
-      const response = await fetch(`${API_URL}/signups/${signupId}`, { method: 'DELETE' });
+      const { response } = await api.DELETE('/signups/{signup_id}', {
+        params: { path: { signup_id: signupId } },
+      });
       if (!response.ok) throw new Error('Failed to cancel signup');
       loadWeeklyData(currentWeekStart);
       onSignupChange?.();
@@ -127,15 +126,13 @@ const SignupCalendar = ({ onSignupChange, onDateSelect }) => {
     if (!messageInput.trim()) return;
 
     try {
-      const response = await fetch(`${API_URL}/messages`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+      const { response } = await api.POST('/messages', {
+        body: {
           date,
           message: messageInput.trim(),
           player_profile_id: 1,
-          player_name: user.name || user.email
-        })
+          player_name: user.name || user.email,
+        },
       });
 
       if (!response.ok) throw new Error('Failed to post message');
@@ -148,7 +145,9 @@ const SignupCalendar = ({ onSignupChange, onDateSelect }) => {
 
   const handleDeleteMessage = async (messageId) => {
     try {
-      await fetch(`${API_URL}/messages/${messageId}`, { method: 'DELETE' });
+      await api.DELETE('/messages/{message_id}', {
+        params: { path: { message_id: messageId } },
+      });
       loadWeeklyData(currentWeekStart);
     } catch (err) {
       setError(err.message);

--- a/frontend/src/components/signup/WgpSignupSheet.jsx
+++ b/frontend/src/components/signup/WgpSignupSheet.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTheme } from '../../theme/Provider';
 import { useAuth0 } from '@auth0/auth0-react';
-import { apiConfig } from '../../config/api.config';
 import { acquireAccessToken } from '../../services/authToken';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../../api/client';
+import { errorDetail } from '../../api/http';
 
 function todayIso() {
   return new Date().toISOString().slice(0, 10);
@@ -41,8 +40,10 @@ export default function WgpSignupSheet() {
     (async () => {
       setLoadingUpcoming(true);
       try {
-        const resp = await fetch(`${API_URL}/tee-sheet/upcoming?start=${todayIso()}&days=14`);
-        if (resp.ok) setUpcomingDays(await resp.json());
+        const { data, response } = await api.GET('/tee-sheet/upcoming', {
+          params: { query: { start: todayIso(), days: 14 } },
+        });
+        if (response.ok) setUpcomingDays(data);
       } catch { /* non-fatal */ } finally {
         setLoadingUpcoming(false);
       }
@@ -51,9 +52,10 @@ export default function WgpSignupSheet() {
 
   const refreshUpcomingCount = useCallback(async (targetDate) => {
     try {
-      const resp = await fetch(`${API_URL}/tee-sheet?date=${targetDate}`);
-      if (!resp.ok) return;
-      const data = await resp.json();
+      const { data, response } = await api.GET('/tee-sheet', {
+        params: { query: { date: targetDate } },
+      });
+      if (!response.ok) return;
       setUpcomingDays(prev =>
         prev.map(d => d.date === targetDate ? { ...d, signed_up_count: data.signed_up_count } : d)
       );
@@ -64,9 +66,10 @@ export default function WgpSignupSheet() {
     setLoadingSheet(true);
     setSheetError('');
     try {
-      const resp = await fetch(`${API_URL}/tee-sheet?date=${date}`);
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-      const data = await resp.json();
+      const { data, response } = await api.GET('/tee-sheet', {
+        params: { query: { date } },
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
       setSlots(data.slots || []);
       setUpcomingDays(prev =>
         prev.map(d => d.date === date ? { ...d, signed_up_count: data.signed_up_count } : d)
@@ -88,10 +91,10 @@ export default function WgpSignupSheet() {
     (async () => {
       try {
         const token = await acquireAccessToken(getAccessTokenSilently);
-        const resp = await fetch(`${API_URL}/players/me`, {
+        const { data, response } = await api.GET('/players/me', {
           headers: { Authorization: `Bearer ${token}` },
         });
-        if (resp.ok) setPlayerProfile(await resp.json());
+        if (response.ok) setPlayerProfile(data);
       } catch { /* non-fatal */ }
     })();
   }, [isAuthenticated, getAccessTokenSilently]);
@@ -107,13 +110,10 @@ export default function WgpSignupSheet() {
     setSigningUp(true);
     setSignupMessage(null);
     try {
-      const resp = await fetch(`${API_URL}/tee-sheet/signup`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ date, name: myName }),
+      const { error: apiError, response } = await api.POST('/tee-sheet/signup', {
+        body: { date, name: myName },
       });
-      const data = await resp.json();
-      if (!resp.ok) throw new Error(data.detail || 'Signup failed');
+      if (!response.ok) throw new Error(errorDetail(apiError) || 'Signup failed');
       setSignupMessage({ type: 'success', text: `You're signed up as ${myName}!` });
       await fetchSignups();
       await refreshUpcomingCount(date);

--- a/frontend/src/components/signup/__tests__/DailySignupView.test.jsx
+++ b/frontend/src/components/signup/__tests__/DailySignupView.test.jsx
@@ -26,12 +26,14 @@ const expectedSignupBody = {
   notes: null,
 };
 
+// Real Response so the typed client (openapi-fetch) can parse it.
 const jsonResponse = (data) =>
-  Promise.resolve({
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve(data),
-  });
+  Promise.resolve(
+    new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
 
 const weeklyResponse = (signups = []) => ({
   week_start: selectedDate,
@@ -62,7 +64,9 @@ describe('DailySignupView', () => {
   test('signs up the logged-in profile and shows that player in the week view', async () => {
     let createdSignup = null;
 
-    fetch.mockImplementation((url, options = {}) => {
+    // The typed client calls fetch with a single Request object.
+    fetch.mockImplementation(async (request) => {
+      const url = request.url;
       if (url.includes('/pairings/')) {
         return jsonResponse({ exists: false });
       }
@@ -71,8 +75,8 @@ describe('DailySignupView', () => {
         return jsonResponse(weeklyResponse(createdSignup ? [createdSignup] : []));
       }
 
-      if (url.endsWith('/signups') && options.method === 'POST') {
-        const body = JSON.parse(options.body);
+      if (url.endsWith('/signups') && request.method === 'POST') {
+        const body = JSON.parse(await request.clone().text());
         createdSignup = {
           id: 101,
           ...body,
@@ -100,16 +104,17 @@ describe('DailySignupView', () => {
     fireEvent.click(within(emptyStateActions).getByRole('button', { name: 'Confirm Sign Up' }));
 
     await waitFor(() => {
-      const signupRequest = fetch.mock.calls.find(
-        ([url, options]) => url.endsWith('/signups') && options?.method === 'POST',
-      );
-
-      expect(JSON.parse(signupRequest[1].body)).toEqual(expectedSignupBody);
-      expect(signupRequest[1].headers).toEqual({
-        Authorization: 'Bearer signup-token',
-        'Content-Type': 'application/json',
-      });
+      expect(
+        fetch.mock.calls.some(([req]) => req.url.endsWith('/signups') && req.method === 'POST'),
+      ).toBe(true);
     });
+
+    const signupRequest = fetch.mock.calls.find(
+      ([req]) => req.url.endsWith('/signups') && req.method === 'POST',
+    )[0];
+    expect(JSON.parse(await signupRequest.clone().text())).toEqual(expectedSignupBody);
+    expect(signupRequest.headers.get('Authorization')).toBe('Bearer signup-token');
+    expect(signupRequest.headers.get('Content-Type')).toContain('application/json');
 
     expect(await screen.findByText('Stuart')).toBeInTheDocument();
     expect(screen.getByText('(you)')).toBeInTheDocument();
@@ -121,7 +126,8 @@ describe('DailySignupView', () => {
       profile: { ...playerProfile, legacy_name: null },
       loading: false,
     });
-    fetch.mockImplementation((url) => {
+    fetch.mockImplementation((request) => {
+      const url = request.url;
       if (url.includes('/pairings/')) return jsonResponse({ exists: false });
       if (url.includes('/signups/weekly-with-messages')) {
         return jsonResponse(weeklyResponse());


### PR DESCRIPTION
## Summary

Batch 2b — completes the **signup cluster** on the generated typed client, finishing what Batch 2a (#324) started.

## Migrations

- **`DailySignupView`** — `/signups/weekly-with-messages`, `/pairings/{date}` (the 404-vs-error handling is preserved via the response object), `POST /signups` (auth), `POST /signups/{id}/replicate-legacy`, `DELETE /signups/{id}`.
- **`SignupCalendar`** — weekly load, `POST /signups`, `DELETE /signups/{id}`, `POST`/`DELETE /messages/{id}`. Its unauthenticated calls stay unauthenticated.
- **`WgpSignupSheet`** — `/tee-sheet/upcoming`, `/tee-sheet`, `/players/me` (auth), `POST /tee-sheet/signup`.
- **`EmailPreferences`** — `GET`/`PUT /players/me/email-preferences` (localStorage token preserved).

All endpoints verified against the committed spec; runtime behavior preserved (auth headers, error handling, request bodies unchanged).

## Test rework

`DailySignupView`'s test routed its `fetch` mock by URL string and asserted on `options.method/body/headers` — none of which exist when the typed client calls `fetch(Request)`. Reworked to inspect the `Request` object (route by `request.url`, read body via `clone().text()`, headers via `headers.get()`), and its local `jsonResponse` helper now returns a real `Response`.

## Verification

- **Frontend:** `npm run typecheck` ✅ · `vitest run` ✅ (563 passed) · `npm run build` ✅

## Migration status

Signup cluster ✅ done. Remaining: Games/Scoring (Batch 3, the big one), Players/Profile, Courses/GHIN/Analytics, Admin/Integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVoeDseEgTJbNf9dTPB21t

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVoeDseEgTJbNf9dTPB21t)_