### PR TITLE
feat: safer signup identity, GHIN handicap provenance, email delivery & tee-sheet guards

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -100,6 +100,13 @@ SUNDAY_GAME_RANDOM_SEED=
 # LEGACY TEE SHEET SYNC
 # =============================================================================
 
+# POST /tee-sheet/signup writes DIRECTLY to the live, shared thousand-cranes.com
+# tee sheet. To stop preview/dev/staging from silently mutating the real club
+# sheet (issue #323), live writes are allowed ONLY when ENVIRONMENT=production,
+# or when this flag explicitly opts a non-production environment in. Any other
+# case returns a dry-run preview (no live mutation). Leave unset/false locally.
+TEE_SHEET_ALLOW_LIVE_WRITES=false
+
 # Enable syncing signups to thousand-cranes.com legacy tee sheet
 LEGACY_SIGNUP_SYNC_ENABLED=false
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -217,6 +217,13 @@ class PlayerProfile(Base):
     handicap = Column(Float, default=18.0)
     ghin_id = Column(String, nullable=True, unique=True, index=True)  # GHIN ID for handicap lookup
     ghin_last_updated = Column(String, nullable=True)  # When GHIN data was last synced
+    # Provenance of `handicap`: None/"default" = the 18.0 placeholder (unknown/
+    # pending), "ghin" = authoritative GHIN-synced value, "manual" = user/admin
+    # entered. Lets the UI show "pending" instead of a fake 18.0. See issue #320.
+    handicap_source = Column(String, nullable=True)
+    # ISO timestamp when the first-login welcome email was accepted by the
+    # provider. Null = never (successfully) sent, so a retry is safe. See #318.
+    welcome_email_sent_at = Column(String, nullable=True)
     avatar_url = Column(String, nullable=True)
     avatar_image = Column(Text, nullable=True)  # uploaded avatar, downscaled JPEG as base64
     created_at = Column(String)
@@ -440,6 +447,10 @@ class DailySignup(Base):
     status = Column(String, default="signed_up")  # signed_up, cancelled, played
     created_at = Column(String)
     updated_at = Column(String)
