### PR TITLE
feat(deploy): scaffold full GCP migration infra (all phases)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -1,0 +1,136 @@
+name: Deploy to GCP
+
+# Manual-only (workflow_dispatch): this deploys to the stuartgano-n8n Google
+# Cloud project and must never fire automatically on push. It authenticates
+# keylessly via Workload Identity Federation — no service-account JSON key.
+#
+# Prerequisites (one-time, see deploy/gcp/README.md):
+#   - Run deploy/gcp/phase0-foundation/*.sh
+#   - Set repo Actions *Variables*: GCP_PROJECT_ID, GCP_REGION,
+#     GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_DEPLOYER_SA
+#     (optional, Phase 3) FIREBASE_SITE, VITE_API_URL
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_backend:
+        description: "Build + deploy the FastAPI backend to Cloud Run (Phase 1)"
+        type: boolean
+        default: true
+      deploy_frontend:
+        description: "Build + deploy the React SPA to Firebase Hosting (Phase 3)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write   # required for Workload Identity Federation
+
+env:
+  AR_REPO: wolf-goat-pig
+  RUN_SERVICE: wolf-goat-pig-api
+  RUNTIME_SA_NAME: wgp-run
+
+jobs:
+  deploy-backend:
+    if: ${{ inputs.deploy_backend }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to GCP (keyless, WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOYER_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${{ vars.GCP_REGION }}-docker.pkg.dev" --quiet
+
+      - name: Build & push backend image
+        run: |
+          set -euo pipefail
+          IMAGE="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${AR_REPO}/${RUN_SERVICE}"
+          docker build -f backend/Dockerfile -t "${IMAGE}:${GITHUB_SHA}" -t "${IMAGE}:latest" backend
+          docker push "${IMAGE}:${GITHUB_SHA}"
+          docker push "${IMAGE}:latest"
+          echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
+
+      - name: Deploy to Cloud Run
+        run: |
+          set -euo pipefail
+          RUNTIME_SA="${RUNTIME_SA_NAME}@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com"
+          gcloud run deploy "${RUN_SERVICE}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --image="${IMAGE}:${GITHUB_SHA}" \
+            --service-account="${RUNTIME_SA}" \
+            --allow-unauthenticated \
+            --min-instances=0 \
+            --max-instances=4 \
+            --cpu=1 \
+            --memory=1Gi \
+            --timeout=300 \
+            --env-vars-file=deploy/gcp/phase1-cloud-run/env.production.yaml \
+            --set-secrets="DATABASE_URL=DATABASE_URL:latest,GHIN_API_USER=GHIN_API_USER:latest,GHIN_API_PASS=GHIN_API_PASS:latest,RESEND_API_KEY=RESEND_API_KEY:latest,BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest,FORETEES_USERNAME=FORETEES_USERNAME:latest,FORETEES_PASSWORD=FORETEES_PASSWORD:latest,FORETEES_ENCRYPTION_KEY=FORETEES_ENCRYPTION_KEY:latest,MONITOR_KEY=MONITOR_KEY:latest"
+
+      - name: Smoke test /ready
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${RUN_SERVICE}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" --region="${{ vars.GCP_REGION }}" \
+            --format='value(status.url)')"
+          echo "Service URL: ${URL}"
+          code="$(curl -s -o /dev/null -w '%{http_code}' "${URL}/ready")"
+          echo "GET /ready -> ${code}"
+          test "${code}" = "200"
+
+  deploy-frontend:
+    if: ${{ inputs.deploy_frontend }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build SPA
+        working-directory: frontend
+        env:
+          # Cross-origin to Cloud Run (backend CORS honors FRONTEND_URL), mirroring
+          # today's Vercel→Render setup. See phase3-hosting/README.md for the
+          # same-origin /api rewrite alternative.
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
+          VITE_AUTH0_DOMAIN: "dev-jm88n088hpt7oe48.us.auth0.com"
+          VITE_AUTH0_CLIENT_ID: "qAZuRv5E9mPQ9uTGg7NWpkpfVj8bCeoB"
+          VITE_AUTH0_AUDIENCE: "https://wolf-goat-pig.onrender.com"
+          VITE_DEPLOY_PLATFORM: "firebase"
+          VITE_SENTRY_DSN: "https://aabb92ca227138a3deafbab2b4375bb3@o4511570300502016.ingest.us.sentry.io/4511570438586368"
+          CI: "false"
+        run: |
+          npm ci --legacy-peer-deps --no-audit
+          npm run build
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOYER_SA }}
+
+      - name: Deploy to Firebase Hosting
+        run: |
+          set -euo pipefail
+          # firebase.json resolves hosting.public relative to its own directory,
+          # so run from repo root with the scaffolded config copied here.
+          cp deploy/gcp/phase3-hosting/firebase.json ./firebase.json
+          npm i -g firebase-tools
+          firebase deploy --only hosting \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --non-interactive

--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,8 @@ hive-mind-prompt-*.txt
 
 # Git worktrees
 .worktrees/
+
+# GCP deploy — local config (holds project-specific but non-secret values)
+deploy/gcp/config.env
+.firebaserc
+/firebase.json

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,102 @@
+# Wolf Goat Pig on Google Cloud — deployment scaffolding
+
+Infrastructure-as-code for the migration designed in
+[`docs/architecture/FIREBASE_MIGRATION_DESIGN.md`](../../docs/architecture/FIREBASE_MIGRATION_DESIGN.md).
+Target project: **`stuartgano-n8n`**, region **`us-central1`**.
+
+> **Scope & status.** This is *scaffolding*: reviewable scripts, a CI deploy
+> workflow, and runbooks. Nothing here has been applied to the live project.
+> Each phase is independently shippable and reversible, matching the design doc's
+> phased plan. Auth stays on **Auth0** throughout (design decision D4) — no auth
+> migration here.
+
+## Target architecture (recap)
+
+```
+Auth0 (unchanged) → JWT
+Firebase Hosting (SPA)  →  Cloud Run (FastAPI container, as-is)  →  Cloud SQL (Postgres)
+                                     │                                Secret Manager
+Cloud Scheduler → Cloud Run jobs     └→ Cloud Storage (future: scorecard images)
+```
+
+## Layout
+
+| Path | Phase | What |
+|---|---|---|
+| `config.env.example` | — | Copy to `config.env` (gitignored); single source of config. |
+| `lib/common.sh` | — | Shared shell helpers (config load, derived names, logging). |
+| `phase0-foundation/` | 0 | Enable APIs, Artifact Registry, service accounts, Workload Identity Federation, Secret Manager. |
+| `phase1-cloud-run/` | 1 | Cloud Run env file + deploy notes (deploy runs via GitHub Actions). |
+| `phase2-cloud-sql/` | 2 | Provision Cloud SQL + Postgres migration runbook. |
+| `phase3-hosting/` | 3 | Firebase Hosting config (`firebase.json`, `.firebaserc`). |
+| `phase4-scheduling/` | 4 | Cloud Scheduler → Cloud Run jobs. |
+| `secrets.md` | — | Secret Manager ↔ render.yaml mapping. |
+| `../../.github/workflows/deploy-gcp.yml` | 1, 3 | Manual (`workflow_dispatch`) build+deploy, keyless via WIF. |
+
+Phase **0.5** (remove WebSockets → stateless HTTP, design D7) already shipped in
+**PR #312**, so the app is already Cloud-Run-ready (interchangeable instances).
+
+## Prerequisites
+
+- `gcloud` CLI, authenticated as a project owner/editor of `stuartgano-n8n`.
+- `docker` (for the manual backend build path; CI has its own).
+- `firebase-tools` (Phase 3 manual path; CI installs it).
+- Billing enabled on the project (Cloud Run, Cloud SQL, Artifact Registry bill).
+
+```bash
+cp deploy/gcp/config.env.example deploy/gcp/config.env
+# review values, then:
+source deploy/gcp/config.env
+```
+
+## Order of operations
+
+```bash
+# ── Phase 0 — foundation (one-time) ──────────────────────────────────────────
+./deploy/gcp/phase0-foundation/00-enable-apis.sh
+./deploy/gcp/phase0-foundation/10-artifact-registry.sh
+./deploy/gcp/phase0-foundation/20-service-accounts.sh
+./deploy/gcp/phase0-foundation/30-workload-identity-federation.sh   # prints repo vars to set
+./deploy/gcp/phase0-foundation/40-secrets.sh                        # then populate values (secrets.md)
+
+# ── Phase 1 — compute ────────────────────────────────────────────────────────
+# Set the printed GitHub Actions Variables, then run the workflow:
+#   Actions → "Deploy to GCP" → deploy_backend = true
+# (manual fallback: deploy/gcp/phase1-cloud-run/README.md)
+
+# ── Phase 2 — database ───────────────────────────────────────────────────────
+./deploy/gcp/phase2-cloud-sql/10-provision.sh
+# then follow deploy/gcp/phase2-cloud-sql/migration-runbook.md
+
+# ── Phase 3 — hosting ────────────────────────────────────────────────────────
+#   Actions → "Deploy to GCP" → deploy_frontend = true
+# (see deploy/gcp/phase3-hosting/README.md for API-connectivity options)
+
+# ── Phase 4 — scheduling (needs an app code change first) ────────────────────
+./deploy/gcp/phase4-scheduling/10-create-scheduler-jobs.sh
+```
+
+## What CI needs (set once, from `30-workload-identity-federation.sh` output)
+
+GitHub → Settings → Secrets and variables → Actions → **Variables**:
+
+| Variable | Example |
+|---|---|
+| `GCP_PROJECT_ID` | `stuartgano-n8n` |
+| `GCP_REGION` | `us-central1` |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/NNN/locations/global/workloadIdentityPools/github-pool/providers/github-provider` |
+| `GCP_DEPLOYER_SA` | `wgp-deployer@stuartgano-n8n.iam.gserviceaccount.com` |
+| `VITE_API_URL` (Phase 3) | the Cloud Run service URL |
+| `FIREBASE_SITE` (Phase 3, optional) | `stuartgano-n8n` |
+
+No service-account JSON key is ever created or stored — auth is keyless OIDC.
+
+## Safety notes
+
+- The deploy workflow is **manual only** (`workflow_dispatch`); it never fires on
+  push, so it can't surprise-deploy to the live GCP project.
+- Phase 1 keeps **Render authoritative** — Cloud Run points at Render Postgres and
+  the Cloud Run URL is additive. Rollback = keep using Render.
+- The legacy tee sheet stays **disconnected** by default (`LEGACY_TEE_SHEET_ENABLED`
+  unset, #313), so no live tee-sheet writes occur even under `ENVIRONMENT=production`.
+- Every script is idempotent and re-runnable.

--- a/deploy/gcp/config.env.example
+++ b/deploy/gcp/config.env.example
@@ -1,0 +1,54 @@
+# Wolf Goat Pig — GCP deployment config
+#
+# Copy to `config.env` (gitignored) and adjust. Every script under deploy/gcp/
+# sources this file. Nothing here is a secret — secret *values* live in Secret
+# Manager (see phase0-foundation/40-secrets.sh and secrets.md), never in git.
+
+# ── Core project ────────────────────────────────────────────────────────────
+GCP_PROJECT_ID="stuartgano-n8n"
+GCP_REGION="us-central1"
+
+# ── GitHub repo (for Workload Identity Federation, keyless CI auth) ──────────
+GITHUB_REPO="stuagano/wolf-goat-pig"
+
+# ── Artifact Registry (backend container images) ────────────────────────────
+AR_REPO="wolf-goat-pig"
+
+# ── Cloud Run (Phase 1 — backend compute) ───────────────────────────────────
+RUN_SERVICE="wolf-goat-pig-api"
+# The container listens on $PORT, which Cloud Run injects (default 8080).
+RUN_MIN_INSTANCES="0"    # scale to zero; set 1 if scorecard-OCR cold starts hurt
+RUN_MAX_INSTANCES="4"
+RUN_CPU="1"
+RUN_MEMORY="1Gi"         # opencv-python-headless + numpy + Pillow need headroom
+RUN_TIMEOUT="300"        # seconds; OCR path is slow — keep generous
+
+# ── Service accounts ────────────────────────────────────────────────────────
+RUNTIME_SA_NAME="wgp-run"        # identity the Cloud Run service runs as
+DEPLOYER_SA_NAME="wgp-deployer"  # identity GitHub Actions impersonates via WIF
+SCHEDULER_SA_NAME="wgp-scheduler" # identity Cloud Scheduler calls Cloud Run as
+
+# ── Workload Identity Federation ────────────────────────────────────────────
+WIF_POOL="github-pool"
+WIF_PROVIDER="github-provider"
+
+# ── Cloud SQL (Phase 2 — Postgres) ──────────────────────────────────────────
+# NOTE: match SQL_VERSION to the *major* version of the current Render Postgres
+# (check with `SELECT version();` before provisioning). D6: accept the always-on
+# floor — a shared-core instance is a few $/mo.
+SQL_INSTANCE="wgp-postgres"
+SQL_VERSION="POSTGRES_16"
+SQL_TIER="db-f1-micro"     # shared-core, cheapest; size up to db-g1-small if needed
+SQL_DB="wolf_goat_pig"
+SQL_USER="wgp"
+
+# ── Firebase Hosting (Phase 3 — frontend) ───────────────────────────────────
+# The Firebase Hosting site ID (defaults to the project ID's site). Set once the
+# site exists: `firebase hosting:sites:list`.
+FIREBASE_SITE="stuartgano-n8n"
+
+# ── Derived (do not edit; scripts compute these) ────────────────────────────
+# AR_HOST="${GCP_REGION}-docker.pkg.dev"
+# IMAGE="${AR_HOST}/${GCP_PROJECT_ID}/${AR_REPO}/${RUN_SERVICE}"
+# RUNTIME_SA="${RUNTIME_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+# DEPLOYER_SA="${DEPLOYER_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"

--- a/deploy/gcp/lib/common.sh
+++ b/deploy/gcp/lib/common.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Shared helpers for the deploy/gcp/* scripts.
+#
+# Usage (from a phase script):
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "${SCRIPT_DIR}/../lib/common.sh"
+#
+# This file loads config.env, verifies required CLIs, and exposes the derived
+# names (IMAGE, RUNTIME_SA, …) plus small log/confirm helpers. It performs no
+# mutations itself.
+
+set -euo pipefail
+
+# ── Locate and load config ──────────────────────────────────────────────────
+GCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -f "${GCP_DIR}/config.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${GCP_DIR}/config.env"
+elif [[ -f "${GCP_DIR}/config.env.example" ]]; then
+  echo "WARNING: config.env not found — falling back to config.env.example." >&2
+  echo "         Copy it first:  cp deploy/gcp/config.env.example deploy/gcp/config.env" >&2
+  # shellcheck disable=SC1091
+  source "${GCP_DIR}/config.env.example"
+else
+  echo "ERROR: no config.env or config.env.example under ${GCP_DIR}" >&2
+  exit 1
+fi
+
+# ── Log helpers ─────────────────────────────────────────────────────────────
+log()  { printf '\033[1;34m▸\033[0m %s\n' "$*"; }
+ok()   { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ── Preconditions ───────────────────────────────────────────────────────────
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+require_config() {
+  local missing=0 var
+  for var in "$@"; do
+    if [[ -z "${!var:-}" ]]; then
+      warn "config value missing: ${var}"
+      missing=1
+    fi
+  done
+  [[ "${missing}" -eq 0 ]] || die "fill the missing values in deploy/gcp/config.env"
+}
+
+confirm() {
+  # Skip prompts in CI / non-interactive shells.
+  if [[ ! -t 0 || "${ASSUME_YES:-}" == "1" ]]; then
+    return 0
+  fi
+  local reply
+  read -r -p "$1 [y/N] " reply
+  [[ "${reply}" == "y" || "${reply}" == "Y" ]]
+}
+
+# ── Derived names (single source of truth) ──────────────────────────────────
+require_config GCP_PROJECT_ID GCP_REGION
+
+AR_HOST="${GCP_REGION}-docker.pkg.dev"
+IMAGE="${AR_HOST}/${GCP_PROJECT_ID}/${AR_REPO:-wolf-goat-pig}/${RUN_SERVICE:-wolf-goat-pig-api}"
+RUNTIME_SA="${RUNTIME_SA_NAME:-wgp-run}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+DEPLOYER_SA="${DEPLOYER_SA_NAME:-wgp-deployer}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+SCHEDULER_SA="${SCHEDULER_SA_NAME:-wgp-scheduler}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+
+export AR_HOST IMAGE RUNTIME_SA DEPLOYER_SA SCHEDULER_SA
+
+# gcloud, invoked with the configured project every time (never relies on the
+# caller's active gcloud config).
+gc() { gcloud --project="${GCP_PROJECT_ID}" "$@"; }

--- a/deploy/gcp/phase0-foundation/00-enable-apis.sh
+++ b/deploy/gcp/phase0-foundation/00-enable-apis.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Phase 0 — enable the Google Cloud APIs the whole migration needs.
+# Idempotent: enabling an already-enabled API is a no-op.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+
+APIS=(
+  run.googleapis.com                # Cloud Run (Phase 1)
+  artifactregistry.googleapis.com   # container images (Phase 1)
+  secretmanager.googleapis.com      # secrets (Phase 0)
+  sqladmin.googleapis.com           # Cloud SQL (Phase 2)
+  firebasehosting.googleapis.com    # Firebase Hosting (Phase 3)
+  cloudscheduler.googleapis.com     # Cloud Scheduler (Phase 4)
+  iamcredentials.googleapis.com     # Workload Identity Federation
+  sts.googleapis.com                # Workload Identity Federation
+  iam.googleapis.com                # service accounts / IAM
+  logging.googleapis.com            # Cloud Logging
+  monitoring.googleapis.com         # Cloud Monitoring
+)
+
+log "Enabling ${#APIS[@]} APIs on project ${GCP_PROJECT_ID} (this can take a minute)…"
+gc services enable "${APIS[@]}"
+ok "APIs enabled."

--- a/deploy/gcp/phase0-foundation/10-artifact-registry.sh
+++ b/deploy/gcp/phase0-foundation/10-artifact-registry.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Phase 0 — create the Artifact Registry Docker repo that holds backend images.
+# Idempotent: skips creation if the repo already exists.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+require_config AR_REPO GCP_REGION
+
+if gc artifacts repositories describe "${AR_REPO}" --location="${GCP_REGION}" >/dev/null 2>&1; then
+  ok "Artifact Registry repo '${AR_REPO}' already exists in ${GCP_REGION}."
+else
+  log "Creating Artifact Registry Docker repo '${AR_REPO}' in ${GCP_REGION}…"
+  gc artifacts repositories create "${AR_REPO}" \
+    --repository-format=docker \
+    --location="${GCP_REGION}" \
+    --description="Wolf Goat Pig backend container images"
+  ok "Created ${AR_HOST}/${GCP_PROJECT_ID}/${AR_REPO}"
+fi

--- a/deploy/gcp/phase0-foundation/20-service-accounts.sh
+++ b/deploy/gcp/phase0-foundation/20-service-accounts.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Phase 0 — create the three service accounts and grant least-privilege roles.
+#
+#   runtime   (wgp-run)       — the identity the Cloud Run service runs as.
+#   deployer  (wgp-deployer)  — impersonated by GitHub Actions (via WIF) to deploy.
+#   scheduler (wgp-scheduler) — Cloud Scheduler uses this to call Cloud Run (Phase 4).
+#
+# Idempotent: creating an existing SA / re-adding a binding is a no-op.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+
+create_sa() {
+  local name="$1" display="$2"
+  local email="${name}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+  if gc iam service-accounts describe "${email}" >/dev/null 2>&1; then
+    ok "service account ${email} exists"
+  else
+    log "Creating service account ${email}…"
+    gc iam service-accounts create "${name}" --display-name="${display}"
+  fi
+}
+
+grant() {
+  # grant <member> <role>
+  log "  binding $2 → $1"
+  gc projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+    --member="$1" --role="$2" --condition=None >/dev/null
+}
+
+create_sa "${RUNTIME_SA_NAME:-wgp-run}"       "WGP Cloud Run runtime"
+create_sa "${DEPLOYER_SA_NAME:-wgp-deployer}" "WGP CI deployer (GitHub Actions)"
+create_sa "${SCHEDULER_SA_NAME:-wgp-scheduler}" "WGP Cloud Scheduler caller"
+
+log "Granting runtime SA roles…"
+grant "serviceAccount:${RUNTIME_SA}" "roles/secretmanager.secretAccessor"  # read secrets
+grant "serviceAccount:${RUNTIME_SA}" "roles/cloudsql.client"               # Phase 2 DB
+grant "serviceAccount:${RUNTIME_SA}" "roles/logging.logWriter"             # structured logs
+
+log "Granting deployer SA roles…"
+grant "serviceAccount:${DEPLOYER_SA}" "roles/run.admin"                    # deploy Cloud Run
+grant "serviceAccount:${DEPLOYER_SA}" "roles/artifactregistry.writer"      # push images
+# deployer must be able to run the service *as* the runtime SA:
+grant "serviceAccount:${DEPLOYER_SA}" "roles/iam.serviceAccountUser"
+
+ok "Service accounts configured."
+warn "Least privilege: roles/run.admin on the deployer is project-wide for"
+warn "simplicity. Tighten to the single service with a conditional binding later."

--- a/deploy/gcp/phase0-foundation/30-workload-identity-federation.sh
+++ b/deploy/gcp/phase0-foundation/30-workload-identity-federation.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Phase 0 — Workload Identity Federation so GitHub Actions can authenticate to
+# GCP with NO long-lived service-account key (keyless OIDC). GitHub mints an OIDC
+# token per run; GCP trusts it only for this exact repo and lets it impersonate
+# the deployer SA.
+#
+# Idempotent: existing pool/provider/binding are left as-is.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+require_config GITHUB_REPO WIF_POOL WIF_PROVIDER
+
+PROJECT_NUMBER="$(gc projects describe "${GCP_PROJECT_ID}" --format='value(projectNumber)')"
+POOL="${WIF_POOL}"
+PROVIDER="${WIF_PROVIDER}"
+
+# ── Pool ────────────────────────────────────────────────────────────────────
+if gc iam workload-identity-pools describe "${POOL}" --location=global >/dev/null 2>&1; then
+  ok "WIF pool '${POOL}' exists"
+else
+  log "Creating WIF pool '${POOL}'…"
+  gc iam workload-identity-pools create "${POOL}" \
+    --location=global --display-name="GitHub Actions"
+fi
+
+# ── OIDC provider (trusts GitHub's token issuer, scoped to this repo) ────────
+if gc iam workload-identity-pools providers describe "${PROVIDER}" \
+      --location=global --workload-identity-pool="${POOL}" >/dev/null 2>&1; then
+  ok "WIF provider '${PROVIDER}' exists"
+else
+  log "Creating OIDC provider '${PROVIDER}' (scoped to ${GITHUB_REPO})…"
+  gc iam workload-identity-pools providers create-oidc "${PROVIDER}" \
+    --location=global \
+    --workload-identity-pool="${POOL}" \
+    --display-name="GitHub OIDC" \
+    --issuer-uri="https://token.actions.githubusercontent.com" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
+    --attribute-condition="assertion.repository=='${GITHUB_REPO}'"
+fi
+
+# ── Let tokens from this repo impersonate the deployer SA ────────────────────
+MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL}/attribute.repository/${GITHUB_REPO}"
+log "Binding ${GITHUB_REPO} → ${DEPLOYER_SA} (roles/iam.workloadIdentityUser)…"
+gc iam service-accounts add-iam-policy-binding "${DEPLOYER_SA}" \
+  --role=roles/iam.workloadIdentityUser \
+  --member="${MEMBER}" >/dev/null
+
+PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL}/providers/${PROVIDER}"
+ok "Workload Identity Federation configured."
+echo
+log "Set these in the GitHub repo (Settings → Secrets and variables → Actions → Variables):"
+echo "    GCP_WORKLOAD_IDENTITY_PROVIDER = ${PROVIDER_RESOURCE}"
+echo "    GCP_DEPLOYER_SA                = ${DEPLOYER_SA}"
+echo "    GCP_PROJECT_ID                 = ${GCP_PROJECT_ID}"
+echo "    GCP_REGION                     = ${GCP_REGION}"

--- a/deploy/gcp/phase0-foundation/40-secrets.sh
+++ b/deploy/gcp/phase0-foundation/40-secrets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Phase 0 — create Secret Manager secrets and grant the runtime SA read access.
+#
+# These mirror the `sync: false` (dashboard-managed) env vars in render.yaml —
+# the values that must NEVER be committed. This script creates the *containers*
+# and IAM; it does not put real values in git. Add each value as a version with:
+#
+#   printf '%s' "the-value" | gcloud --project=PROJECT secrets versions add NAME --data-file=-
+#
+# Or set matching env vars before running and pass --from-env to seed them.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+
+FROM_ENV=0
+[[ "${1:-}" == "--from-env" ]] && FROM_ENV=1
+
+# Secret names must match what the Cloud Run deploy wires via --set-secrets
+# (see .github/workflows/deploy-gcp.yml and secrets.md).
+SECRETS=(
+  DATABASE_URL             # Phase 1: the Render Postgres URL; Phase 2: Cloud SQL
+  GHIN_API_USER
+  GHIN_API_PASS
+  RESEND_API_KEY
+  BOOKING_SERVICE_SECRET
+  FORETEES_USERNAME
+  FORETEES_PASSWORD
+  FORETEES_ENCRYPTION_KEY  # Fernet key for per-user ForeTees creds — do not lose
+  MONITOR_KEY              # guards GET /health/external
+)
+
+for name in "${SECRETS[@]}"; do
+  if gc secrets describe "${name}" >/dev/null 2>&1; then
+    ok "secret ${name} exists"
+  else
+    log "Creating secret ${name}…"
+    gc secrets create "${name}" --replication-policy="automatic"
+  fi
+
+  # Optionally seed a first version from a same-named env var.
+  if [[ "${FROM_ENV}" -eq 1 && -n "${!name:-}" ]]; then
+    log "  adding version to ${name} from env…"
+    printf '%s' "${!name}" | gc secrets versions add "${name}" --data-file=- >/dev/null
+  fi
+
+  # Runtime SA may read the latest version.
+  gc secrets add-iam-policy-binding "${name}" \
+    --member="serviceAccount:${RUNTIME_SA}" \
+    --role="roles/secretmanager.secretAccessor" >/dev/null
+done
+
+ok "Secrets created and readable by ${RUNTIME_SA}."
+echo
+warn "Populate any empty secrets before the first Cloud Run deploy, e.g.:"
+echo "    printf '%s' \"\$DATABASE_URL\" | gcloud --project=${GCP_PROJECT_ID} \\"
+echo "      secrets versions add DATABASE_URL --data-file=-"

--- a/deploy/gcp/phase1-cloud-run/README.md
+++ b/deploy/gcp/phase1-cloud-run/README.md
@@ -1,0 +1,64 @@
+# Phase 1 — Compute (FastAPI on Cloud Run)
+
+Deploys the existing `backend/Dockerfile` container to Cloud Run, **still pointing
+at the Render Postgres** via the `DATABASE_URL` secret. This is the design doc's
+deliberate, reversible stepping stone (§4 "Interim") — compute moves first, data
+moves in Phase 2.
+
+## How it deploys
+
+Normally via GitHub Actions: **Actions → Deploy to GCP → Run workflow** with
+`deploy_backend = true`. The workflow builds the image, pushes it to Artifact
+Registry, and runs `gcloud run deploy` with `env.production.yaml` + Secret Manager.
+
+## Why it works unchanged on Cloud Run
+
+- **Port:** `render-startup.py` binds `0.0.0.0:$PORT`; Cloud Run injects `PORT`.
+- **Health:** `/ready` (startup) and `/health` already exist in
+  `backend/app/routers/health.py`.
+- **DB:** `app/database.py` normalizes `postgres://`→`postgresql://` and only
+  needs `DATABASE_URL`; no Cloud SQL connector until Phase 2.
+- **Statelessness:** WebSockets/in-memory registry were removed in PR #312
+  (Phase 0.5, D7), so instances are interchangeable — no `max-instances=1`.
+
+## Manual deploy (fallback, no CI)
+
+```bash
+source deploy/gcp/config.env
+IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${AR_REPO}/${RUN_SERVICE}"
+
+gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev"
+docker build -f backend/Dockerfile -t "${IMAGE}:manual" backend
+docker push "${IMAGE}:manual"
+
+gcloud run deploy "${RUN_SERVICE}" \
+  --project="${GCP_PROJECT_ID}" --region="${GCP_REGION}" \
+  --image="${IMAGE}:manual" \
+  --service-account="${RUNTIME_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --allow-unauthenticated \
+  --env-vars-file=deploy/gcp/phase1-cloud-run/env.production.yaml \
+  --set-secrets="DATABASE_URL=DATABASE_URL:latest,GHIN_API_USER=GHIN_API_USER:latest,GHIN_API_PASS=GHIN_API_PASS:latest,RESEND_API_KEY=RESEND_API_KEY:latest,BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest,FORETEES_USERNAME=FORETEES_USERNAME:latest,FORETEES_PASSWORD=FORETEES_PASSWORD:latest,FORETEES_ENCRYPTION_KEY=FORETEES_ENCRYPTION_KEY:latest,MONITOR_KEY=MONITOR_KEY:latest"
+```
+
+## After the first deploy
+
+1. Grab the service URL: `gcloud run services describe wolf-goat-pig-api --region us-central1 --format='value(status.url)'`.
+2. Set `BACKEND_URL` in `env.production.yaml` to that URL and redeploy.
+3. Smoke test (mirrors CLAUDE.md's definition of done):
+   ```bash
+   curl "$URL/health"                              # environment must be production
+   curl -s -o /dev/null -w '%{http_code}' \
+     -H 'Authorization: Bearer junk' "$URL/players/me"   # must be 401, not 500
+   ```
+
+## Rollback
+
+Cloud Run keeps every revision. Roll back instantly:
+
+```bash
+gcloud run services update-traffic wolf-goat-pig-api \
+  --region us-central1 --to-revisions=PREVIOUS_REVISION=100
+```
+
+Render stays live and authoritative throughout Phase 1 — the canary Cloud Run URL
+is additive, so "rollback" can also just mean "keep using Render."

--- a/deploy/gcp/phase1-cloud-run/env.production.yaml
+++ b/deploy/gcp/phase1-cloud-run/env.production.yaml
@@ -1,0 +1,61 @@
+# Non-secret environment for the Cloud Run service (Phase 1).
+# Mirrors the plain (non `sync:false`) env vars from render.yaml. Secret *values*
+# are injected separately from Secret Manager via --set-secrets (see the deploy
+# workflow and secrets.md) and must NOT appear here.
+#
+# Applied with:  gcloud run deploy ... --env-vars-file=env.production.yaml
+#
+# ⚠️  Two URL-dependent values (BACKEND_URL, and the frontend's VITE_API_URL) are
+#     only known after the first deploy prints the Cloud Run URL. Fill BACKEND_URL
+#     in, then redeploy. Until then the app still boots; only self-referential
+#     links are affected.
+
+ENVIRONMENT: "production"
+
+# Auth0 stays (design doc D4) — identical values to Render.
+AUTH0_DOMAIN: "dev-jm88n088hpt7oe48.us.auth0.com"
+AUTH0_API_AUDIENCE: "https://wolf-goat-pig.onrender.com"
+AUTH0_CLIENT_ID: "qAZuRv5E9mPQ9uTGg7NWpkpfVj8bCeoB"
+
+# Front/back URLs. FRONTEND_URL drives CORS; set to the Firebase Hosting URL once
+# Phase 3 lands. BACKEND_URL should become the Cloud Run service URL after deploy.
+FRONTEND_URL: "https://wolf-goat-pig.vercel.app"
+BACKEND_URL: "https://wolf-goat-pig.onrender.com"
+
+# GHIN integration (static token is public by design; user/pass are secrets).
+ENABLE_GHIN_INTEGRATION: "true"
+GHIN_API_STATIC_TOKEN: "ghincom"
+
+# Legacy tee-sheet integration stays DISCONNECTED by default (#313). While this
+# is unset/false the whole /tee-sheet router returns 503, so even though
+# ENVIRONMENT=production would otherwise enable live writes (#323), no live
+# mutation can occur. Set to "true" only when a live tee sheet is intended.
+# LEGACY_TEE_SHEET_ENABLED: "true"
+
+# Legacy signup sync (outbound to thousand-cranes.com).
+LEGACY_SIGNUP_SYNC_ENABLED: "true"
+LEGACY_SIGNUP_CREATE_URL: "https://thousand-cranes.com/WolfGoatPig/wgp_add_tee_sheet_ajax.cgi"
+LEGACY_SIGNUP_FIELD_MAP: '{"player_name": "name", "date": "date"}'
+LEGACY_SIGNUP_CREATE_ACTION_FIELD: "type"
+LEGACY_SIGNUP_CREATE_ACTION_VALUE: "add"
+LEGACY_SIGNUP_CANCEL_ACTION_FIELD: "type"
+LEGACY_SIGNUP_CANCEL_ACTION_VALUE: "cancel"
+
+# Email (Resend). Key is a secret.
+EMAIL_PROVIDER: "resend"
+FROM_EMAIL: "onboarding@resend.dev"
+FROM_NAME: "Wolf Goat Pig"
+
+# ForeTees booking microservice. Still on Render for now; secret is separate.
+BOOKING_SERVICE_URL: "https://wolf-goat-pig-booking.onrender.com"
+FORETEES_ENABLED: "true"
+
+# Server tuning. WEB_CONCURRENCY=1 matches Render; Cloud Run scales by instance,
+# not by in-process workers, so keep a single uvicorn worker per instance.
+WEB_CONCURRENCY: "1"
+FORWARDED_ALLOW_IPS: "*"
+TIMEOUT_KEEP_ALIVE: "75"
+EXTERNAL_HEALTH_TTL: "300"
+
+# Sentry DSN is public by design (ships in the browser bundle too).
+SENTRY_DSN: "https://a2c007dfb1792d9f41e2d6c8c838dfcd@o4511570300502016.ingest.us.sentry.io/4511570311839744"

--- a/deploy/gcp/phase2-cloud-sql/10-provision.sh
+++ b/deploy/gcp/phase2-cloud-sql/10-provision.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Phase 2 — provision the Cloud SQL for PostgreSQL instance, database, and user.
+# Design doc D1/§4: Cloud SQL lift-and-shift, schema unchanged.
+#
+# Idempotent-ish: skips the instance/db/user if they already exist. The DB
+# password is read from the Secret Manager secret CLOUD_SQL_PASSWORD (create it
+# first, see below).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+require_config SQL_INSTANCE SQL_VERSION SQL_TIER SQL_DB SQL_USER GCP_REGION
+
+warn "Match SQL_VERSION (${SQL_VERSION}) to the CURRENT Render Postgres major"
+warn "version before running. Check with: SELECT version();"
+confirm "Provision Cloud SQL instance '${SQL_INSTANCE}' (${SQL_TIER}, always-on)?" \
+  || die "aborted"
+
+# ── Instance ────────────────────────────────────────────────────────────────
+if gc sql instances describe "${SQL_INSTANCE}" >/dev/null 2>&1; then
+  ok "Cloud SQL instance '${SQL_INSTANCE}' exists"
+else
+  log "Creating Cloud SQL instance '${SQL_INSTANCE}' (this takes several minutes)…"
+  gc sql instances create "${SQL_INSTANCE}" \
+    --database-version="${SQL_VERSION}" \
+    --tier="${SQL_TIER}" \
+    --region="${GCP_REGION}" \
+    --storage-auto-increase \
+    --availability-type=zonal
+fi
+
+# ── Password (from Secret Manager) ──────────────────────────────────────────
+if ! gc secrets describe CLOUD_SQL_PASSWORD >/dev/null 2>&1; then
+  die "Secret 'CLOUD_SQL_PASSWORD' not found. Create it first:
+    openssl rand -base64 32 | tr -d '/+=' | \\
+      gcloud --project=${GCP_PROJECT_ID} secrets create CLOUD_SQL_PASSWORD --data-file=-"
+fi
+DB_PASSWORD="$(gc secrets versions access latest --secret=CLOUD_SQL_PASSWORD)"
+
+# ── Database ────────────────────────────────────────────────────────────────
+if gc sql databases describe "${SQL_DB}" --instance="${SQL_INSTANCE}" >/dev/null 2>&1; then
+  ok "database '${SQL_DB}' exists"
+else
+  log "Creating database '${SQL_DB}'…"
+  gc sql databases create "${SQL_DB}" --instance="${SQL_INSTANCE}"
+fi
+
+# ── User ────────────────────────────────────────────────────────────────────
+if gc sql users list --instance="${SQL_INSTANCE}" --format='value(name)' | grep -qx "${SQL_USER}"; then
+  ok "user '${SQL_USER}' exists"
+else
+  log "Creating user '${SQL_USER}'…"
+  gc sql users create "${SQL_USER}" --instance="${SQL_INSTANCE}" --password="${DB_PASSWORD}"
+fi
+
+CONN_NAME="$(gc sql instances describe "${SQL_INSTANCE}" --format='value(connectionName)')"
+ok "Cloud SQL ready. Connection name: ${CONN_NAME}"
+echo
+log "Next:"
+echo "  1. Attach to Cloud Run:   gcloud run services update ${RUN_SERVICE:-wolf-goat-pig-api} \\"
+echo "        --region ${GCP_REGION} --add-cloudsql-instances=${CONN_NAME}"
+echo "  2. Point DATABASE_URL at it (Unix socket via the Cloud SQL connector)."
+echo "     Use the plain 'postgresql://' scheme — app/database.py detects Postgres"
+echo "     via startswith('postgresql://'), so a '+psycopg2' scheme would misroute"
+echo "     to the SQLite branch:"
+echo "        postgresql://${SQL_USER}:PASSWORD@/${SQL_DB}?host=/cloudsql/${CONN_NAME}"
+echo "     Store that as a new version of the DATABASE_URL secret (see migration-runbook.md)."

--- a/deploy/gcp/phase2-cloud-sql/migration-runbook.md
+++ b/deploy/gcp/phase2-cloud-sql/migration-runbook.md
@@ -1,0 +1,86 @@
+# Phase 2 — Database migration runbook (Render Postgres → Cloud SQL)
+
+Follows design doc §8. **Option A: lift-and-shift** — same schema, same ORM, same
+queries. Nothing in `backend/` changes except the `DATABASE_URL` secret.
+
+> Do a full **dry run** against a staging instance first (steps 1–5 below into a
+> throwaway DB) and run the backend test suite against it before touching prod.
+
+## 0. Prerequisites
+
+- Phase 1 is live (Cloud Run serving off Render Postgres).
+- `deploy/gcp/phase2-cloud-sql/10-provision.sh` has created the instance/db/user.
+- `psql`, `pg_dump`, `pg_restore` locally (matching the target major version).
+- The current Render `DATABASE_URL` (source) and the new Cloud SQL one (target).
+
+## 1. Confirm version parity
+
+```sql
+-- against Render:
+SELECT version();
+```
+`SQL_VERSION` in `config.env` must match the major version. Fix and re-provision
+if not — a major-version mismatch can break the restore.
+
+## 2. Dump from Render
+
+```bash
+pg_dump --no-owner --no-privileges --format=custom \
+  "$RENDER_DATABASE_URL" > wgp.dump
+```
+
+## 3. Open a path to Cloud SQL
+
+Easiest for a one-off migration — the Cloud SQL Auth Proxy (no public IP):
+
+```bash
+cloud-sql-proxy "$(gcloud sql instances describe "$SQL_INSTANCE" \
+  --format='value(connectionName)')" &   # listens on 127.0.0.1:5432
+```
+
+## 4. Restore into Cloud SQL
+
+```bash
+pg_restore --no-owner --no-privileges --clean --if-exists \
+  -d "postgresql://${SQL_USER}:${DB_PASSWORD}@127.0.0.1:5432/${SQL_DB}" \
+  wgp.dump
+```
+
+## 5. Verify parity
+
+- Row counts on the big tables match Render (`game_state`, `game_players`,
+  `hole_events`, `player_profiles`, `player_statistics`).
+- The app already ships `ensure_schema.py` / `migrations_runner.py` — run them
+  against Cloud SQL to confirm the schema is complete.
+- Point a local backend at the Cloud SQL URL and run:
+  `cd backend && pytest tests/ --ignore=tests/manual --ignore=tests/_diagnostic`.
+
+## 6. Cutover (short maintenance window)
+
+1. Freeze writes (put the app in maintenance / stop schedulers).
+2. Final incremental `pg_dump` → `pg_restore` to catch late rows.
+3. Attach Cloud SQL to the service and flip the secret:
+   ```bash
+   CONN="$(gcloud sql instances describe "$SQL_INSTANCE" --format='value(connectionName)')"
+   gcloud run services update "$RUN_SERVICE" --region "$GCP_REGION" \
+     --add-cloudsql-instances="$CONN"
+   printf '%s' "postgresql://${SQL_USER}:${DB_PASSWORD}@/${SQL_DB}?host=/cloudsql/${CONN}" \
+     | gcloud secrets versions add DATABASE_URL --data-file=-
+   ```
+4. Redeploy (or `gcloud run services update ... --update-secrets=DATABASE_URL=DATABASE_URL:latest`)
+   so the new secret version is picked up.
+5. Smoke test: `/health` → `environment=production`; junk Bearer to `/players/me`
+   → 401 not 500.
+
+## 7. Rollback
+
+The `DATABASE_URL` flip is instantly reversible — add a new secret version with
+the Render URL and redeploy. Keep **Render Postgres warm and read-only for N days**
+(§8) before decommissioning in Phase 6.
+
+## Note on the connection string scheme
+
+Use the plain **`postgresql://`** scheme (not `postgresql+psycopg2://`).
+`app/database.py` detects Postgres with `startswith("postgresql://")`; a
+`+driver` scheme would fall through to the SQLite branch. The `?host=/cloudsql/…`
+Unix-socket form works with the default psycopg2 driver.

--- a/deploy/gcp/phase3-hosting/README.md
+++ b/deploy/gcp/phase3-hosting/README.md
@@ -1,0 +1,47 @@
+# Phase 3 — Hosting (React SPA on Firebase Hosting)
+
+Moves the Vite-built SPA from Vercel to Firebase Hosting (design doc D3/§6).
+Static assets are edge-cached with free SSL; no compute wakes to serve HTML.
+
+## Deploy
+
+Via GitHub Actions: **Actions → Deploy to GCP → Run workflow** with
+`deploy_frontend = true`. The job builds `frontend/` and runs `firebase deploy
+--only hosting`. `firebase.json` here is copied to the repo root at deploy time
+because Firebase resolves `hosting.public` relative to the config file's location.
+
+`firebaserc.example` → copy to `.firebaserc` (or pass `--project`) to pin the
+Firebase project.
+
+## API connectivity: two options
+
+### A. Cross-origin to Cloud Run (what this scaffolding uses) ✅ simplest, correct today
+The SPA calls the backend at its Cloud Run URL via the build-time `VITE_API_URL`
+(set as a repo Actions Variable). The backend already does CORS off `FRONTEND_URL`
+— set that to the Firebase Hosting URL. This mirrors today's Vercel→Render setup
+exactly, so it needs no backend change.
+
+### B. Same-origin `/api/**` rewrite (doc's D3 ideal) — needs a backend prefix change
+The doc favors a Firebase Hosting **rewrite** so `/api/**` proxies to Cloud Run
+and the browser sees one origin (no CORS). That requires the backend routes to
+live under a shared `/api` prefix — today they are mounted at the root
+(`/players/me`, `/signups`, `/tee-sheet`, …), and a broad rewrite would collide
+with the SPA's own client-side routes. Adopting option B means:
+
+1. Mount all API routers under `/api` in `backend/app/main.py` (and update
+   `VITE_API_URL` to `/api`), then
+2. add this to `firebase.json` **before** the `"**" → /index.html` rewrite:
+   ```json
+   { "source": "/api/**", "run": { "serviceId": "wolf-goat-pig-api", "region": "us-central1" } }
+   ```
+
+That backend refactor is out of scope for this infra PR; option A is wired up and
+works now.
+
+## After deploy
+
+- Set the backend's `FRONTEND_URL` (in `env.production.yaml`) to the Firebase
+  Hosting URL and redeploy the backend so CORS + email links are correct.
+- Add the Firebase Hosting domain to the **Auth0 Allowed Callback/Logout/Web
+  Origins** (Auth0 stays — D4).
+- Decommission the Vercel project only after the Firebase URL is verified.

--- a/deploy/gcp/phase3-hosting/firebase.json
+++ b/deploy/gcp/phase3-hosting/firebase.json
@@ -1,0 +1,32 @@
+{
+  "hosting": {
+    "public": "frontend/build",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
+    ],
+    "headers": [
+      {
+        "source": "/static/**",
+        "headers": [
+          { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        ]
+      },
+      {
+        "source": "**/*.@(ico|png|jpg|jpeg|svg|gif|css|js|json|woff|woff2|ttf|eot)",
+        "headers": [
+          { "key": "Cache-Control", "value": "public, max-age=3600" }
+        ]
+      },
+      {
+        "source": "**",
+        "headers": [
+          { "key": "X-Content-Type-Options", "value": "nosniff" },
+          { "key": "X-Frame-Options", "value": "DENY" },
+          { "key": "X-XSS-Protection", "value": "1; mode=block" },
+          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+        ]
+      }
+    ]
+  }
+}

--- a/deploy/gcp/phase3-hosting/firebaserc.example
+++ b/deploy/gcp/phase3-hosting/firebaserc.example
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "stuartgano-n8n"
+  }
+}

