### PR TITLE
refactor: migrate game-list and leaderboard views to the typed client

### DIFF
--- a/frontend/src/components/game/Leaderboard.jsx
+++ b/frontend/src/components/game/Leaderboard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Card } from '../ui';
 import { useSheetSync } from '../../context';
-import { apiConfig } from '../../config/api.config';
+import { api } from '../../api/client';
 
 const Leaderboard = () => {
   const { syncData: liveLeaderboardData, syncStatus, error: syncError, performLiveSync } = useSheetSync();
@@ -13,13 +13,11 @@ const Leaderboard = () => {
   useEffect(() => {
     // Both fetches are best-effort decorations (spreadsheet link, LivSow team
     // chips) — on failure the leaderboard renders fine without them.
-    fetch(`${apiConfig.baseUrl}/data/leaderboard-config`)
-      .then(r => r.ok ? r.json() : null)
-      .then(d => { if (d?.sheet_url) setSheetUrl(d.sheet_url); })
+    api.GET('/data/leaderboard-config')
+      .then(({ data }) => { if (data?.sheet_url) setSheetUrl(data.sheet_url); })
       .catch(() => {});
-    fetch(`${apiConfig.baseUrl}/data/livsow/team-map`)
-      .then(r => r.ok ? r.json() : null)
-      .then(d => { if (d) setTeamMap(d); })
+    api.GET('/data/livsow/team-map')
+      .then(({ data }) => { if (data) setTeamMap(data); })
       .catch(() => {});
   }, []);
 

--- a/frontend/src/components/game/LivSowLeaderboard.jsx
+++ b/frontend/src/components/game/LivSowLeaderboard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { Link } from 'react-router-dom';
-import { apiConfig } from '../../config/api.config';
+import { api } from '../../api/client';
 import { RoleTag, WeekCell, slugify, teamColor } from './livsow/shared';
 import LivSowTransactions from './livsow/LivSowTransactions';
 import GroupMeFeed from '../chat/GroupMeFeed';
@@ -158,9 +158,8 @@ const LivSowLeaderboard = () => {
 
   useEffect(() => {
     // Best-effort: recent transactions feed — page works without it
-    fetch(`${apiConfig.baseUrl}/data/livsow/transactions?limit=10`)
-      .then(r => (r.ok ? r.json() : null))
-      .then(d => { if (d?.transactions) setRecentMoves(d.transactions); })
+    api.GET('/data/livsow/transactions', { params: { query: { limit: 10 } } })
+      .then(({ data }) => { if (data?.transactions) setRecentMoves(data.transactions); })
       .catch(() => {});
   }, []);
 
@@ -168,10 +167,10 @@ const LivSowLeaderboard = () => {
     try {
       setLoading(true);
       setError(null);
-      const url = `${apiConfig.baseUrl}/data/livsow/leaderboard${refresh ? '?refresh=true' : ''}`;
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
+      const { data: json, response } = await api.GET('/data/livsow/leaderboard', {
+        params: { query: refresh ? { refresh: true } : {} },
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
       setData(json);
       // Default: expand the top team
       if (json.teams?.length > 0 && expandedTeam === null) {

--- a/frontend/src/pages/ActiveGamesPage.jsx
+++ b/frontend/src/pages/ActiveGamesPage.jsx
@@ -5,9 +5,8 @@ import { Card } from '../components/ui';
 import { useTheme } from '../theme/Provider';
 import CommissionerChat from '../components/game/CommissionerChat';
 import AppFooter from '../components/ui/AppFooter';
-import { apiConfig } from '../config/api.config';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../api/client';
+import { errorDetail } from '../api/http';
 
 /**
  * ActiveGamesPage - List all in-progress games
@@ -32,22 +31,20 @@ const ActiveGamesPage = () => {
     setError(null);
 
     try {
-      const params = new URLSearchParams({
-        limit: LIMIT,
-        offset: currentPage * LIMIT
+      const { data, response } = await api.GET('/games', {
+        params: {
+          query: {
+            limit: LIMIT,
+            offset: currentPage * LIMIT,
+            ...(filter !== 'all' ? { status: filter } : {}),
+          },
+        },
       });
-
-      if (filter !== 'all') {
-        params.append('status', filter);
-      }
-
-      const response = await fetch(`${API_URL}/games?${params.toString()}`);
 
       if (!response.ok) {
         throw new Error(`Failed to load games: ${response.statusText}`);
       }
 
-      const data = await response.json();
       setGames(data.games || []);
       setTotalCount(data.total_count || 0);
       setHasMore(data.has_more || false);
@@ -90,21 +87,14 @@ const ActiveGamesPage = () => {
     setError(null);
 
     try {
-      const deleteUrl = `${API_URL}/games/${gameId}`;
-      const response = await fetch(deleteUrl, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json'
-        }
+      const { error: apiError, response } = await api.DELETE('/games/{game_id}', {
+        params: { path: { game_id: gameId } },
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
-        console.error('❌ Delete failed:', errorData);
-        throw new Error(errorData.detail || `Failed to delete game (${response.status})`);
+        console.error('❌ Delete failed:', apiError);
+        throw new Error(errorDetail(apiError) || `Failed to delete game (${response.status})`);
       }
-
-      await response.json();
 
       // Show success message briefly
       setError(null);

--- a/frontend/src/pages/CompletedGamesPage.jsx
+++ b/frontend/src/pages/CompletedGamesPage.jsx
@@ -4,9 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Card } from '../components/ui';
 import { useTheme } from '../theme/Provider';
 import CommissionerChat from '../components/game/CommissionerChat';
-import { apiConfig } from '../config/api.config';
-
-const API_URL = apiConfig.baseUrl;
+import { api } from '../api/client';
 
 /**
  * CompletedGamesPage - List all completed games with results
@@ -28,19 +26,20 @@ const CompletedGamesPage = () => {
     setError(null);
 
     try {
-      const params = new URLSearchParams({
-        status: 'completed',
-        limit: LIMIT,
-        offset: currentPage * LIMIT
+      const { data, response } = await api.GET('/games', {
+        params: {
+          query: {
+            status: 'completed',
+            limit: LIMIT,
+            offset: currentPage * LIMIT,
+          },
+        },
       });
-
-      const response = await fetch(`${API_URL}/games?${params.toString()}`);
 
       if (!response.ok) {
         throw new Error(`Failed to load games: ${response.statusText}`);
       }
 
-      const data = await response.json();
       setGames(data.games || []);
       setTotalCount(data.total_count || 0);
       setHasMore(data.has_more || false);
@@ -73,8 +72,8 @@ const CompletedGamesPage = () => {
     if (!confirmed) return;
 
     try {
-      const response = await fetch(`${API_URL}/games/${gameId}`, {
-        method: 'DELETE'
+      const { response } = await api.DELETE('/games/{game_id}', {
+        params: { path: { game_id: gameId } },
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Batch 3a — the first, low-risk slice of the Games/Scoring area: the read-mostly **game-list and leaderboard views**. (Games/Scoring is ~25 files, so it's split into cohesive sub-batches; this one is the read-heavy views with simple pagination/delete.)

## Migrations

- **`Leaderboard`** — `GET /data/leaderboard-config`, `GET /data/livsow/team-map` (best-effort decorations; failures still render the leaderboard).
- **`LivSowLeaderboard`** — `GET /data/livsow/leaderboard` (with the `refresh` flag), `GET /data/livsow/transactions`.
- **`ActiveGamesPage`** — `GET /games` (status/limit/offset paging), `DELETE /games/{id}`.
- **`CompletedGamesPage`** — `GET /games` (completed), `DELETE /games/{id}`.

All endpoints verified against the committed spec. Runtime behavior preserved — same paging, best-effort `catch`es, and error handling; the `/games` responses (`data.games`, `data.total_count`, `data.has_more`) are read exactly as before.

## Verification

- **Frontend:** `npm run typecheck` ✅ · `vitest run` ✅ (563 passed) · `npm run build` ✅
- No tests exist for these four files; converted structurally + spec-verified, behavior unchanged.

## Migration status

Matchmaking ✅, signup cluster ✅, now the game-list/leaderboard views. Remaining in Games/Scoring: the scoring/lobby flow (`GameLobbyPage`, `GameScorerPage`, `SimpleScorekeeper`, `useScorekeeperSync`, scorecard components) and the course/GHIN/livsow-admin pieces — following sub-batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVoeDseEgTJbNf9dTPB21t

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVoeDseEgTJbNf9dTPB21t)_