+    # ISO timestamp when the signup confirmation email was accepted by the
+    # provider. Null = not yet sent; used to avoid duplicate confirmations on
+    # retried/duplicate signup requests. See issue #317.
+    confirmation_email_sent_at = Column(String, nullable=True)
 
 
 class PlayerAvailability(Base):

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -158,9 +158,27 @@ def get_all_players_availability(db: Session = Depends(get_db)) -> list[dict[str
 @handle_api_errors(operation_name="get my profile")
 async def get_my_profile(
     current_user: models.PlayerProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ) -> schemas.PlayerProfileResponse:
-    """Get current authenticated user's profile."""
-    return schemas.PlayerProfileResponse.model_validate(current_user)
+    """Get current authenticated user's profile.
+
+    Adds two computed fields not stored on the row:
+    - ``legacy_name_suggestion``: when the account has no confirmed legacy link,
+      a fuzzy roster match to *suggest* (never auto-persist) in onboarding (#322).
+    - ``is_admin``: server-side ADMIN_EMAILS membership so the client doesn't
+      depend on a hardcoded allowlist that can drift (#316).
+    """
+    from ..services.legacy_player_service import find_similar_players
+    from ..utils.admin_auth import get_admin_emails
+
+    profile = schemas.PlayerProfileResponse.model_validate(current_user)
+
+    if not current_user.legacy_name:
+        suggestions = find_similar_players(current_user.name, max_results=1, db=db)
+        profile.legacy_name_suggestion = suggestions[0] if suggestions else None
+
+    profile.is_admin = bool(current_user.email and current_user.email in get_admin_emails())
+    return profile
 
 
 @router.put("/me/legacy-name", response_model=schemas.PlayerProfileResponse)

--- a/backend/app/routers/signups.py
+++ b/backend/app/routers/signups.py
@@ -5,8 +5,10 @@ Legacy player lookup and daily sign-up management.
 """
 
 import logging
+import threading
 from datetime import datetime, timedelta
 
+import sentry_sdk
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel
 
@@ -27,6 +29,70 @@ from ..utils.time import utc_now
 logger = logging.getLogger("app.routers.signups")
 
 router = APIRouter(tags=["signups"])
+
+
+def _deliver_signup_confirmation(signup_id: int, to_email: str, player_name: str, signup_date: str) -> None:
+    """Send one signup confirmation email and record the outcome. Best-effort.
+
+    Runs on a daemon thread (own DB session) so the external send never adds
+    latency to or breaks POST /signups. Idempotent: re-checks
+    ``confirmation_email_sent_at`` under a fresh read and stamps it only after
+    the provider accepts, so retried/duplicate signups never double-send (#317).
+    Honors the recipient's ``signup_confirmations_enabled`` preference. A soft
+    failure (provider returns False) is logged and reported to Sentry rather
+    than silently reported as delivered.
+    """
+    if not to_email:
+        return
+    db = database.SessionLocal()
+    try:
+        signup = db.query(models.DailySignup).filter(models.DailySignup.id == signup_id).first()
+        if signup is None or signup.confirmation_email_sent_at:
+            return  # already sent, or the row vanished — never double-send
+
+        prefs = (
+            db.query(models.EmailPreferences)
+            .filter(models.EmailPreferences.player_profile_id == signup.player_profile_id)
+            .first()
+        )
+        if prefs is not None and not prefs.signup_confirmations_enabled:
+            logger.info("Signup confirmation suppressed by preference for player %s", signup.player_profile_id)
+            return
+
+        from ..services.email_service import get_email_service
+
+        svc = get_email_service()
+        if not svc.is_configured():
+            logger.warning("Signup confirmation skipped for <%s>: email provider not configured", to_email)
+            sentry_sdk.capture_message(f"Signup confirmation skipped: provider not configured (signup_id={signup_id})")
+            return
+
+        accepted = svc.send_signup_confirmation(to_email, player_name, signup_date)
+        if accepted:
+            signup.confirmation_email_sent_at = utc_now().isoformat()
+            db.commit()
+            logger.info("Signup confirmation accepted by provider for signup %s <%s>", signup_id, to_email)
+        else:
+            logger.error("Signup confirmation rejected by provider for signup %s <%s>", signup_id, to_email)
+            sentry_sdk.capture_message(f"Signup confirmation rejected by provider (signup_id={signup_id})")
+    except Exception as exc:  # never surface to the signup path
+        logger.warning("Failed to send signup confirmation for signup %s: %s", signup_id, exc)
+        sentry_sdk.capture_exception(exc)
+        db.rollback()
+    finally:
+        db.close()
+
+
+def _send_signup_confirmation(signup_id: int, to_email: str | None, player_name: str, signup_date: str) -> None:
+    """Dispatch the signup confirmation on a daemon thread (non-blocking)."""
+    if not to_email:
+        return
+    threading.Thread(
+        target=_deliver_signup_confirmation,
+        args=(signup_id, to_email, player_name, signup_date),
+        daemon=True,
+        name="signup-confirmation",
+    ).start()
 
 
 @router.get("/legacy-players")
@@ -259,6 +325,10 @@ def create_signup(
             legacy_service.sync_signup_created(db_signup)
         except Exception:
             logger.exception("Legacy signup sync failed for create id=%s", db_signup.id)
+
+        # Send a confirmation email to the AUTHENTICATED player's address (never
+        # client-supplied). Non-blocking and idempotent; see _send_signup_confirmation.
+        _send_signup_confirmation(db_signup.id, getattr(current_user, "email", None), player_name, signup.date)
 
         return schemas.DailySignupResponse.from_orm(db_signup)
 

--- a/backend/app/routers/tee_sheet.py
+++ b/backend/app/routers/tee_sheet.py
@@ -7,6 +7,7 @@ CGI endpoints: wgp_tee_sheet.cgi (read), wgp_add_tee_sheet_ajax.cgi (write)
 
 import asyncio
 import logging
+import os
 import re
 from datetime import date as date_type
 from datetime import timedelta
@@ -25,6 +26,19 @@ router = APIRouter(prefix="/tee-sheet", tags=["tee-sheet"])
 TEE_SHEET_BASE = "https://thousand-cranes.com/WolfGoatPig"
 TEE_SHEET_READ_URL = f"{TEE_SHEET_BASE}/wgp_tee_sheet.cgi"
 TEE_SHEET_SIGNUP_URL = f"{TEE_SHEET_BASE}/wgp_add_tee_sheet_ajax.cgi"
+
+
+def live_tee_sheet_writes_enabled() -> bool:
+    """Whether this deployment may mutate the LIVE thousand-cranes.com tee sheet.
+
+    POST /tee-sheet/signup writes straight to the real, shared tee sheet that
+    Jeff and the club see. A preview/local/dev deployment must NOT silently do
+    that (issue #323): allowed only in production, or when an operator has
+    explicitly opted a non-prod environment in via TEE_SHEET_ALLOW_LIVE_WRITES.
+    """
+    if os.getenv("ENVIRONMENT") == "production":
+        return True
+    return os.getenv("TEE_SHEET_ALLOW_LIVE_WRITES", "").lower() in {"1", "true", "yes"}
 
 
 def _parse_slots(html: str) -> list[dict]:
@@ -126,6 +140,10 @@ async def get_upcoming_counts(
 class SignupRequest(BaseModel):
     date: str
     name: NonBlankStr
+    # When true, validate and report what WOULD happen without touching the live
+    # tee sheet. Also implied whenever live writes are disabled for this
+    # environment. See issue #323.
+    dry_run: bool = False
 
 
 def _mirror_signup_to_db(name: str, date: str) -> None:
@@ -203,8 +221,26 @@ def _mirror_signup_to_db(name: str, date: str) -> None:
 
 @router.post("/signup")
 async def signup_for_tee_sheet(request: SignupRequest) -> dict[str, Any]:
-    """Sign up a player for a given date on the thousand-cranes.com tee sheet."""
+    """Sign up a player for a given date on the thousand-cranes.com tee sheet.
+
+    This writes to the LIVE, shared club tee sheet. A dry-run request — or any
+    non-production deployment without an explicit opt-in — returns a preview of
+    exactly what would be written (name + date) and performs no live mutation,
+    so preview/testing can never silently change the real sheet. See issue #323.
+    """
     name = request.name
+    live_allowed = live_tee_sheet_writes_enabled()
+
+    if request.dry_run or not live_allowed:
+        reason = "dry_run requested" if request.dry_run else "live tee-sheet writes disabled for this environment"
+        logger.info("Tee-sheet signup PREVIEW (%s): would sign up %s for %s", reason, name, request.date)
+        return {
+            "success": True,
+            "live_write": False,
+            "dry_run": True,
+            "reason": reason,
+            "would_sign_up": {"name": name, "date": request.date},
+        }
 
     async with httpx.AsyncClient(timeout=10.0) as client:
         try:
@@ -226,4 +262,4 @@ async def signup_for_tee_sheet(request: SignupRequest) -> dict[str, Any]:
         await asyncio.to_thread(_mirror_signup_to_db, name, request.date)
     except Exception:
         logger.exception("Post-signup mirror failed for %s on %s", name, request.date)
-    return {"success": True, "name": name, "date": request.date}
+    return {"success": True, "live_write": True, "dry_run": False, "name": name, "date": request.date}

--- a/backend/app/schemas/players.py
+++ b/backend/app/schemas/players.py
@@ -75,10 +75,22 @@ class PlayerProfileResponse(PlayerProfileBase):
     is_active: bool = True
     is_ai: bool = False
     ghin_id: str | None = None
+    ghin_last_updated: str | None = None  # when the GHIN handicap was last synced (#320)
+    # Provenance of `handicap`: "default" (18.0 placeholder / unknown), "ghin"
+    # (authoritative), or "manual". Lets the UI distinguish unknown from a real
+    # 18.0. See issue #320.
+    handicap_source: str | None = None
     venmo_handle: str | None = None
     playing_style: str | None = None
     description: str | None = None
     has_avatar_image: bool = False
+    # Computed, not stored. Populated by GET /players/me only.
+    # A non-authoritative fuzzy legacy-name suggestion to confirm in onboarding;
+    # never auto-persisted to legacy_name. See issue #322.
+    legacy_name_suggestion: str | None = None
+    # Whether this account is an admin (server-side ADMIN_EMAILS allowlist), so
+    # the client doesn't rely on a hardcoded list that can drift. See issue #316.
+    is_admin: bool = False
 
 
 # Player Statistics Schemas

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -54,13 +54,37 @@ def _notify_admins_of_new_player(name: str, email: str | None) -> None:
     threading.Thread(target=_send, daemon=True, name="new-player-notify").start()
 
 
-def _deliver_welcome_email(name: str, email: str | None) -> None:
+def _mark_welcome_email_sent(player_id: int) -> None:
+    """Persist that the welcome email was accepted by the provider.
+
+    Opens its own short-lived session because this runs on a detached daemon
+    thread, after the request's session is already closed. The timestamp both
+    proves delivery (observability, #318) and guards against re-sending on a
+    later login.
+    """
+    db = SessionLocal()
+    try:
+        player = db.query(PlayerProfile).filter(PlayerProfile.id == player_id).first()
+        if player is not None:
+            player.welcome_email_sent_at = utc_now().isoformat()
+            db.commit()
+    except Exception as exc:  # never surface to the login path
+        logger.warning(f"Failed to record welcome_email_sent_at for player {player_id}: {exc}")
+        db.rollback()
+    finally:
+        db.close()
+
+
+def _deliver_welcome_email(name: str, email: str | None, player_id: int) -> None:
     """Synchronously deliver the first-login welcome email. Best-effort.
 
-    Any failure (provider outage, misconfig) is swallowed so it can never break
-    the login path, but it is reported to Sentry — matching the
-    swallowed-outages-are-captured convention used at the Resend/GHIN/Sheets/
-    ForeTees swallow sites — so an outage is observable, not silent.
+    Inspects the provider outcome so a *soft* failure (provider returns False
+    without raising — e.g. a non-2xx from Resend, or an unconfigured provider)
+    is observable, not just an unraised exception. Records the recipient and a
+    provider outcome for every send (traceable delivery evidence, #318), and
+    persists welcome_email_sent_at only on success so a failed send stays
+    retryable. Any exception is swallowed so it can never break the login path
+    but is reported to Sentry.
     """
     if not email:
         return
@@ -69,14 +93,23 @@ def _deliver_welcome_email(name: str, email: str | None) -> None:
 
         svc = get_email_service()
         if not svc.is_configured():
+            logger.warning("Welcome email skipped for player %s <%s>: email provider not configured", player_id, email)
+            sentry_sdk.capture_message(f"Welcome email skipped: provider not configured (player_id={player_id})")
             return
-        svc.send_welcome_email(email, name)
+        accepted = svc.send_welcome_email(email, name)
+        if accepted:
+            _mark_welcome_email_sent(player_id)
+            logger.info("Welcome email accepted by provider for player %s <%s>", player_id, email)
+        else:
+            # Soft failure: provider returned False without raising.
+            logger.error("Welcome email rejected by provider for player %s <%s>", player_id, email)
+            sentry_sdk.capture_message(f"Welcome email rejected by provider (player_id={player_id}, email={email})")
     except Exception as exc:  # never surface to the login path
         logger.warning(f"Failed to send welcome email to '{email}': {exc}")
         sentry_sdk.capture_exception(exc)
 
 
-def _send_welcome_email(name: str, email: str | None) -> None:
+def _send_welcome_email(name: str, email: str | None, player_id: int) -> None:
     """Best-effort, non-blocking welcome email on first-login profile creation.
 
     Runs the (external, potentially slow) send on a daemon thread so it can
@@ -84,7 +117,7 @@ def _send_welcome_email(name: str, email: str | None) -> None:
     """
     threading.Thread(
         target=_deliver_welcome_email,
-        args=(name, email),
+        args=(name, email, player_id),
         daemon=True,
         name="welcome-email",
     ).start()
@@ -162,15 +195,26 @@ class AuthService:
         player = db.query(PlayerProfile).filter(PlayerProfile.email == email).first()
 
         if not player:
-            # Try to match name to legacy tee sheet system (same session as the
+            # Match name to the legacy tee sheet system (same session as the
             # profile write so the whole flow is transactionally consistent).
+            #
+            # Only an EXACT canonical match auto-links: case-folding a name to
+            # its roster spelling is deterministic and safe. A *fuzzy* match is a
+            # guess — writing it to legacy_name would faithfully sign the golfer
+            # up as the wrong person (issue #322). So we never persist a fuzzy
+            # hit here; we leave legacy_name unset and surface the suggestion in
+            # onboarding (GET /players/me) for the authenticated user to confirm.
             legacy_name = get_canonical_name(name, db)
+            fuzzy_suggestion: str | None = None
             if not legacy_name:
-                # Try fuzzy matching
                 suggestions = find_similar_players(name, max_results=1, db=db)
                 if suggestions:
-                    legacy_name = suggestions[0]
-                    logger.info(f"Fuzzy matched '{name}' to legacy name '{legacy_name}'")
+                    fuzzy_suggestion = suggestions[0]
+                    logger.info(
+                        "Fuzzy legacy suggestion for '%s': '%s' (NOT auto-linked; awaiting confirmation)",
+                        name,
+                        fuzzy_suggestion,
+                    )
 
             # Create new player profile
             player = PlayerProfile(
@@ -180,7 +224,8 @@ class AuthService:
                 avatar_url=picture,
                 created_at=utc_now().isoformat(),
                 updated_at=utc_now().isoformat(),
-                handicap=18.0,  # Default handicap
+                handicap=18.0,  # Placeholder until GHIN sync — marked below
+                handicap_source="default",  # unknown/pending, not a real 18.0 (#320)
                 preferences={
                     "auth0_id": auth0_id,
                     "ai_difficulty": "medium",
@@ -209,16 +254,18 @@ class AuthService:
             # returning login. Best-effort and wrapped so even dispatching it can
             # never add latency to or break first login; failures go to Sentry.
             try:
-                _send_welcome_email(name, email)
+                _send_welcome_email(name, email, player.id)
             except Exception as exc:
                 logger.warning(f"Failed to dispatch welcome email for '{name}': {exc}")
                 sentry_sdk.capture_exception(exc)
 
-            # No canonical legacy match → capture into the pending queue and
-            # alert admins so the golfer can be added to Jeff's tee-sheet
-            # dropdown (a manual step on the legacy side). Best-effort: never
-            # block account creation if capture/notify fails.
-            if not legacy_name:
+            # No legacy link → decide between "confirm a suggestion" and "brand
+            # new golfer". If there's a plausible fuzzy suggestion, onboarding
+            # will surface it for the user to accept/reject, so we don't add them
+            # to the pending roster yet. Only a truly unknown golfer (no exact
+            # match, no suggestion) is captured into the pending queue with an
+            # admin alert. Best-effort: never block account creation.
+            if not legacy_name and not fuzzy_suggestion:
                 try:
                     result = capture_pending_player(name, email=email, player_profile_id=player.id, db=db)
                     if result.get("captured"):

--- a/backend/app/services/ghin_service.py
+++ b/backend/app/services/ghin_service.py
@@ -119,8 +119,13 @@ class GHINService:
             handicap_data = await self._fetch_handicap_from_ghin(ghin_id_str)
 
             if handicap_data:
-                # Update player profile with latest handicap - use setattr to avoid Column type errors
-                player.handicap = handicap_data.get("handicap_index", player.handicap)
+                # Only overwrite the stored handicap when GHIN actually returned
+                # a value; otherwise keep the last known good one (never clobber
+                # it with the 18.0 placeholder on a partial/failed lookup). #320
+                new_index = handicap_data.get("handicap_index")
+                if new_index is not None:
+                    player.handicap = new_index
+                    player.handicap_source = "ghin"  # authoritative, not the default placeholder
                 player.ghin_last_updated = utc_now().isoformat()
 
                 # Store handicap history

--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -46,10 +46,13 @@ class PlayerService:
             if existing_player:
                 raise ValueError(f"Player with name '{profile_data.name}' already exists")
 
-            # Create player profile
+            # Create player profile. This path is admin/manual creation, so the
+            # supplied handicap is treated as manually set (not the 18.0
+            # unknown/pending placeholder). See issue #320.
             player_profile = PlayerProfile(
                 name=profile_data.name,
                 handicap=profile_data.handicap,
+                handicap_source="manual",
                 avatar_url=profile_data.avatar_url,
                 created_at=utc_now().isoformat(),
                 preferences=profile_data.preferences

--- a/backend/migrations/add_handicap_source_and_email_tracking_postgres.sql
+++ b/backend/migrations/add_handicap_source_and_email_tracking_postgres.sql
@@ -1,0 +1,29 @@
+-- Migration: track handicap provenance and email-delivery state.
+--
+-- issue #320: handicap_source distinguishes an authoritative GHIN handicap
+--   from the 18.0 placeholder so the UI can show "pending" instead of a fake 18.
+-- issue #318: welcome_email_sent_at records when the first-login welcome email
+--   was accepted by the provider (null = safe to retry).
+-- issue #317: confirmation_email_sent_at dedupes signup confirmation emails.
+
+ALTER TABLE player_profiles ADD COLUMN IF NOT EXISTS handicap_source VARCHAR;
+ALTER TABLE player_profiles ADD COLUMN IF NOT EXISTS welcome_email_sent_at VARCHAR;
+ALTER TABLE daily_signups ADD COLUMN IF NOT EXISTS confirmation_email_sent_at VARCHAR;
+
+-- Backfill: existing profiles whose handicap is the exact 18.0 placeholder and
+-- have never synced GHIN are "default" (unknown); everything else with a value
+-- we treat as manually set so we don't mislabel real 18.0 golfers as unknown.
+UPDATE player_profiles
+   SET handicap_source = 'default'
+ WHERE handicap_source IS NULL
+   AND ghin_last_updated IS NULL
+   AND handicap = 18.0;
+
+UPDATE player_profiles
+   SET handicap_source = 'ghin'
+ WHERE handicap_source IS NULL
+   AND ghin_last_updated IS NOT NULL;
+
+UPDATE player_profiles
+   SET handicap_source = 'manual'
+ WHERE handicap_source IS NULL;

--- a/backend/tests/unit/routers/test_players_router.py
+++ b/backend/tests/unit/routers/test_players_router.py
@@ -4,10 +4,87 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
+from app.database import get_db
 from app.main import app
+from app.models import Base, PlayerProfile
+from app.services import legacy_player_service as legacy_svc
+from app.services.auth_service import get_current_user
 
 client = TestClient(app)
+
+_me_engine = create_engine("sqlite:///./test_players_me.db", connect_args={"check_same_thread": False})
+_MeSession = sessionmaker(autocommit=False, autoflush=False, bind=_me_engine)
+
+
+def _make_user(**kwargs) -> PlayerProfile:
+    """A minimally-valid (unsaved) profile for GET /players/me overrides."""
+    defaults = {
+        "id": 1,
+        "name": "Test Golfer",
+        "email": "golfer@example.com",
+        "legacy_name": "Test Golfer",
+        "handicap": 18.0,
+        "handicap_source": "default",
+        "is_active": 1,
+        "is_ai": 0,
+        "created_at": "2026-01-01T00:00:00",
+    }
+    defaults.update(kwargs)
+    return PlayerProfile(**defaults)
+
+
+class TestMyProfileComputedFields:
+    """GET /players/me adds computed is_admin (#316) and legacy_name_suggestion (#322)."""
+
+    def setup_method(self):
+        Base.metadata.create_all(bind=_me_engine)
+
+        def _get_db():
+            session = _MeSession()
+            try:
+                yield session
+            finally:
+                session.close()
+
+        app.dependency_overrides[get_db] = _get_db
+
+    def teardown_method(self):
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_db, None)
+        Base.metadata.drop_all(bind=_me_engine)
+
+    def test_is_admin_true_for_allowlisted_email(self, monkeypatch):
+        monkeypatch.setenv("ADMIN_EMAILS", "boss@example.com")
+        app.dependency_overrides[get_current_user] = lambda: _make_user(email="boss@example.com")
+        resp = client.get("/players/me")
+        assert resp.status_code == 200
+        assert resp.json()["is_admin"] is True
+
+    def test_is_admin_false_for_non_allowlisted_email(self, monkeypatch):
+        monkeypatch.setenv("ADMIN_EMAILS", "boss@example.com")
+        app.dependency_overrides[get_current_user] = lambda: _make_user(email="nobody@example.com")
+        resp = client.get("/players/me")
+        assert resp.status_code == 200
+        assert resp.json()["is_admin"] is False
+
+    def test_fuzzy_suggestion_surfaced_when_unlinked(self):
+        seed = _MeSession()
+        try:
+            legacy_svc.add_legacy_player("Jonathan Smith", db=seed)
+        finally:
+            seed.close()
+
+        app.dependency_overrides[get_current_user] = lambda: _make_user(
+            name="Jonathon Smith", legacy_name=None, email="jon@example.com"
+        )
+        resp = client.get("/players/me")
+        data = resp.json()
+        assert data["legacy_name"] is None
+        # A fuzzy match is surfaced as a suggestion, never auto-linked.
+        assert data["legacy_name_suggestion"] == "Jonathan Smith"
 
 
 def unique_name(prefix="Player"):

--- a/backend/tests/unit/routers/test_signup_confirmation_email.py
+++ b/backend/tests/unit/routers/test_signup_confirmation_email.py
@@ -1,0 +1,123 @@
+"""Tests for the signup confirmation email sent from POST /signups (issue #317).
+
+Covers the delivery helper directly: recipient comes from the authenticated
+profile (passed in, never client input), idempotency via
+confirmation_email_sent_at, preference opt-out, and observable soft failure.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+import sentry_sdk
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base, DailySignup, EmailPreferences
+from app.routers import signups as signups_module
+from app.utils.time import utc_now
+
+engine = create_engine("sqlite:///./test_signup_confirm.db", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db(monkeypatch):
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(signups_module.database, "SessionLocal", TestingSessionLocal)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def _make_signup(db, **kwargs) -> DailySignup:
+    signup = DailySignup(
+        date="2026-08-02",
+        player_profile_id=1,
+        player_name="Brett Saks",
+        signup_time=utc_now().isoformat(),
+        status="signed_up",
+        created_at=utc_now().isoformat(),
+        updated_at=utc_now().isoformat(),
+        **kwargs,
+    )
+    db.add(signup)
+    db.commit()
+    db.refresh(signup)
+    return signup
+
+
+def _reread(signup_id: int) -> DailySignup:
+    return TestingSessionLocal().query(DailySignup).filter(DailySignup.id == signup_id).first()
+
+
+def test_confirmation_sent_and_marked(db, monkeypatch):
+    signup = _make_signup(db)
+    svc = Mock()
+    svc.is_configured.return_value = True
+    svc.send_signup_confirmation.return_value = True
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: svc)
+
+    signups_module._deliver_signup_confirmation(signup.id, "brett@example.com", "Brett Saks", "2026-08-02")
+
+    svc.send_signup_confirmation.assert_called_once_with("brett@example.com", "Brett Saks", "2026-08-02")
+    assert _reread(signup.id).confirmation_email_sent_at is not None
+
+
+def test_confirmation_not_resent_when_already_sent(db, monkeypatch):
+    signup = _make_signup(db, confirmation_email_sent_at=utc_now().isoformat())
+    svc = Mock()
+    svc.is_configured.return_value = True
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: svc)
+
+    signups_module._deliver_signup_confirmation(signup.id, "brett@example.com", "Brett Saks", "2026-08-02")
+
+    svc.send_signup_confirmation.assert_not_called()
+
+
+def test_confirmation_respects_preference_opt_out(db, monkeypatch):
+    signup = _make_signup(db)
+    db.add(
+        EmailPreferences(
+            player_profile_id=1,
+            signup_confirmations_enabled=False,
+            created_at=utc_now().isoformat(),
+            updated_at=utc_now().isoformat(),
+        )
+    )
+    db.commit()
+    svc = Mock()
+    svc.is_configured.return_value = True
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: svc)
+
+    signups_module._deliver_signup_confirmation(signup.id, "brett@example.com", "Brett Saks", "2026-08-02")
+
+    svc.send_signup_confirmation.assert_not_called()
+
+
+def test_confirmation_soft_failure_is_observable_and_not_marked(db, monkeypatch):
+    signup = _make_signup(db)
+    svc = Mock()
+    svc.is_configured.return_value = True
+    svc.send_signup_confirmation.return_value = False
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: svc)
+
+    messages: list[str] = []
+    monkeypatch.setattr(sentry_sdk, "capture_message", lambda m, *a, **k: messages.append(m))
+
+    signups_module._deliver_signup_confirmation(signup.id, "brett@example.com", "Brett Saks", "2026-08-02")
+
+    assert _reread(signup.id).confirmation_email_sent_at is None
+    assert any("rejected" in m for m in messages)
+
+
+def test_no_recipient_is_a_noop(db, monkeypatch):
+    signup = _make_signup(db)
+    svc = Mock()
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: svc)
+
+    signups_module._send_signup_confirmation(signup.id, None, "Brett Saks", "2026-08-02")
+
+    svc.send_signup_confirmation.assert_not_called()

--- a/backend/tests/unit/routers/test_tee_sheet_router.py
+++ b/backend/tests/unit/routers/test_tee_sheet_router.py
@@ -17,6 +17,45 @@ class TestTeeSheetSignupValidation:
         assert resp.status_code == 422
 
 
+class TestTeeSheetSignupSafety:
+    """Live tee-sheet writes must be gated so preview/testing can't silently
+    mutate the real, shared club sheet (issue #323)."""
+
+    @respx.mock
+    def test_non_production_returns_preview_without_live_write(self, monkeypatch):
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("TEE_SHEET_ALLOW_LIVE_WRITES", raising=False)
+        route = respx.post(url__startswith="https://thousand-cranes.com").mock(
+            return_value=httpx.Response(200, text="OK")
+        )
+
+        resp = client.post("/tee-sheet/signup", json={"date": "2026-06-20", "name": "Preview Golfer"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["live_write"] is False
+        assert body["dry_run"] is True
+        assert body["would_sign_up"] == {"name": "Preview Golfer", "date": "2026-06-20"}
+        # The live CGI was never called.
+        assert not route.called
+
+    @respx.mock
+    def test_explicit_dry_run_never_writes_even_when_live_enabled(self, monkeypatch):
+        monkeypatch.setenv("TEE_SHEET_ALLOW_LIVE_WRITES", "true")
+        route = respx.post(url__startswith="https://thousand-cranes.com").mock(
+            return_value=httpx.Response(200, text="OK")
+        )
+
+        resp = client.post(
+            "/tee-sheet/signup",
+            json={"date": "2026-06-20", "name": "Preview Golfer", "dry_run": True},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["live_write"] is False
+        assert not route.called
+
+
 class TestTeeSheetSignupMirror:
     """A successful CGI signup mirrors into daily_signups and emails the player.
 
@@ -26,6 +65,8 @@ class TestTeeSheetSignupMirror:
 
     @respx.mock
     def test_signup_mirrors_to_db_and_sends_confirmation(self, monkeypatch):
+        # Live tee-sheet writes are gated (issue #323); opt this env in explicitly.
+        monkeypatch.setenv("TEE_SHEET_ALLOW_LIVE_WRITES", "true")
         respx.post(url__startswith="https://thousand-cranes.com").mock(return_value=httpx.Response(200, text="OK"))
 
         legacy_name = "Mirrortest Player"

--- a/backend/tests/unit/services/test_auth_new_player_capture.py
+++ b/backend/tests/unit/services/test_auth_new_player_capture.py
@@ -82,6 +82,47 @@ def test_matched_returning_player_is_not_captured(db, notify_spy):
     notify_spy.assert_not_called()
 
 
+def test_fuzzy_match_is_not_auto_linked(db, notify_spy):
+    """A near-but-not-exact name is a GUESS: it must never be written to
+    legacy_name automatically (issue #322). It is surfaced as a suggestion in
+    onboarding instead, so we also don't add them to the pending roster yet."""
+    svc.add_legacy_player("Jonathan Smith", db=db)
+
+    auth0_user = {
+        "sub": "auth0|fuzzy",
+        "email": "jonathon@example.com",
+        "name": "Jonathon Smith",  # one letter off — fuzzy match at cutoff 0.6
+        "picture": None,
+    }
+    player = AuthService.get_or_create_player_profile(db, auth0_user)
+
+    # NOT auto-linked to the near-duplicate roster name.
+    assert player.legacy_name is None
+    # A plausible suggestion exists → don't capture as a brand-new pending
+    # player; onboarding will surface it for the user to accept/reject.
+    assert db.query(PendingLegacyPlayer).count() == 0
+    notify_spy.assert_not_called()
+
+
+def test_unrelated_name_is_not_linked_and_is_captured(db, notify_spy):
+    """An unrelated name never links to an existing golfer, and (no suggestion)
+    is captured as a brand-new pending player (issues #322/#321)."""
+    svc.add_legacy_player("Jonathan Smith", db=db)
+
+    auth0_user = {
+        "sub": "auth0|unrelated",
+        "email": "zzz@example.com",
+        "name": "Zebediah Xylophone",  # nothing like any roster name
+        "picture": None,
+    }
+    player = AuthService.get_or_create_player_profile(db, auth0_user)
+
+    assert player.legacy_name is None
+    pending = db.query(PendingLegacyPlayer).filter(PendingLegacyPlayer.name == "Zebediah Xylophone").first()
+    assert pending is not None
+    notify_spy.assert_called_once()
+
+
 def test_existing_account_relogin_does_not_recapture(db, notify_spy):
     svc.add_legacy_player("Anchor Player", db=db)
     auth0_user = {

--- a/backend/tests/unit/services/test_auth_welcome_email.py
+++ b/backend/tests/unit/services/test_auth_welcome_email.py
@@ -13,7 +13,7 @@ import sentry_sdk
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.models import Base
+from app.models import Base, PlayerProfile
 from app.services import auth_service as auth_module
 from app.services import legacy_player_service as svc
 from app.services.auth_service import AuthService
@@ -63,7 +63,9 @@ def test_welcome_email_sent_once_for_new_profile(db, welcome_spy):
     player = AuthService.get_or_create_player_profile(db, auth0_user)
 
     assert player.id is not None
-    welcome_spy.assert_called_once_with("Brand New Golfer", "brandnew@example.com")
+    # Dispatched with (name, email, player_id) so the delivery thread can record
+    # the outcome against the profile. See issue #318.
+    welcome_spy.assert_called_once_with("Brand New Golfer", "brandnew@example.com", player.id)
 
 
 def test_welcome_email_not_sent_for_returning_player(db, welcome_spy):
@@ -114,3 +116,47 @@ def test_welcome_email_failure_is_captured_and_login_survives(db, monkeypatch):
     boom_svc.send_welcome_email.assert_called_once()
     assert len(captured) == 1
     assert isinstance(captured[0], RuntimeError)
+
+
+def _brandnew_user() -> dict:
+    return {"sub": "auth0|brandnew", "email": "brandnew@example.com", "name": "Brand New Golfer", "picture": None}
+
+
+def test_welcome_email_success_records_sent_timestamp(db, monkeypatch):
+    """On provider acceptance we persist welcome_email_sent_at (traceable, #318)."""
+    svc.add_legacy_player("Brand New Golfer", db=db)
+    # Run delivery synchronously against the test DB so we can assert on the row.
+    monkeypatch.setattr(auth_module, "SessionLocal", TestingSessionLocal)
+    monkeypatch.setattr(auth_module, "_send_welcome_email", auth_module._deliver_welcome_email)
+
+    ok_svc = Mock()
+    ok_svc.is_configured.return_value = True
+    ok_svc.send_welcome_email.return_value = True
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: ok_svc)
+
+    player = AuthService.get_or_create_player_profile(db, _brandnew_user())
+
+    refreshed = TestingSessionLocal().query(PlayerProfile).filter(PlayerProfile.id == player.id).first()
+    assert refreshed.welcome_email_sent_at is not None
+
+
+def test_welcome_email_soft_failure_is_observable_and_not_marked(db, monkeypatch):
+    """A provider that returns False (no raise) is reported and left retryable (#318)."""
+    svc.add_legacy_player("Brand New Golfer", db=db)
+    monkeypatch.setattr(auth_module, "SessionLocal", TestingSessionLocal)
+    monkeypatch.setattr(auth_module, "_send_welcome_email", auth_module._deliver_welcome_email)
+
+    soft_svc = Mock()
+    soft_svc.is_configured.return_value = True
+    soft_svc.send_welcome_email.return_value = False
+    monkeypatch.setattr("app.services.email_service.get_email_service", lambda: soft_svc)
+
+    messages: list[str] = []
+    monkeypatch.setattr(sentry_sdk, "capture_message", lambda m, *a, **k: messages.append(m))
+
+    player = AuthService.get_or_create_player_profile(db, _brandnew_user())
+
+    refreshed = TestingSessionLocal().query(PlayerProfile).filter(PlayerProfile.id == player.id).first()
+    # Not marked sent → a retry remains possible.
+    assert refreshed.welcome_email_sent_at is None
+    assert any("rejected" in m for m in messages)

--- a/backend/tests/unit/services/test_ghin_service.py
+++ b/backend/tests/unit/services/test_ghin_service.py
@@ -187,6 +187,38 @@ class TestSyncPlayerHandicap:
             # Should call the fetch method
             mock_fetch.assert_called_once()
 
+        # A successful sync persists the authoritative value AND marks its source
+        # as "ghin" so the UI stops showing it as an unknown/default. See #320.
+        db.refresh(player)
+        assert player.handicap == 14.2
+        assert player.handicap_source == "ghin"
+
+    @pytest.mark.asyncio
+    async def test_sync_handicap_missing_index_does_not_clobber(self, db):
+        """A partial GHIN response (no handicap_index) must not overwrite the
+        last known good handicap with the placeholder. See issue #320."""
+        service = GHINService(db)
+        service.initialized = True
+        service.jwt_token = "test_token"
+
+        player = PlayerProfile(
+            name="Keep My Handicap",
+            email="keep@example.com",
+            handicap=9.9,
+            handicap_source="ghin",
+            ghin_id="7654321",
+            created_at=datetime.now().isoformat(),
+        )
+        db.add(player)
+        db.commit()
+
+        with patch.object(service, "_fetch_handicap_from_ghin", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = {"handicap_index": None, "last_updated": datetime.now().isoformat()}
+            await service.sync_player_handicap(player_id=player.id)
+
+        db.refresh(player)
+        assert player.handicap == 9.9  # unchanged
+
 
 class TestGHINConfiguration:
     """Test GHIN configuration"""

--- a/docs/guides/admin-access.md
+++ b/docs/guides/admin-access.md
@@ -1,0 +1,47 @@
+# Admin access (roster & commissioner tools)
+
+Some routes — `/admin/roster`, `/admin`, and the promote/dismiss/add-player
+roster operations — are intentionally **admin-only**. This doc explains who has
+access, how access is granted, and what testers should expect. It exists
+because testers following the July 2026 checklist hit `Access Denied` at
+`/admin/roster` with no explanation of why or how to get in (issue #316).
+
+## Who is an admin
+
+Admin status is decided by an **email allowlist** configured on the server via
+the `ADMIN_EMAILS` environment variable (comma-separated). If unset, the code
+falls back to a small default set (the commissioner). The allowlist lives in
+`backend/app/utils/admin_auth.py`.
+
+The frontend no longer keeps its own separate hardcoded list as the source of
+truth: `GET /players/me` now returns an `is_admin` boolean computed from the
+same server allowlist, and the admin screens use that. This removes the old
+drift where the backend `ADMIN_EMAILS` and a hardcoded frontend list could
+disagree (a user could be a backend admin but still see `Access Denied`).
+
+## Granting access
+
+1. An existing admin (the commissioner) adds the new admin's **login email** to
+   `ADMIN_EMAILS` in the Render dashboard (the live service does not sync env
+   vars from `render.yaml` — set it in the dashboard).
+2. Redeploy / restart so the new value is picked up.
+3. The new admin hard-refreshes and re-opens `/admin/roster`.
+
+Do not commit real admin emails beyond the commissioner default into the repo.
+Keep the production allowlist in the Render dashboard.
+
+## What testers should expect
+
+- **Not signed in** → the page prompts you to sign in (this is normal).
+- **Signed in but not an admin** → you see a clear "you're signed in as
+  `<email>` but this area is admin-only; ask the commissioner to grant admin
+  access" message. This is expected for most testers — admin steps are **not**
+  part of the general tester checklist.
+- **Admin** → you can open `/admin/roster` and promote / dismiss / add players.
+
+## Tester checklist guidance
+
+The test plan should name **one responsible admin tester** (the commissioner or
+a designated admin) to perform the roster/admin steps, rather than asking every
+tester to reach `/admin/roster`. Non-admin testers seeing the
+authenticated-but-not-authorized message is a **pass**, not a bug.

--- a/docs/guides/tee-sheet-safety.md
+++ b/docs/guides/tee-sheet-safety.md
@@ -1,0 +1,71 @@
+# Tee-sheet safety: live side effects, preview & cleanup
+
+Signing up in the app can write **directly to the live thousand-cranes.com WGP
+tee sheet** — the same shared sheet Jeff and the club see. That live sync is
+intentional (it's the whole point of the round-trip), but it surprised testers
+who didn't realize a test signup would immediately change the real sheet. This
+doc makes the side effects explicit and describes the guardrails added in
+issue #323.
+
+## Which actions touch the live sheet
+
+- `POST /tee-sheet/signup` (used by the **WGP Signup Sheet** UI) posts straight
+  to the live CGI. This is the one that mutates the real, shared sheet.
+- `POST /signups` (the **Daily Signup** UI) writes to our own DB first and only
+  mirrors to the legacy sheet when `LEGACY_SIGNUP_SYNC_ENABLED=true` (off by
+  default).
+
+## Guardrails
+
+### 1. Environment gating (no silent prod writes from preview)
+
+`POST /tee-sheet/signup` performs a live write **only** when:
+
+- `ENVIRONMENT=production`, **or**
+- `TEE_SHEET_ALLOW_LIVE_WRITES=true` explicitly opts a non-production
+  environment in.
+
+In every other case (local, preview, staging) the endpoint returns a **dry-run
+preview** and performs no live mutation:
+
+```json
+{ "success": true, "live_write": false, "dry_run": true,
+  "reason": "live tee-sheet writes disabled for this environment",
+  "would_sign_up": { "name": "Jane Doe", "date": "2026-08-02" } }
+```
+
+### 2. Explicit dry-run
+
+Any caller can pass `{"dry_run": true}` to preview what would be written without
+touching the live sheet, even in production.
+
+### 3. UI confirmation
+
+The signup UI names the **exact player and date** and states that it will
+change the **LIVE** tee sheet before you confirm, and shows a **LIVE** vs
+**PREVIEW** badge based on the environment. A preview signup is clearly labeled
+as a preview, not a real signup.
+
+### 4. Failures are visible
+
+A live CGI failure surfaces as an error to the user (HTTP 502), not a silent
+success. The best-effort DB mirror / confirmation email that runs afterward is
+logged and reported to Sentry on failure rather than swallowed.
+
+## Testing safely
+
+- **Use a safe future date** you're willing to clean up, and coordinate with
+  the tee-sheet owner (Jeff) before writing to the live sheet.
+- Prefer **preview/dry-run** for identity/onboarding testing — you do not need
+  a live write to verify signup identity; the dry-run response echoes the exact
+  name and date that would be written.
+- Only flip `TEE_SHEET_ALLOW_LIVE_WRITES=true` (or test against production)
+  when you specifically intend to verify the live round-trip.
+
+## Cleanup responsibility
+
+Whoever performs a **live** test signup is responsible for removing the test
+row from the live tee sheet afterward (or asking the tee-sheet owner to). Test
+rows accidentally written under the wrong name — e.g. the July 2026 "everyone is
+Steve" incident — are audited and repaired with
+`scripts/diagnostics/audit_signup_identities.py` (see issue #319).

--- a/frontend/src/components/admin/RosterManager.jsx
+++ b/frontend/src/components/admin/RosterManager.jsx
@@ -7,6 +7,7 @@ import {
   getStoredUserEmail,
   adminHeaders,
 } from "../../utils/adminAuth";
+import { usePlayerProfile } from "../../hooks/usePlayerProfile";
 import { apiConfig } from "../../config/api.config";
 
 const API_URL = apiConfig.baseUrl;
@@ -26,7 +27,11 @@ const API_URL = apiConfig.baseUrl;
  */
 const RosterManager = () => {
   const navigate = useNavigate();
-  const { user, isLoading: authLoading } = useAuth0();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth0();
+  const {
+    isAdmin: serverIsAdmin,
+    loading: profileLoading,
+  } = usePlayerProfile();
 
   const [isAdmin, setIsAdmin] = useState(false);
   const [checkingAdmin, setCheckingAdmin] = useState(true);
@@ -40,14 +45,24 @@ const RosterManager = () => {
   const [adding, setAdding] = useState(false);
   const [actingId, setActingId] = useState(null);
 
-  // Auth0 identity is authoritative; stored email is a fallback on reload.
-  // No hardcoded default — unknown users are never admins.
+  // The server's is_admin (from /players/me) is authoritative — it mirrors the
+  // backend ADMIN_EMAILS allowlist so the two never drift. The hardcoded email
+  // list is only a fallback while the profile is still loading. No hardcoded
+  // default grants access — unknown users are never admins.
   useEffect(() => {
     if (authLoading) return;
-    const email = user?.email || getStoredUserEmail();
-    setIsAdmin(isAdminEmail(email));
+    // Wait for the profile fetch to resolve before deciding, unless the user
+    // isn't authenticated (no profile will ever load).
+    if (isAuthenticated && profileLoading) return;
+
+    if (serverIsAdmin !== null && serverIsAdmin !== undefined) {
+      setIsAdmin(serverIsAdmin);
+    } else {
+      const email = user?.email || getStoredUserEmail();
+      setIsAdmin(isAdminEmail(email));
+    }
     setCheckingAdmin(false);
-  }, [authLoading, user]);
+  }, [authLoading, user, isAuthenticated, serverIsAdmin, profileLoading]);
 
   const fetchPending = useCallback(async () => {
     setLoading(true);
@@ -177,9 +192,25 @@ const RosterManager = () => {
             <h2 className="text-2xl font-bold text-red-600 mb-4">
               Access Denied
             </h2>
-            <p className="text-gray-600 mb-6">
-              You don't have permission to access this page.
-            </p>
+            {!isAuthenticated ? (
+              <p className="text-gray-600 mb-6" data-testid="denied-signed-out">
+                You're not signed in. Please sign in with an admin account to
+                manage the roster.
+              </p>
+            ) : (
+              <p className="text-gray-600 mb-6" data-testid="denied-not-admin">
+                You're signed in
+                {user?.email ? (
+                  <>
+                    {" "}
+                    as <strong>{user.email}</strong>
+                  </>
+                ) : null}
+                , but this account isn't an admin. Admin access is granted
+                server-side via the <code>ADMIN_EMAILS</code> allowlist — contact
+                the commissioner to be added.
+              </p>
+            )}
             <button
               onClick={() => navigate("/")}
               className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"

--- a/frontend/src/components/admin/__tests__/RosterManager.test.jsx
+++ b/frontend/src/components/admin/__tests__/RosterManager.test.jsx
@@ -164,3 +164,65 @@ describe("RosterManager", () => {
     ).toBeFalsy();
   });
 });
+
+// Server-driven admin gating (issue #316): /players/me is_admin is authoritative
+// and overrides the hardcoded ADMIN_EMAILS fallback in both directions.
+function installServerAdminFetch({ isAdmin, pending = PENDING } = {}) {
+  global.fetch.mockImplementation((url, opts = {}) => {
+    if (url.endsWith("/players/me")) {
+      return okJson({ id: 1, name: "Someone", is_admin: isAdmin });
+    }
+    if (url.includes("/legacy-players/pending")) {
+      return okJson({ count: pending.length, status: "pending", players: pending });
+    }
+    if (url.endsWith("/legacy-players") && opts.method === "POST") {
+      return okJson({ added: true, canonical_name: "Jane Smith" });
+    }
+    return okJson({});
+  });
+}
+
+describe("RosterManager server-driven admin", () => {
+  test("server is_admin:true grants access even when the email is NOT in the hardcoded list", async () => {
+    mockAuth = {
+      user: { email: "random@nobody.com" },
+      isAuthenticated: true,
+      isLoading: false,
+      getAccessTokenSilently: vi.fn().mockResolvedValue("token"),
+    };
+    localStorage.setItem("userEmail", "random@nobody.com");
+    installServerAdminFetch({ isAdmin: true });
+
+    render(<RosterManager />);
+    // Roster content loads because the server says this account is an admin.
+    expect(await screen.findByTestId("pending-row-11")).toBeInTheDocument();
+    expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
+  });
+
+  test("server is_admin:false denies access even when the email IS in the hardcoded list", async () => {
+    mockAuth = {
+      user: { email: ADMIN_EMAIL },
+      isAuthenticated: true,
+      isLoading: false,
+      getAccessTokenSilently: vi.fn().mockResolvedValue("token"),
+    };
+    localStorage.setItem("userEmail", ADMIN_EMAIL);
+    installServerAdminFetch({ isAdmin: false });
+
+    render(<RosterManager />);
+    expect(await screen.findByText("Access Denied")).toBeInTheDocument();
+    // "signed in but not an admin" copy, mentioning the ADMIN_EMALS allowlist.
+    expect(screen.getByTestId("denied-not-admin")).toHaveTextContent(/ADMIN_EMAILS/);
+    expect(screen.queryByTestId("denied-signed-out")).not.toBeInTheDocument();
+  });
+
+  test("signed-out visitors get the 'not signed in' denial copy", async () => {
+    mockAuth = { user: null, isAuthenticated: false, isLoading: false };
+    localStorage.setItem("userEmail", "");
+
+    render(<RosterManager />);
+    expect(await screen.findByText("Access Denied")).toBeInTheDocument();
+    expect(screen.getByTestId("denied-signed-out")).toBeInTheDocument();
+    expect(screen.queryByTestId("denied-not-admin")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/auth/LegacyNameSelector.jsx
+++ b/frontend/src/components/auth/LegacyNameSelector.jsx
@@ -17,7 +17,9 @@ const LegacyNameSelector = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedName, setSelectedName] = useState(suggestedName || '');
+  // A fuzzy suggestion is SHOWN via the "Did you mean?" banner but is NOT
+  // pre-selected — the account stays unlinked until the user confirms a choice.
+  const [selectedName, setSelectedName] = useState('');
   const [isOpen, setIsOpen] = useState(false);
 
   // Fetch legacy players list

--- a/frontend/src/components/auth/OnboardingWrapper.jsx
+++ b/frontend/src/components/auth/OnboardingWrapper.jsx
@@ -12,9 +12,9 @@ import usePlayerProfile from '../../hooks/usePlayerProfile';
 const OnboardingWrapper = ({ children }) => {
   const { isAuthenticated, isLoading: authLoading } = useAuth0();
   const {
-    profile,
     loading: profileLoading,
     needsLegacyName,
+    legacyNameSuggestion,
     updateLegacyName,
     skipLegacyName
   } = usePlayerProfile();
@@ -29,9 +29,10 @@ const OnboardingWrapper = ({ children }) => {
     return children;
   }
 
-  // Calculate suggested name based on fuzzy match (if any)
-  // The backend already attempted this, so check if profile has a suggestion
-  const suggestedName = profile?.legacy_name || null;
+  // Fuzzy legacy-name match to SUGGEST (not auto-linked). The backend returns
+  // this as legacy_name_suggestion; the account's legacy_name stays null until
+  // the user explicitly confirms in the modal.
+  const suggestedName = legacyNameSuggestion || null;
 
   return (
     <>

--- a/frontend/src/components/auth/__tests__/OnboardingWrapper.test.jsx
+++ b/frontend/src/components/auth/__tests__/OnboardingWrapper.test.jsx
@@ -1,0 +1,182 @@
+// Tests for the fuzzy legacy-name onboarding flow (issues #322 / #321).
+//
+// These exercise the real usePlayerProfile hook wired through OnboardingWrapper
+// → OnboardingModal → LegacyNameSelector, mocking only Auth0 and fetch (the same
+// pattern DailySignupView / RosterManager tests use).
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import OnboardingWrapper from "../OnboardingWrapper";
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: vi.fn(),
+}));
+
+import { useAuth0 as mockUseAuth0 } from "@auth0/auth0-react";
+
+const SUGGESTION = "Stuart Gano";
+const LEGACY_PLAYERS = ["Alice Adams", "Bob Brown", "Stuart Gano", "Jane Smith"];
+
+const okJson = (body) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  });
+
+/**
+ * Install a fetch mock for the onboarding flow.
+ * @param {object} opts
+ * @param {string|null} opts.legacyName    profile.legacy_name
+ * @param {string|null} opts.suggestion    profile.legacy_name_suggestion
+ * @param {function} [opts.onPut]          called with the PUT body
+ */
+function installFetch({ legacyName = null, suggestion = SUGGESTION, onPut } = {}) {
+  global.fetch.mockImplementation((url, opts = {}) => {
+    if (url.endsWith("/players/me/legacy-name") && opts.method === "PUT") {
+      const body = JSON.parse(opts.body);
+      if (onPut) onPut(body);
+      return okJson({
+        legacy_name: body.legacy_name,
+        legacy_name_suggestion: null,
+        is_admin: false,
+      });
+    }
+    if (url.endsWith("/players/me")) {
+      return okJson({
+        id: 7,
+        name: "Auth0 Name",
+        legacy_name: legacyName,
+        legacy_name_suggestion: suggestion,
+        is_admin: false,
+      });
+    }
+    if (url.endsWith("/legacy-players")) {
+      return okJson({ players: LEGACY_PLAYERS });
+    }
+    return okJson({});
+  });
+}
+
+beforeEach(() => {
+  mockUseAuth0.mockReturnValue({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { name: "Auth0 Name", email: "stu@example.com" },
+    getAccessTokenSilently: vi.fn().mockResolvedValue("token-123"),
+  });
+  localStorage.clear();
+});
+
+describe("OnboardingWrapper fuzzy legacy-name flow", () => {
+  test("shows the fuzzy suggestion when legacy_name_suggestion is set and legacy_name is null", async () => {
+    installFetch({ legacyName: null, suggestion: SUGGESTION });
+
+    render(
+      <OnboardingWrapper>
+        <div>App Content</div>
+      </OnboardingWrapper>,
+    );
+
+    // Children still render underneath the modal overlay.
+    expect(screen.getByText("App Content")).toBeInTheDocument();
+
+    // "Did you mean <suggestion>?" banner appears with the suggested name.
+    expect(await screen.findByText(/Did you mean/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: SUGGESTION })).toBeInTheDocument();
+  });
+
+  test("does not show the modal when the account already has a confirmed legacy_name", async () => {
+    installFetch({ legacyName: "Stuart Gano", suggestion: null });
+
+    render(
+      <OnboardingWrapper>
+        <div>App Content</div>
+      </OnboardingWrapper>,
+    );
+
+    expect(await screen.findByText("App Content")).toBeInTheDocument();
+    // No onboarding modal when the user is already linked.
+    await waitFor(() => {
+      expect(screen.queryByText(/Link Your Account/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test("selecting a name from the dropdown PUTs it and persists (modal closes)", async () => {
+    const putBodies = [];
+    installFetch({ legacyName: null, suggestion: SUGGESTION, onPut: (b) => putBodies.push(b) });
+
+    render(
+      <OnboardingWrapper>
+        <div>App Content</div>
+      </OnboardingWrapper>,
+    );
+
+    // Wait for the selector to load its player list.
+    const search = await screen.findByPlaceholderText(/Search for your name/i);
+    fireEvent.change(search, { target: { value: "Jane" } });
+
+    // Pick "Jane Smith" from the dropdown.
+    fireEvent.click(await screen.findByText("Jane Smith"));
+
+    // Confirm the selection.
+    fireEvent.click(screen.getByRole("button", { name: /Confirm: Jane Smith/i }));
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([{ legacy_name: "Jane Smith" }]);
+    });
+
+    // After a successful link the onboarding modal closes.
+    await waitFor(() => {
+      expect(screen.queryByText(/Link Your Account/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test("clicking the suggestion button and confirming PUTs the suggested name", async () => {
+    const putBodies = [];
+    installFetch({ legacyName: null, suggestion: SUGGESTION, onPut: (b) => putBodies.push(b) });
+
+    render(
+      <OnboardingWrapper>
+        <div>App Content</div>
+      </OnboardingWrapper>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: SUGGESTION }));
+    fireEvent.click(screen.getByRole("button", { name: new RegExp(`Confirm: ${SUGGESTION}`, "i") }));
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([{ legacy_name: SUGGESTION }]);
+    });
+  });
+
+  test("'Skip for now' sets the localStorage skip flag and never writes legacy_name", async () => {
+    installFetch({ legacyName: null, suggestion: SUGGESTION });
+
+    render(
+      <OnboardingWrapper>
+        <div>App Content</div>
+      </OnboardingWrapper>,
+    );
+
+    // The main skip control in the selector.
+    const skip = await screen.findByRole("button", { name: /I'm not in the list/i });
+    fireEvent.click(skip);
+
+    // Skip persists a local flag only.
+    await waitFor(() => {
+      expect(localStorage.setItem).toHaveBeenCalledWith("legacy_name_skipped", "true");
+    });
+
+    // No PUT to legacy-name — the account stays unlinked.
+    const putCall = global.fetch.mock.calls.find(
+      ([url, opts]) => url.endsWith("/players/me/legacy-name") && opts?.method === "PUT",
+    );
+    expect(putCall).toBeUndefined();
+
+    // Modal closes after skipping.
+    await waitFor(() => {
+      expect(screen.queryByText(/Link Your Account/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/signup/WgpSignupSheet.jsx
+++ b/frontend/src/components/signup/WgpSignupSheet.jsx
@@ -34,6 +34,7 @@ export default function WgpSignupSheet() {
   const [playerProfile, setPlayerProfile] = useState(null);
   const [signingUp, setSigningUp] = useState(false);
   const [signupMessage, setSignupMessage] = useState(null);
+  const [confirming, setConfirming] = useState(false);
   const [upcomingDays, setUpcomingDays] = useState([]);
   const [loadingUpcoming, setLoadingUpcoming] = useState(true);
 
@@ -81,6 +82,7 @@ export default function WgpSignupSheet() {
   useEffect(() => {
     fetchSignups();
     setSignupMessage(null);
+    setConfirming(false);
   }, [fetchSignups]);
 
   useEffect(() => {
@@ -102,6 +104,18 @@ export default function WgpSignupSheet() {
     s => s.name?.toLowerCase() === myName.toLowerCase()
   );
 
+  // Non-production surfaces (local/preview) never write the LIVE club tee
+  // sheet — they send dry_run so the backend returns live_write:false.
+  const isLive = apiConfig.isProduction;
+
+  const requestSignup = () => {
+    if (!myName) return;
+    setSignupMessage(null);
+    setConfirming(true);
+  };
+
+  const cancelSignup = () => setConfirming(false);
+
   const handleSignup = async () => {
     if (!myName) return;
     setSigningUp(true);
@@ -110,11 +124,20 @@ export default function WgpSignupSheet() {
       const resp = await fetch(`${API_URL}/tee-sheet/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ date, name: myName }),
+        body: JSON.stringify({ date, name: myName, dry_run: !isLive }),
       });
       const data = await resp.json();
       if (!resp.ok) throw new Error(data.detail || 'Signup failed');
-      setSignupMessage({ type: 'success', text: `You're signed up as ${myName}!` });
+      setConfirming(false);
+      // A dry-run / non-live write did NOT touch the club tee sheet.
+      if (data.live_write === false || data.dry_run) {
+        setSignupMessage({
+          type: 'preview',
+          text: `Preview only — the LIVE tee sheet was not changed. In production this would sign up ${myName} for ${formatDate(date)}.`,
+        });
+      } else {
+        setSignupMessage({ type: 'success', text: `You're signed up as ${myName}!` });
+      }
       await fetchSignups();
       await refreshUpcomingCount(date);
     } catch (err) {
@@ -232,8 +255,22 @@ export default function WgpSignupSheet() {
 
       {/* Sign me up */}
       <div style={{ padding: 16, background: '#f0f7ff', borderRadius: 10, border: `1px solid ${theme.colors.primary}22` }}>
-        <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 1, color: theme.colors.textSecondary, marginBottom: 10 }}>
-          Sign Up
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 1, color: theme.colors.textSecondary }}>
+            Sign Up
+          </div>
+          <span
+            data-testid="signup-env-badge"
+            style={{
+              fontSize: 11, fontWeight: 700, letterSpacing: 0.5, textTransform: 'uppercase',
+              padding: '2px 8px', borderRadius: 999,
+              background: isLive ? '#fdecea' : '#e8f0fe',
+              color: isLive ? '#c62828' : '#1565c0',
+              border: `1px solid ${isLive ? '#f5c6cb' : '#b3d1ff'}`,
+            }}
+          >
+            {isLive ? '● LIVE tee sheet' : '● Preview (no live changes)'}
+          </span>
         </div>
         {!isAuthenticated ? (
           <p style={{ color: theme.colors.textSecondary, fontSize: 14, margin: 0 }}>Log in to sign yourself up.</p>
@@ -251,27 +288,77 @@ export default function WgpSignupSheet() {
             ) : (
               <p style={{ margin: '0 0 12px 0', color: theme.colors.textSecondary, fontSize: 14 }}>Loading your profile...</p>
             )}
-            <button
-              onClick={handleSignup}
-              disabled={signingUp || !myName}
-              style={{
-                ...theme.buttonStyle,
-                fontSize: 15, padding: '12px 24px', width: '100%',
-                background: (!myName || signingUp) ? theme.colors.textSecondary : theme.colors.primary,
-                cursor: (!myName || signingUp) ? 'not-allowed' : 'pointer',
-              }}
-            >
-              {signingUp ? 'Signing you up...' : 'Sign Me Up'}
-            </button>
+            {!confirming ? (
+              <button
+                onClick={requestSignup}
+                disabled={signingUp || !myName}
+                style={{
+                  ...theme.buttonStyle,
+                  fontSize: 15, padding: '12px 24px', width: '100%',
+                  background: (!myName || signingUp) ? theme.colors.textSecondary : theme.colors.primary,
+                  cursor: (!myName || signingUp) ? 'not-allowed' : 'pointer',
+                }}
+              >
+                Sign Me Up
+              </button>
+            ) : (
+              <div
+                data-testid="signup-confirm"
+                style={{
+                  padding: 14, borderRadius: 8,
+                  background: isLive ? '#fff8e1' : '#e8f0fe',
+                  border: `1px solid ${isLive ? '#ffe082' : '#b3d1ff'}`,
+                }}
+              >
+                <p style={{ margin: '0 0 12px 0', fontSize: 14, color: theme.colors.textPrimary }}>
+                  {isLive ? (
+                    <>
+                      This will sign up <strong>{myName}</strong> on the{' '}
+                      <strong>LIVE</strong> club tee sheet for <strong>{formatDate(date)}</strong>. Continue?
+                    </>
+                  ) : (
+                    <>
+                      Preview mode — this will <strong>not</strong> change the live tee sheet. It will
+                      preview signing up <strong>{myName}</strong> for <strong>{formatDate(date)}</strong>. Continue?
+                    </>
+                  )}
+                </p>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button
+                    onClick={handleSignup}
+                    disabled={signingUp}
+                    style={{
+                      ...theme.buttonStyle,
+                      fontSize: 14, padding: '10px 18px', flex: 1,
+                      background: signingUp ? theme.colors.textSecondary : (isLive ? (theme.colors.error || '#c62828') : theme.colors.primary),
+                      cursor: signingUp ? 'not-allowed' : 'pointer',
+                    }}
+                  >
+                    {signingUp ? 'Working...' : (isLive ? 'Yes, sign me up on the LIVE sheet' : 'Yes, preview it')}
+                  </button>
+                  <button
+                    onClick={cancelSignup}
+                    disabled={signingUp}
+                    style={{
+                      fontSize: 14, padding: '10px 18px', borderRadius: 8,
+                      background: 'white', color: theme.colors.textSecondary,
+                      border: '1px solid #ddd', cursor: signingUp ? 'not-allowed' : 'pointer',
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
           </>
         )}
         {signupMessage && (
           <div style={{
             marginTop: 12, padding: 10, borderRadius: 6, fontSize: 14, fontWeight: 500,
-            background: signupMessage.type === 'success' ? '#e8f5e9' : '#ffebee',
-            color: signupMessage.type === 'success' ? '#2e7d32' : theme.colors.error,
+            background: signupMessage.type === 'success' ? '#e8f5e9' : signupMessage.type === 'preview' ? '#e8f0fe' : '#ffebee',
+            color: signupMessage.type === 'success' ? '#2e7d32' : signupMessage.type === 'preview' ? '#1565c0' : theme.colors.error,
           }}>
-            {signupMessage.type === 'success' ? '✓ ' : '✗ '}{signupMessage.text}
+            {signupMessage.type === 'success' ? '✓ ' : signupMessage.type === 'preview' ? 'ⓘ ' : '✗ '}{signupMessage.text}
           </div>
         )}
       </div>

--- a/frontend/src/components/signup/__tests__/WgpSignupSheet.test.jsx
+++ b/frontend/src/components/signup/__tests__/WgpSignupSheet.test.jsx
@@ -76,6 +76,15 @@ const renderSheet = () =>
     </ThemeProvider>,
   );
 
+// The "Sign Me Up" button renders disabled until the profile fetch populates
+// the player name. Wait for it to be enabled before clicking, otherwise the
+// click is a no-op (racy in CI) and the confirmation never opens.
+async function clickSignMeUp() {
+  const button = await screen.findByRole("button", { name: "Sign Me Up" });
+  await waitFor(() => expect(button).toBeEnabled());
+  fireEvent.click(button);
+}
+
 beforeEach(() => {
   mockIsProduction = true;
   mockUseAuth0.mockReturnValue({
@@ -95,7 +104,7 @@ describe("WgpSignupSheet — LIVE (production)", () => {
     expect(badge).toHaveTextContent(/LIVE/i);
 
     // Click "Sign Me Up" — this must NOT post yet, only reveal a confirmation.
-    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+    await clickSignMeUp();
 
     const confirmBox = await screen.findByTestId("signup-confirm");
     expect(confirmBox).toHaveTextContent(MY_NAME);
@@ -110,7 +119,7 @@ describe("WgpSignupSheet — LIVE (production)", () => {
     installFetch({ onSignupPost: (b) => posts.push(b) });
     renderSheet();
 
-    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+    await clickSignMeUp();
     fireEvent.click(
       await screen.findByRole("button", {
         name: /Yes, sign me up on the LIVE sheet/i,
@@ -134,7 +143,7 @@ describe("WgpSignupSheet — LIVE (production)", () => {
     installFetch({ onSignupPost: (b) => posts.push(b) });
     renderSheet();
 
-    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+    await clickSignMeUp();
     await screen.findByTestId("signup-confirm");
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -168,7 +177,7 @@ describe("WgpSignupSheet — PREVIEW (non-production)", () => {
     const badge = await screen.findByTestId("signup-env-badge");
     expect(badge).toHaveTextContent(/Preview/i);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+    await clickSignMeUp();
     const confirmBox = await screen.findByTestId("signup-confirm");
     expect(confirmBox).toHaveTextContent(/Preview mode/i);
 

--- a/frontend/src/components/signup/__tests__/WgpSignupSheet.test.jsx
+++ b/frontend/src/components/signup/__tests__/WgpSignupSheet.test.jsx
@@ -1,0 +1,179 @@
+// Tests for the tee-sheet signup safety UI (issue #323).
+//
+// The "Sign Me Up" button must NOT post directly to the live sheet — it first
+// shows an explicit confirmation naming the player + date, and a LIVE / PREVIEW
+// badge. Non-production sends dry_run so the live sheet is never mutated.
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "../../../theme/Provider";
+import WgpSignupSheet from "../WgpSignupSheet";
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: vi.fn(),
+}));
+
+import { useAuth0 as mockUseAuth0 } from "@auth0/auth0-react";
+
+// Mutable production flag so a single suite can exercise LIVE and PREVIEW.
+let mockIsProduction = true;
+vi.mock("../../../config/api.config", () => ({
+  apiConfig: {
+    baseUrl: "http://test-api.com",
+    get isProduction() {
+      return mockIsProduction;
+    },
+    get isDevelopment() {
+      return !mockIsProduction;
+    },
+  },
+  default: { baseUrl: "http://test-api.com" },
+}));
+
+const MY_NAME = "Stuart Gano";
+
+const okJson = (body) =>
+  Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+
+/**
+ * @param {object} opts
+ * @param {object} opts.signupResponse  body returned by POST /tee-sheet/signup
+ * @param {function} [opts.onSignupPost] called with the parsed POST body
+ */
+function installFetch({ signupResponse, onSignupPost } = {}) {
+  global.fetch.mockImplementation((url, opts = {}) => {
+    if (url.includes("/tee-sheet/signup") && opts.method === "POST") {
+      if (onSignupPost) onSignupPost(JSON.parse(opts.body));
+      return okJson(
+        signupResponse || { success: true, live_write: true, dry_run: false },
+      );
+    }
+    if (url.includes("/tee-sheet/upcoming")) {
+      return okJson([]);
+    }
+    if (url.includes("/tee-sheet?date=")) {
+      return okJson({ slots: [], signed_up_count: 0 });
+    }
+    if (url.endsWith("/players/me")) {
+      return okJson({ id: 7, name: "Auth0 Name", legacy_name: MY_NAME });
+    }
+    return okJson({});
+  });
+}
+
+const renderSheet = () =>
+  render(
+    <ThemeProvider>
+      <WgpSignupSheet />
+    </ThemeProvider>,
+  );
+
+beforeEach(() => {
+  mockIsProduction = true;
+  mockUseAuth0.mockReturnValue({
+    isAuthenticated: true,
+    getAccessTokenSilently: vi.fn().mockResolvedValue("token-123"),
+  });
+});
+
+describe("WgpSignupSheet — LIVE (production)", () => {
+  test("shows a LIVE badge and requires confirmation before posting", async () => {
+    const posts = [];
+    installFetch({ onSignupPost: (b) => posts.push(b) });
+    renderSheet();
+
+    // LIVE badge visible.
+    const badge = await screen.findByTestId("signup-env-badge");
+    expect(badge).toHaveTextContent(/LIVE/i);
+
+    // Click "Sign Me Up" — this must NOT post yet, only reveal a confirmation.
+    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+
+    const confirmBox = await screen.findByTestId("signup-confirm");
+    expect(confirmBox).toHaveTextContent(MY_NAME);
+    expect(confirmBox).toHaveTextContent(/LIVE/);
+
+    // No POST happened just from clicking "Sign Me Up".
+    expect(posts).toHaveLength(0);
+  });
+
+  test("confirming posts with dry_run:false and shows the signed-up message", async () => {
+    const posts = [];
+    installFetch({ onSignupPost: (b) => posts.push(b) });
+    renderSheet();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Yes, sign me up on the LIVE sheet/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(posts).toHaveLength(1);
+    });
+    expect(posts[0]).toEqual({
+      date: expect.any(String),
+      name: MY_NAME,
+      dry_run: false,
+    });
+
+    expect(await screen.findByText(/You're signed up as/i)).toBeInTheDocument();
+  });
+
+  test("Cancel dismisses the confirmation without posting", async () => {
+    const posts = [];
+    installFetch({ onSignupPost: (b) => posts.push(b) });
+    renderSheet();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+    await screen.findByTestId("signup-confirm");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("signup-confirm")).not.toBeInTheDocument();
+    });
+    expect(posts).toHaveLength(0);
+    // Back to the initial button.
+    expect(screen.getByRole("button", { name: "Sign Me Up" })).toBeInTheDocument();
+  });
+});
+
+describe("WgpSignupSheet — PREVIEW (non-production)", () => {
+  beforeEach(() => {
+    mockIsProduction = false;
+  });
+
+  test("shows a Preview badge and sends dry_run:true, surfacing the preview result", async () => {
+    const posts = [];
+    installFetch({
+      signupResponse: {
+        success: true,
+        live_write: false,
+        dry_run: true,
+        would_sign_up: { name: MY_NAME, date: "2099-01-04" },
+      },
+      onSignupPost: (b) => posts.push(b),
+    });
+    renderSheet();
+
+    const badge = await screen.findByTestId("signup-env-badge");
+    expect(badge).toHaveTextContent(/Preview/i);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Sign Me Up" }));
+    const confirmBox = await screen.findByTestId("signup-confirm");
+    expect(confirmBox).toHaveTextContent(/Preview mode/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /Yes, preview it/i }));
+
+    await waitFor(() => {
+      expect(posts).toHaveLength(1);
+    });
+    expect(posts[0].dry_run).toBe(true);
+
+    // Result message makes clear the live sheet was not changed.
+    expect(
+      await screen.findByText(/LIVE tee sheet was not changed/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/usePlayerProfile.js
+++ b/frontend/src/hooks/usePlayerProfile.js
@@ -15,6 +15,7 @@ export const usePlayerProfile = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [needsLegacyName, setNeedsLegacyName] = useState(false);
+  const [legacyNameSuggestion, setLegacyNameSuggestion] = useState(null);
 
   // Fetch current user's profile
   const fetchProfile = useCallback(async () => {
@@ -44,6 +45,10 @@ export const usePlayerProfile = () => {
       // They need it if: no legacy_name set AND they haven't explicitly skipped
       const skipped = localStorage.getItem("legacy_name_skipped");
       setNeedsLegacyName(!data.legacy_name && !skipped);
+
+      // Fuzzy legacy-name match to SUGGEST during onboarding. This is NOT an
+      // auto-link — the account stays unlinked until the user confirms it.
+      setLegacyNameSuggestion(data.legacy_name_suggestion || null);
 
       setError(null);
     } catch (err) {
@@ -116,6 +121,9 @@ export const usePlayerProfile = () => {
     loading,
     error,
     needsLegacyName,
+    legacyNameSuggestion,
+    // Server-side admin allowlist membership (from /players/me). Null until loaded.
+    isAdmin: profile ? !!profile.is_admin : null,
     updateLegacyName,
     skipLegacyName,
     resetSkip,

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { isAdminEmail, getStoredUserEmail } from '../utils/adminAuth';
+import { usePlayerProfile } from '../hooks/usePlayerProfile';
 import { Card } from '../components/ui';
 import SheetIntegrationDashboard from '../components/integration/SheetIntegrationDashboard';
 import WGPAnalyticsDashboard from '../components/analytics/WGPAnalyticsDashboard';
@@ -14,7 +15,8 @@ const API_URL = apiConfig.baseUrl;
 
 const AdminPage = () => {
   const navigate = useNavigate();
-  const { user, isLoading: authLoading } = useAuth0();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth0();
+  const { isAdmin: serverIsAdmin, loading: profileLoading } = usePlayerProfile();
   const [activeTab, setActiveTab] = useState('email');
   const [isAdmin, setIsAdmin] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -54,6 +56,9 @@ const AdminPage = () => {
   // Check admin access
   useEffect(() => {
     if (authLoading) return;
+    // Wait for the profile fetch before deciding admin status, unless the user
+    // isn't authenticated (no profile will ever load).
+    if (isAuthenticated && profileLoading) return;
     checkAdminAccess();
     if (activeTab === 'email') {
       if (emailMethod === 'smtp') {
@@ -64,13 +69,20 @@ const AdminPage = () => {
     } else if (activeTab === 'banners') {
       fetchBannerConfig();
     }
-  }, [activeTab, emailMethod, authLoading, user]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, emailMethod, authLoading, user, isAuthenticated, serverIsAdmin, profileLoading]);
 
   const checkAdminAccess = () => {
-    // Auth0 identity is authoritative; stored email is a fallback for page
-    // reloads mid-session. No hardcoded default — unknown users are not admins.
-    const userEmail = user?.email || getStoredUserEmail();
-    setIsAdmin(isAdminEmail(userEmail));
+    // The server's is_admin (from /players/me) is authoritative and mirrors the
+    // backend ADMIN_EMAILS allowlist, so the two never drift. The hardcoded
+    // email list is only a fallback while the profile hasn't loaded. No
+    // hardcoded default grants access — unknown users are not admins.
+    if (serverIsAdmin !== null && serverIsAdmin !== undefined) {
+      setIsAdmin(serverIsAdmin);
+    } else {
+      const userEmail = user?.email || getStoredUserEmail();
+      setIsAdmin(isAdminEmail(userEmail));
+    }
     setLoading(false);
   };
 
@@ -425,7 +437,17 @@ const AdminPage = () => {
         <div className="max-w-4xl mx-auto px-4">
           <Card className="p-8 text-center">
             <h2 className="text-2xl font-bold text-red-600 mb-4">Access Denied</h2>
-            <p className="text-gray-600 mb-6">You don't have permission to access this page.</p>
+            {!isAuthenticated ? (
+              <p className="text-gray-600 mb-6" data-testid="denied-signed-out">
+                You're not signed in. Please sign in with an admin account to access the dashboard.
+              </p>
+            ) : (
+              <p className="text-gray-600 mb-6" data-testid="denied-not-admin">
+                You're signed in{user?.email ? <> as <strong>{user.email}</strong></> : null}, but this
+                account isn't an admin. Admin access is granted server-side via the{' '}
+                <code>ADMIN_EMAILS</code> allowlist — contact the commissioner to be added.
+              </p>
+            )}
             <button
               onClick={() => navigate('/')}
               className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"

--- a/frontend/src/pages/PlayerProfilePage.jsx
+++ b/frontend/src/pages/PlayerProfilePage.jsx
@@ -28,6 +28,17 @@ const formatGameDate = (dateStr) => {
 
 const formatScore = (q) => `${q >= 0 ? '+' : ''}${q}`;
 
+// A handicap_source of "default" means the 18.0 placeholder — i.e. unknown /
+// pending a GHIN sync — so we must not present it as a real handicap.
+const isPendingHandicap = (source) => !source || source === 'default';
+
+const formatGhinFreshness = (iso) => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return null;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
 const PlayerProfilePage = () => {
   const { playerId } = useParams();
   const navigate = useNavigate();
@@ -153,7 +164,9 @@ const PlayerProfilePage = () => {
     );
   }
 
-  const { name, handicap, description, avatar_url, has_avatar_image, last_played, created_at, available_days, game_history, badges, total_badges, stats } = profile;
+  const { name, handicap, handicap_source, ghin_last_updated, description, avatar_url, has_avatar_image, last_played, created_at, available_days, game_history, badges, total_badges, stats } = profile;
+  const handicapPending = isPendingHandicap(handicap_source) || handicap == null;
+  const ghinFreshness = handicap_source === 'ghin' ? formatGhinFreshness(ghin_last_updated) : null;
   const avatarSrc = has_avatar_image
     ? `${API_URL}/players/${playerId}/avatar${avatarVersion ? `?v=${avatarVersion}` : ''}`
     : avatar_url;
@@ -205,7 +218,19 @@ const PlayerProfilePage = () => {
             <div style={{ flex: 1, minWidth: 0 }}>
               <h1 className="wgp-profile__name">{name}</h1>
               <div className="wgp-profile__meta-row">
-                <span>Handicap <strong>{handicap != null ? handicap : '—'}</strong></span>
+                {handicapPending ? (
+                  <span title="GHIN sync pending">
+                    Handicap <strong>Pending</strong>
+                    <span style={{ marginLeft: 4, fontSize: 12, opacity: 0.7 }}>(GHIN sync pending)</span>
+                  </span>
+                ) : (
+                  <span>
+                    Handicap <strong>{handicap}</strong>
+                    {ghinFreshness && (
+                      <span style={{ marginLeft: 4, fontSize: 12, opacity: 0.7 }}>(GHIN · {ghinFreshness})</span>
+                    )}
+                  </span>
+                )}
                 {livsowTeam && (
                   <span className="wgp-profile__livsow-pill">
                     ⛳ {livsowTeam.team} · {livsowTeam.role}

--- a/frontend/src/pages/PlayersRosterPage.jsx
+++ b/frontend/src/pages/PlayersRosterPage.jsx
@@ -6,6 +6,10 @@ import './PlayersRosterPage.css';
 
 const API_URL = apiConfig.baseUrl;
 
+// A handicap_source of "default" is the 18.0 placeholder (unknown / pending a
+// GHIN sync), so we show it as pending rather than a real handicap value.
+const isPendingHandicap = (source) => !source || source === 'default';
+
 const PlayersRosterPage = () => {
   const navigate = useNavigate();
   const [players, setPlayers] = useState([]);
@@ -79,7 +83,11 @@ const PlayersRosterPage = () => {
               )}
               <div className="wgp-roster__name">{p.name}</div>
               <div className="wgp-roster__handicap">
-                Handicap {p.handicap != null ? p.handicap : '—'}
+                {isPendingHandicap(p.handicap_source) || p.handicap == null ? (
+                  <span title="GHIN sync pending">Handicap Pending</span>
+                ) : (
+                  <>Handicap {p.handicap}</>
+                )}
               </div>
             </button>
           ))}

--- a/frontend/src/pages/__tests__/PlayerProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/PlayerProfilePage.test.jsx
@@ -186,6 +186,57 @@ describe('PlayerProfilePage badges', () => {
   });
 });
 
+describe('PlayerProfilePage handicap display (issue #320)', () => {
+  test('shows "Pending" with a GHIN hint when handicap_source is "default"', async () => {
+    mockUsePlayerProfile.mockReturnValue({ profile: { id: 999 } });
+    global.fetch = vi.fn(async (url) => {
+      if (String(url).includes('/public-profile')) {
+        return { ok: true, json: async () => ({ ...baseProfile, handicap: 18.0, handicap_source: 'default' }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    renderPage();
+
+    expect(await screen.findByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText(/GHIN sync pending/)).toBeInTheDocument();
+    // The 18.0 placeholder must NOT be shown as a real handicap.
+    expect(screen.queryByText('18')).toBeNull();
+    expect(screen.queryByText('18.0')).toBeNull();
+  });
+
+  test('shows "Pending" when handicap_source is missing', async () => {
+    mockUsePlayerProfile.mockReturnValue({ profile: { id: 999 } });
+    // baseProfile has no handicap_source at all.
+    renderPage();
+
+    expect(await screen.findByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText(/GHIN sync pending/)).toBeInTheDocument();
+  });
+
+  test('shows the GHIN handicap value with a freshness note when source is "ghin"', async () => {
+    mockUsePlayerProfile.mockReturnValue({ profile: { id: 999 } });
+    global.fetch = vi.fn(async (url) => {
+      if (String(url).includes('/public-profile')) {
+        return {
+          ok: true,
+          json: async () => ({
+            ...baseProfile,
+            handicap: 7.6,
+            handicap_source: 'ghin',
+            ghin_last_updated: '2026-07-01T12:00:00Z',
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    renderPage();
+
+    expect(await screen.findByText('7.6')).toBeInTheDocument();
+    expect(screen.getByText(/GHIN ·/)).toBeInTheDocument();
+    expect(screen.queryByText('Pending')).toBeNull();
+  });
+});
+
 describe('PlayerProfilePage avatar upload', () => {
   test('does not show an upload control on someone else\'s profile', async () => {
     mockUsePlayerProfile.mockReturnValue({ profile: { id: 999 } });

--- a/frontend/src/pages/__tests__/PlayersRosterPage.test.jsx
+++ b/frontend/src/pages/__tests__/PlayersRosterPage.test.jsx
@@ -31,6 +31,30 @@ describe('PlayersRosterPage', () => {
     expect(names).toEqual(['Alice Park', 'Kevin Gent']);
   });
 
+  test('shows "Handicap Pending" for default/unknown source and the value for a real one (issue #320)', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { id: 1, name: 'Pending Pete', handicap: 18, handicap_source: 'default', is_ai: false },
+        { id: 2, name: 'Ghin Gary', handicap: 9.3, handicap_source: 'ghin', is_ai: false },
+        { id: 3, name: 'Nosource Nancy', handicap: 18, is_ai: false },
+      ],
+    }));
+
+    render(
+      <MemoryRouter>
+        <PlayersRosterPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Ghin Gary');
+    // Real GHIN handicap shows the value.
+    expect(screen.getByText('Handicap 9.3')).toBeInTheDocument();
+    // Default and missing sources show "Pending", never the 18 placeholder.
+    expect(screen.getAllByText('Handicap Pending')).toHaveLength(2);
+    expect(screen.queryByText('Handicap 18')).toBeNull();
+  });
+
   test('clicking a player navigates to their profile', async () => {
     render(
       <MemoryRouter initialEntries={['/players']}>

--- a/scripts/diagnostics/audit_signup_identities.py
+++ b/scripts/diagnostics/audit_signup_identities.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Audit (and optionally repair) player signup identities — issue #319.
+
+Background: during July 2026 testing, Brett Saks and Jeff Green were both
+treated as "Steve" and Steve's name was written to the live tee sheet. The
+client-controlled signup-identity bug was fixed in ae6a0cb (identity is now
+derived from the authenticated server profile), but existing profile links and
+erroneous tee-sheet / DailySignup rows may still need cleanup.
+
+This script is READ-ONLY by default. It connects to whatever database
+``backend.app.database`` is configured for (set ``DATABASE_URL`` to point at
+production), and reports:
+
+  * each PlayerProfile matching the audited names/emails, with its legacy_name
+  * profiles that SHARE a legacy_name (the classic "everyone is Steve" symptom)
+  * profiles whose legacy_name is not a canonical roster name
+  * DailySignup rows whose player_name disagrees with the owning profile's
+    legacy_name (a signup attributed to the wrong golfer)
+
+Examples::
+
+    # Report against production (read-only)
+    DATABASE_URL=postgres://... python scripts/diagnostics/audit_signup_identities.py
+
+    # Narrow to specific names
+    python scripts/diagnostics/audit_signup_identities.py --names "Brett Saks" "Jeff Green" "Steve Sutorius"
+
+    # Repair one profile's legacy_name (writes; requires --yes)
+    python scripts/diagnostics/audit_signup_identities.py --set-legacy-name 42="Brett Saks" --yes
+
+The repair path never merges distinct users — it only rewrites a single
+profile's legacy_name, validated against the canonical roster.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.app.database import SessionLocal  # noqa: E402
+from backend.app.models import DailySignup, PlayerProfile  # noqa: E402
+from backend.app.services.legacy_player_service import get_canonical_name  # noqa: E402
+
+DEFAULT_NAMES = ["Brett Saks", "Jeff Green", "Steve Sutorius"]
+
+
+def _match(profile: PlayerProfile, needles: list[str]) -> bool:
+    hay = " ".join(str(x or "").lower() for x in (profile.name, profile.email, profile.legacy_name))
+    return any(n.lower() in hay for n in needles)
+
+
+def audit(names: list[str]) -> int:
+    """Print the audit report. Returns the number of anomalies found."""
+    db = SessionLocal()
+    anomalies = 0
+    try:
+        profiles = db.query(PlayerProfile).all()
+        matched = [p for p in profiles if _match(p, names)]
+
+        print("=" * 72)
+        print(f"AUDITED PROFILES (matching {names})")
+        print("=" * 72)
+        if not matched:
+            print("  (no matching profiles found)")
+        for p in matched:
+            canonical = get_canonical_name(p.legacy_name, db) if p.legacy_name else None
+            flag = ""
+            if p.legacy_name and canonical is None:
+                flag = "  <-- legacy_name NOT in canonical roster"
+                anomalies += 1
+            print(f"  id={p.id:<5} name={p.name!r:<24} email={p.email!r:<32} legacy_name={p.legacy_name!r}{flag}")
+
+        # Profiles sharing a legacy_name — the "everyone is Steve" symptom.
+        by_legacy: dict[str, list[PlayerProfile]] = {}
+        for p in profiles:
+            if p.legacy_name:
+                by_legacy.setdefault(p.legacy_name.lower(), []).append(p)
+        shared = {k: v for k, v in by_legacy.items() if len(v) > 1}
+        print("\n" + "=" * 72)
+        print("LEGACY NAMES SHARED BY MULTIPLE PROFILES (should normally be unique)")
+        print("=" * 72)
+        if not shared:
+            print("  (none — every legacy_name maps to at most one profile)")
+        for legacy, ps in sorted(shared.items()):
+            anomalies += 1
+            ids = ", ".join(f"id={p.id}({p.email})" for p in ps)
+            print(f"  {ps[0].legacy_name!r}: {ids}")
+
+        # DailySignup rows whose player_name disagrees with the profile link.
+        print("\n" + "=" * 72)
+        print("SIGNUPS WHOSE player_name DISAGREES WITH THE OWNING PROFILE")
+        print("=" * 72)
+        profile_by_id = {p.id: p for p in profiles}
+        mismatches = 0
+        for s in db.query(DailySignup).all():
+            owner = profile_by_id.get(s.player_profile_id)
+            if owner is None:
+                continue
+            expected = owner.legacy_name or owner.name
+            if expected and s.player_name and s.player_name.lower() != expected.lower():
+                mismatches += 1
+                anomalies += 1
+                print(
+                    f"  signup id={s.id} date={s.date} player_name={s.player_name!r} "
+                    f"but profile id={owner.id} legacy_name={owner.legacy_name!r}"
+                )
+        if not mismatches:
+            print("  (none — every signup matches its profile's linked name)")
+
+        print("\n" + "=" * 72)
+        print(f"DONE. {anomalies} anomaly(ies) found.")
+        print("=" * 72)
+        return anomalies
+    finally:
+        db.close()
+
+
+def repair_legacy_name(spec: str, confirmed: bool) -> None:
+    """Rewrite a single profile's legacy_name. spec is 'ID=Canonical Name'."""
+    try:
+        raw_id, _, raw_name = spec.partition("=")
+        profile_id = int(raw_id.strip())
+        new_name = raw_name.strip().strip('"').strip("'")
+    except ValueError:
+        raise SystemExit(f"--set-legacy-name expects ID=\"Name\", got {spec!r}")
+
+    db = SessionLocal()
+    try:
+        canonical = get_canonical_name(new_name, db)
+        if canonical is None:
+            raise SystemExit(f"{new_name!r} is not a canonical roster name; refusing to write.")
+        profile = db.query(PlayerProfile).filter(PlayerProfile.id == profile_id).first()
+        if profile is None:
+            raise SystemExit(f"No profile with id={profile_id}")
+        print(f"profile id={profile_id}: legacy_name {profile.legacy_name!r} -> {canonical!r}")
+        if not confirmed:
+            print("  (dry run — pass --yes to apply)")
+            return
+        profile.legacy_name = canonical
+        db.commit()
+        print("  applied.")
+    finally:
+        db.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit/repair player signup identities (issue #319).")
+    parser.add_argument("--names", nargs="*", default=DEFAULT_NAMES, help="Name/email substrings to audit.")
+    parser.add_argument("--set-legacy-name", metavar='ID="Name"', help="Repair one profile's legacy_name.")
+    parser.add_argument("--yes", action="store_true", help="Actually apply a --set-legacy-name repair.")
+    args = parser.parse_args()
+
+    if args.set_legacy_name:
+        repair_legacy_name(args.set_legacy_name, args.yes)
+        return
+
+    anomalies = audit(args.names)
+    sys.exit(1 if anomalies else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tackles the batch of July 2026 tester-feedback issues. Each area ships code + tests; the two that need production data/live systems (#319, #300) ship tooling/design instead of a blind change.

## What's included

**#322 / #321 — never auto-link a fuzzy legacy-name guess**
- First login now auto-links **only** on an exact canonical roster match. A fuzzy match is surfaced as a *suggestion* via `GET /players/me` (`legacy_name_suggestion`) and is **never** written to `PlayerProfile.legacy_name` until the authenticated user selects it.
- Onboarding selector shows the suggestion as a "Did you mean?" banner without pre-selecting it (the account stays unlinked until confirmed). "Skip for now" leaves it unset.
- Coverage: backend near-duplicate + unrelated-name regression tests; new frontend onboarding tests (suggestion shown, selection persists, skip leaves unlinked).

**#320 — real handicap vs. the 18.0 placeholder**
- New `handicap_source` column (`default` / `ghin` / `manual`). GHIN sync marks values `ghin` and no longer clobbers a known handicap on a partial lookup. `/players/me` exposes `handicap_source` + `ghin_last_updated`; profile/roster UI show **"Pending"** instead of a fake `18`.

**#317 — signup confirmation email**
- `POST /signups` sends a confirmation to the **authenticated** player's email (never client input), idempotent via `confirmation_email_sent_at`, honoring the opt-out preference, recording the provider outcome (no silent "delivered").

**#318 — welcome email observability & retryability**
- Inspects the provider result (soft failures reported to Sentry), records `welcome_email_sent_at` only on acceptance, never resends on a returning login.

**#323 — live tee-sheet side effects made explicit & safe**
- `POST /tee-sheet/signup` performs a live write only when `ENVIRONMENT=production` or `TEE_SHEET_ALLOW_LIVE_WRITES=true`; otherwise returns a **dry-run preview** (no live mutation). Supports explicit `dry_run`.
- Signup UI adds a **LIVE / PREVIEW** badge and an explicit confirmation naming the exact player + date before any live write.

**#316 — admin roster access**
- `GET /players/me` returns server-computed `is_admin`, so the admin screens no longer depend on a drift-prone hardcoded frontend allowlist. Denial copy distinguishes signed-out from not-authorized. Documented in `docs/guides/admin-access.md`.

**#319 — identity audit/repair tooling**
- `scripts/diagnostics/audit_signup_identities.py` (read-only by default) audits profile links, shared `legacy_name`s ("everyone is Steve"), and mis-attributed signup rows, with a guarded repair path. Needs a one-time run against production data to close the issue.

Plus a Postgres migration for the three new columns and a `docs/guides/tee-sheet-safety.md` guide.

## Verification

- Backend: `ruff check` clean, `ruff format --check` clean, **1584 passed** (`pytest`, manual/diagnostic excluded, mirrors backend-ci).
- Frontend: `npm run typecheck` ✓, `npx vitest run` ✓ (**579 passed**), `npm run build` ✓ (mirrors frontend-ci).

## Follow-ups (tracked on issues, not in this PR)
- **#319** requires running the audit script against production and recording findings — cannot be done from the repo.
- **#300** (SimpleScorekeeper refactor) is intentionally not a drive-by; a design/spec is posted on the issue.
- Live email/tee-sheet round-trips (#317/#318/#323) still need a live-recipient smoke test in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PECBxBQSJrbU9xeALaYqeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PECBxBQSJrbU9xeALaYqeN)_