--- a/deploy/gcp/phase4-scheduling/10-create-scheduler-jobs.sh
+++ b/deploy/gcp/phase4-scheduling/10-create-scheduler-jobs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Phase 4 — replace in-process `schedule` loops with Cloud Scheduler → Cloud Run.
+# Design doc §9 (Phase 4) / §12 (audit idempotency).
+#
+# Cloud Scheduler POSTs to authenticated Cloud Run endpoints on a cron. Each job
+# authenticates with an OIDC token minted for the scheduler SA, so the endpoints
+# stay private (no public trigger surface).
+#
+# ⚠️  SCAFFOLDING: the trigger endpoints below (/internal/jobs/*) do NOT exist in
+#     the app yet. Extracting each in-process scheduler
+#     (app/services/email_scheduler.py, pairing_scheduler_service.py, and the
+#     callout/matchmaking/sheet-sync loops) into an idempotent HTTP-invoked
+#     endpoint is an app code change that must land BEFORE these jobs will do
+#     anything. This script creates the jobs so the infra is ready; comment out
+#     any job whose endpoint isn't implemented yet.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+require_config RUN_SERVICE GCP_REGION
+
+RUN_URL="$(gc run services describe "${RUN_SERVICE}" --region="${GCP_REGION}" \
+  --format='value(status.url)' 2>/dev/null || true)"
+[[ -n "${RUN_URL}" ]] || die "Cloud Run service '${RUN_SERVICE}' not found — deploy Phase 1 first."
+
+# Let the scheduler SA invoke the Cloud Run service.
+log "Granting ${SCHEDULER_SA} roles/run.invoker on ${RUN_SERVICE}…"
+gc run services add-iam-policy-binding "${RUN_SERVICE}" --region="${GCP_REGION}" \
+  --member="serviceAccount:${SCHEDULER_SA}" --role=roles/run.invoker >/dev/null
+
+# job name | cron (UTC) | endpoint path
+# Adjust cadence to match the current in-process schedules before enabling.
+JOBS=(
+  "wgp-email-digest|*/15 * * * *|/internal/jobs/email-digest"
+  "wgp-pairing|0 * * * *|/internal/jobs/pairing"
+  "wgp-callouts|*/10 * * * *|/internal/jobs/callouts"
+  "wgp-sheet-sync|*/30 * * * *|/internal/jobs/sheet-sync"
+)
+
+for entry in "${JOBS[@]}"; do
+  IFS='|' read -r name cron path <<<"${entry}"
+  uri="${RUN_URL}${path}"
+  if gc scheduler jobs describe "${name}" --location="${GCP_REGION}" >/dev/null 2>&1; then
+    log "Updating scheduler job ${name} (${cron})…"
+    gc scheduler jobs update http "${name}" --location="${GCP_REGION}" \
+      --schedule="${cron}" --uri="${uri}" --http-method=POST \
+      --oidc-service-account-email="${SCHEDULER_SA}" --oidc-token-audience="${RUN_URL}"
+  else
+    log "Creating scheduler job ${name} (${cron})…"
+    gc scheduler jobs create http "${name}" --location="${GCP_REGION}" \
+      --schedule="${cron}" --uri="${uri}" --http-method=POST \
+      --oidc-service-account-email="${SCHEDULER_SA}" --oidc-token-audience="${RUN_URL}"
+  fi
+done
+
+ok "Scheduler jobs configured against ${RUN_URL}."
+warn "These fire immediately on schedule. Ensure each /internal/jobs/* endpoint"
+warn "exists and is IDEMPOTENT before enabling — Cloud Scheduler is at-least-once,"
+warn "unlike the previous single-process at-most-once loop (doc §12)."

--- a/deploy/gcp/phase4-scheduling/README.md
+++ b/deploy/gcp/phase4-scheduling/README.md
@@ -1,0 +1,35 @@
+# Phase 4 — Scheduling (Cloud Scheduler → Cloud Run)
+
+Design doc §9 (Phase 4). Today the backend runs periodic work inside the process
+via the `schedule` library (`app/services/email_scheduler.py`,
+`pairing_scheduler_service.py`, plus callout/matchmaking/sheet-sync loops). That
+assumes one long-lived process — which is exactly the assumption Cloud Run
+autoscaling breaks (every instance would run its own copy of every loop).
+
+**Target:** move each loop to a private HTTP endpoint that **Cloud Scheduler**
+POSTs to on a cron, authenticated with an OIDC token for the `wgp-scheduler`
+service account.
+
+## Two-part change
+
+1. **App code (out of scope for this infra PR).** Extract each in-process loop
+   into an idempotent endpoint under `/internal/jobs/*` and stop starting the
+   `schedule` thread when running on Cloud Run. This is the real work and needs
+   its own PR.
+2. **Infra (this script).** `10-create-scheduler-jobs.sh` creates the Cloud
+   Scheduler jobs and grants the scheduler SA `run.invoker`. Run it **after** the
+   endpoints exist; comment out any job whose endpoint isn't implemented yet.
+
+## Idempotency (doc §12)
+
+The in-process `schedule` loop is effectively at-most-once. Cloud Scheduler is
+**at-least-once** — a job can fire twice. Every `/internal/jobs/*` handler must be
+safe to run twice in a row (e.g. the email jobs already gate on
+`*_email_sent_at` columns; preserve that discipline for pairing/callouts/sync).
+
+## Verify
+
+```bash
+gcloud scheduler jobs list --location us-central1
+gcloud scheduler jobs run wgp-email-digest --location us-central1   # manual fire
+```

--- a/deploy/gcp/secrets.md
+++ b/deploy/gcp/secrets.md
@@ -1,0 +1,43 @@
+# Secret Manager mapping
+
+Every value Render kept as `sync: false` (dashboard-managed, never committed)
+becomes a Secret Manager secret. `phase0-foundation/40-secrets.sh` creates the
+containers and grants the runtime SA `secretAccessor`; the Cloud Run deploy wires
+them in with `--set-secrets`.
+
+| Secret name | From render.yaml | Notes |
+|---|---|---|
+| `DATABASE_URL` | `DATABASE_URL` | Phase 1: the Render Postgres URL. Phase 2: the Cloud SQL URL. Use the `postgresql://` scheme (not `+psycopg2`). |
+| `GHIN_API_USER` | `GHIN_API_USER` | GHIN handicap lookups. |
+| `GHIN_API_PASS` | `GHIN_API_PASS` | |
+| `RESEND_API_KEY` | `RESEND_API_KEY` | Email delivery (Resend). |
+| `BOOKING_SERVICE_SECRET` | `BOOKING_SERVICE_SECRET` | Shared secret with the ForeTees booking microservice. |
+| `FORETEES_USERNAME` | `FORETEES_USERNAME` | |
+| `FORETEES_PASSWORD` | `FORETEES_PASSWORD` | |
+| `FORETEES_ENCRYPTION_KEY` | `FORETEES_ENCRYPTION_KEY` | Fernet key for per-user ForeTees creds — **losing/rotating it breaks stored creds**. |
+| `MONITOR_KEY` | `MONITOR_KEY` | Guards `GET /health/external`. |
+| `CLOUD_SQL_PASSWORD` | — (new) | Phase 2 only: the Cloud SQL `wgp` user password. Not injected into the app; used by provisioning + to build `DATABASE_URL`. |
+
+## What is **not** a secret (stays in `env.production.yaml`)
+
+`SENTRY_DSN` (public by design — also ships in the browser bundle),
+`GHIN_API_STATIC_TOKEN` (`"ghincom"`), the Auth0 domain/client-id/audience, and
+the various `LEGACY_SIGNUP_*` / URL / tuning values. These mirror the plain
+(non-`sync:false`) entries in render.yaml.
+
+## Populate a secret value
+
+```bash
+printf '%s' 'THE-VALUE' | \
+  gcloud --project=stuartgano-n8n secrets versions add DATABASE_URL --data-file=-
+```
+
+Or seed everything at once from a local env (values already exported):
+
+```bash
+DATABASE_URL=... RESEND_API_KEY=... ./phase0-foundation/40-secrets.sh --from-env
+```
+
+Cloud Run reads `:latest`, so adding a new version + redeploy rotates a secret.
+Never `echo` a secret into shell history or commit it — `config.env` is gitignored
+and holds only non-secret names.


### PR DESCRIPTION
## Summary

Implements the infrastructure-as-code for the Firebase/GCP migration designed in [`docs/architecture/FIREBASE_MIGRATION_DESIGN.md`](../blob/main/docs/architecture/FIREBASE_MIGRATION_DESIGN.md) (RFC merged in #311; Phase 0.5 de-socketing shipped in #312). Target project **`stuartgano-n8n`**, region **`us-central1`**.

**This is scaffolding — nothing here is applied to the live project.** Every script is idempotent, each phase is independently shippable and reversible, and the deploy workflow is manual-only so it can never surprise-deploy. Auth stays on **Auth0** throughout (design decision D4).

All new code lives under `deploy/gcp/` plus one `.github/workflows/` file; no existing app or CI code is touched.

## What's included

**Phase 0 — Foundation** (`deploy/gcp/phase0-foundation/`)
- Enable APIs · Artifact Registry repo · runtime/deployer/scheduler service accounts with least-privilege roles · **keyless Workload Identity Federation** for GitHub Actions (no SA JSON key) · Secret Manager secrets mapped from render.yaml's `sync:false` vars.

**Phase 1 — Compute (Cloud Run)** (`deploy/gcp/phase1-cloud-run/` + `.github/workflows/deploy-gcp.yml`)
- Manual (`workflow_dispatch`) workflow: builds the existing `backend/Dockerfile`, pushes to Artifact Registry, deploys to Cloud Run, and smoke-tests `/ready`.
- Still points at **Render Postgres** via the `DATABASE_URL` secret — the doc's deliberate, reversible interim (§4). Non-secret env in `env.production.yaml`; secrets via `--set-secrets`.
- Verified the container is Cloud-Run-ready: binds `0.0.0.0:$PORT`, `/ready` + `/health` exist, and `database.py` needs only `DATABASE_URL`.

**Phase 2 — Database (Cloud SQL)** (`deploy/gcp/phase2-cloud-sql/`)
- Provisioning script + `pg_dump`/`pg_restore` migration runbook with `DATABASE_URL` cutover and rollback (§8). Notes the `postgresql://` scheme requirement (a `+psycopg2` scheme would misroute to the SQLite branch in `database.py`).

**Phase 3 — Hosting (Firebase)** (`deploy/gcp/phase3-hosting/`)
- `firebase.json` (SPA + security/cache headers mirrored from `vercel.json`), `.firebaserc` example, frontend deploy job. Documents cross-origin-to-Cloud-Run (wired up, correct today) vs. the same-origin `/api/**` rewrite (needs a backend `/api` prefix — out of scope).

**Phase 4 — Scheduling (Cloud Scheduler)** (`deploy/gcp/phase4-scheduling/`)
- Cloud Scheduler → Cloud Run job scaffolding with OIDC auth and at-least-once idempotency notes (§12). The `/internal/jobs/*` trigger endpoints are a follow-up app change, clearly flagged.

## Verification

- All shell scripts pass `bash -n`; workflow + env YAML and firebase JSON validated; `env.production.yaml` is a flat string map (valid for `gcloud --env-vars-file`).
- No hardcoded secrets — the only keys present (public Sentry DSN, Auth0 client-id/audience) already ship in the committed `render.yaml`/`vercel.json`. `config.env` and local firebase files are gitignored.
- Does not affect existing frontend/backend CI (new files only; deploy workflow is `workflow_dispatch`).

## How to apply (summary — see `deploy/gcp/README.md`)

1. `cp deploy/gcp/config.env.example deploy/gcp/config.env`
2. Run `phase0-foundation/*.sh`, then set the printed GitHub Actions **Variables** and populate Secret Manager values.
3. **Actions → "Deploy to GCP" → `deploy_backend`** for Phase 1; follow the runbooks for Phases 2–4.

## Follow-ups (tracked, not in this PR)

- Phase 2 cutover, Phase 3 frontend cutover, and Vercel/Render decommission require running against live systems.
- Phase 4 needs the in-process schedulers extracted into idempotent `/internal/jobs/*` endpoints (app code change).
- Same-origin `/api/**` hosting rewrite needs the backend routers mounted under `/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PECBxBQSJrbU9xeALaYqeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PECBxBQSJrbU9xeALaYqeN)_