### PR TITLE
feat(deploy): add Cloud Build pipeline and CI wiring for GCP deploys

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,25 @@
+# Keep `gcloud builds submit` source uploads small. The Cloud Build pipeline
+# (deploy/gcp/cloudbuild.yaml) only needs backend/** and deploy/gcp/**; the
+# Docker build context is backend/. Everything below is irrelevant to the build.
+#
+# NOTE: if no .gcloudignore existed, gcloud would import .gitignore. This file
+# takes over that role, so it must not exclude backend/ or deploy/.
+.git/
+.github/
+.worktrees/
+
+# Frontend (built and deployed separately via Firebase Hosting)
+frontend/node_modules/
+frontend/build/
+frontend/dist/
+
+# Python / Node build & cache artifacts
+**/__pycache__/
+*.pyc
+backend/venv/
+backend/.venv/
+**/node_modules/
+
+# Local env / logs
+**/*.log
+deploy/gcp/config.env

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -1,13 +1,22 @@
 name: Deploy to GCP
 
-# Manual-only (workflow_dispatch): this deploys to the stuartgano-n8n Google
-# Cloud project and must never fire automatically on push. It authenticates
-# keylessly via Workload Identity Federation — no service-account JSON key.
+# Deploys the FastAPI backend to Cloud Run via the Cloud Build pipeline
+# (deploy/gcp/cloudbuild.yaml), authenticating keylessly through Workload
+# Identity Federation — no service-account JSON key.
+#
+# Triggers:
+#   - workflow_dispatch — always available (manual button), never surprises.
+#   - push to main      — ONLY deploys the backend when the repo variable
+#                         GCP_AUTO_DEPLOY == "true". Unset (the default) = the
+#                         push run starts but the deploy job is skipped, so a
+#                         merge can never surprise-deploy until you opt in.
+# The frontend (Firebase Hosting) is manual-only regardless.
 #
 # Prerequisites (one-time, see deploy/gcp/README.md):
-#   - Run deploy/gcp/phase0-foundation/*.sh
+#   - Run deploy/gcp/phase0-foundation/*.sh  (incl. 25-cloud-build-iam.sh)
 #   - Set repo Actions *Variables*: GCP_PROJECT_ID, GCP_REGION,
 #     GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_DEPLOYER_SA
+#     (opt-in auto-deploy) GCP_AUTO_DEPLOY=true
 #     (optional, Phase 3) FIREBASE_SITE, VITE_API_URL
 
 on:
@@ -21,19 +30,26 @@ on:
         description: "Build + deploy the React SPA to Firebase Hosting (Phase 3)"
         type: boolean
         default: false
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "deploy/gcp/**"
+      - ".github/workflows/deploy-gcp.yml"
 
 permissions:
   contents: read
   id-token: write   # required for Workload Identity Federation
 
 env:
-  AR_REPO: wolf-goat-pig
   RUN_SERVICE: wolf-goat-pig-api
-  RUNTIME_SA_NAME: wgp-run
 
 jobs:
   deploy-backend:
-    if: ${{ inputs.deploy_backend }}
+    # workflow_dispatch: honor the checkbox. push: only if opted in via the var.
+    if: >-
+      ${{ (github.event_name == 'workflow_dispatch' && inputs.deploy_backend) ||
+          (github.event_name == 'push' && vars.GCP_AUTO_DEPLOY == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,35 +65,15 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker "${{ vars.GCP_REGION }}-docker.pkg.dev" --quiet
-
-      - name: Build & push backend image
+      - name: Build & deploy via Cloud Build
         run: |
           set -euo pipefail
-          IMAGE="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${AR_REPO}/${RUN_SERVICE}"
-          docker build -f backend/Dockerfile -t "${IMAGE}:${GITHUB_SHA}" -t "${IMAGE}:latest" backend
-          docker push "${IMAGE}:${GITHUB_SHA}"
-          docker push "${IMAGE}:latest"
-          echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
-
-      - name: Deploy to Cloud Run
-        run: |
-          set -euo pipefail
-          RUNTIME_SA="${RUNTIME_SA_NAME}@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com"
-          gcloud run deploy "${RUN_SERVICE}" \
+          gcloud builds submit \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ vars.GCP_REGION }}" \
-            --image="${IMAGE}:${GITHUB_SHA}" \
-            --service-account="${RUNTIME_SA}" \
-            --allow-unauthenticated \
-            --min-instances=0 \
-            --max-instances=4 \
-            --cpu=1 \
-            --memory=1Gi \
-            --timeout=300 \
-            --env-vars-file=deploy/gcp/phase1-cloud-run/env.production.yaml \
-            --set-secrets="DATABASE_URL=DATABASE_URL:latest,GHIN_API_USER=GHIN_API_USER:latest,GHIN_API_PASS=GHIN_API_PASS:latest,RESEND_API_KEY=RESEND_API_KEY:latest,BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest,FORETEES_USERNAME=FORETEES_USERNAME:latest,FORETEES_PASSWORD=FORETEES_PASSWORD:latest,FORETEES_ENCRYPTION_KEY=FORETEES_ENCRYPTION_KEY:latest,MONITOR_KEY=MONITOR_KEY:latest"
+            --config=deploy/gcp/cloudbuild.yaml \
+            --substitutions="SHORT_SHA=${GITHUB_SHA::12},_REGION=${{ vars.GCP_REGION }}" \
+            .
 
       - name: Smoke test /ready
         run: |
@@ -91,7 +87,8 @@ jobs:
           test "${code}" = "200"
 
   deploy-frontend:
-    if: ${{ inputs.deploy_frontend }}
+    # Manual-only — never runs on push, even with GCP_AUTO_DEPLOY set.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_frontend }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -25,13 +25,14 @@ Cloud Scheduler → Cloud Run jobs     └→ Cloud Storage (future: scorecard i
 |---|---|---|
 | `config.env.example` | — | Copy to `config.env` (gitignored); single source of config. |
 | `lib/common.sh` | — | Shared shell helpers (config load, derived names, logging). |
-| `phase0-foundation/` | 0 | Enable APIs, Artifact Registry, service accounts, Workload Identity Federation, Secret Manager. |
-| `phase1-cloud-run/` | 1 | Cloud Run env file + deploy notes (deploy runs via GitHub Actions). |
+| `phase0-foundation/` | 0 | Enable APIs, Artifact Registry, service accounts, Workload Identity Federation, Secret Manager, Cloud Build IAM. |
+| `cloudbuild.yaml` | 1 | Cloud Build pipeline: build → push → deploy to Cloud Run. |
+| `phase1-cloud-run/` | 1 | Cloud Run env file, deploy notes, native Cloud Build trigger script. |
 | `phase2-cloud-sql/` | 2 | Provision Cloud SQL + Postgres migration runbook. |
 | `phase3-hosting/` | 3 | Firebase Hosting config (`firebase.json`, `.firebaserc`). |
 | `phase4-scheduling/` | 4 | Cloud Scheduler → Cloud Run jobs. |
 | `secrets.md` | — | Secret Manager ↔ render.yaml mapping. |
-| `../../.github/workflows/deploy-gcp.yml` | 1, 3 | Manual (`workflow_dispatch`) build+deploy, keyless via WIF. |
+| `../../.github/workflows/deploy-gcp.yml` | 1, 3 | GitHub Actions → Cloud Build (keyless WIF). Manual by default; opt-in auto-deploy on merge. |
 
 Phase **0.5** (remove WebSockets → stateless HTTP, design D7) already shipped in
 **PR #312**, so the app is already Cloud-Run-ready (interchangeable instances).
@@ -56,13 +57,16 @@ source deploy/gcp/config.env
 ./deploy/gcp/phase0-foundation/00-enable-apis.sh
 ./deploy/gcp/phase0-foundation/10-artifact-registry.sh
 ./deploy/gcp/phase0-foundation/20-service-accounts.sh
+./deploy/gcp/phase0-foundation/25-cloud-build-iam.sh                # Cloud Build SA deploy roles
 ./deploy/gcp/phase0-foundation/30-workload-identity-federation.sh   # prints repo vars to set
 ./deploy/gcp/phase0-foundation/40-secrets.sh                        # then populate values (secrets.md)
 
-# ── Phase 1 — compute ────────────────────────────────────────────────────────
+# ── Phase 1 — compute (Cloud Build pipeline) ─────────────────────────────────
 # Set the printed GitHub Actions Variables, then run the workflow:
 #   Actions → "Deploy to GCP" → deploy_backend = true
-# (manual fallback: deploy/gcp/phase1-cloud-run/README.md)
+# It calls `gcloud builds submit --config deploy/gcp/cloudbuild.yaml`.
+# Opt-in auto-deploy on merge: set repo variable GCP_AUTO_DEPLOY=true.
+# (manual submit / native trigger: deploy/gcp/phase1-cloud-run/README.md)
 
 # ── Phase 2 — database ───────────────────────────────────────────────────────
 ./deploy/gcp/phase2-cloud-sql/10-provision.sh
@@ -86,6 +90,7 @@ GitHub → Settings → Secrets and variables → Actions → **Variables**:
 | `GCP_REGION` | `us-central1` |
 | `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/NNN/locations/global/workloadIdentityPools/github-pool/providers/github-provider` |
 | `GCP_DEPLOYER_SA` | `wgp-deployer@stuartgano-n8n.iam.gserviceaccount.com` |
+| `GCP_AUTO_DEPLOY` (optional) | `true` to auto-deploy the backend on merge to main; unset = manual-only |
 | `VITE_API_URL` (Phase 3) | the Cloud Run service URL |
 | `FIREBASE_SITE` (Phase 3, optional) | `stuartgano-n8n` |
 

--- a/deploy/gcp/cloudbuild.yaml
+++ b/deploy/gcp/cloudbuild.yaml
@@ -1,0 +1,70 @@
+# Cloud Build pipeline — build the backend image, push to Artifact Registry, and
+# deploy to Cloud Run. Design doc Phase 1 (compute).
+#
+# Run it three ways (all covered in deploy/gcp/README.md):
+#   1. From GitHub Actions:  gcloud builds submit --config deploy/gcp/cloudbuild.yaml .
+#      (the "Deploy to GCP" workflow does this, authed keylessly via WIF)
+#   2. Manually:             gcloud builds submit --config deploy/gcp/cloudbuild.yaml \
+#                              --substitutions=SHORT_SHA=manual .
+#   3. From a native Cloud Build trigger watching GitHub
+#      (deploy/gcp/phase1-cloud-run/create-cloud-build-trigger.sh)
+#
+# The build runs as the Cloud Build service account, which needs deploy roles —
+# granted by deploy/gcp/phase0-foundation/25-cloud-build-iam.sh.
+
+substitutions:
+  _REGION: us-central1
+  _AR_REPO: wolf-goat-pig
+  _SERVICE: wolf-goat-pig-api
+  _RUNTIME_SA_NAME: wgp-run
+  # Comma-separated KEY=SECRET:latest pairs, mirrored from the Actions workflow.
+  _SECRETS: "DATABASE_URL=DATABASE_URL:latest,GHIN_API_USER=GHIN_API_USER:latest,GHIN_API_PASS=GHIN_API_PASS:latest,RESEND_API_KEY=RESEND_API_KEY:latest,BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest,FORETEES_USERNAME=FORETEES_USERNAME:latest,FORETEES_PASSWORD=FORETEES_PASSWORD:latest,FORETEES_ENCRYPTION_KEY=FORETEES_ENCRYPTION_KEY:latest,MONITOR_KEY=MONITOR_KEY:latest"
+
+# The image Cloud Build pushes on success ($SHORT_SHA is provided by triggers;
+# pass --substitutions=SHORT_SHA=... for manual submits).
+images:
+  - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:${SHORT_SHA}"
+  - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:latest"
+
+steps:
+  # ── Build the existing backend Dockerfile (context = backend/) ─────────────
+  - id: build
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - backend/Dockerfile
+      - -t
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:${SHORT_SHA}"
+      - -t
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:latest"
+      - backend
+
+  # ── Deploy to Cloud Run (image is pushed by the `images:` block first) ──────
+  - id: deploy
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - "${_SERVICE}"
+      - --project=${PROJECT_ID}
+      - --region=${_REGION}
+      - --image=${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:${SHORT_SHA}
+      - --service-account=${_RUNTIME_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+      - --allow-unauthenticated
+      - --min-instances=0
+      - --max-instances=4
+      - --cpu=1
+      - --memory=1Gi
+      - --timeout=300
+      - --env-vars-file=deploy/gcp/phase1-cloud-run/env.production.yaml
+      - --set-secrets=${_SECRETS}
+
+# Bigger machine — the image bundles opencv-python-headless, numpy, Pillow, and a
+# Playwright Chromium shell, which is heavy to build on the default machine.
+options:
+  machineType: E2_HIGHCPU_8
+  logging: CLOUD_LOGGING_ONLY   # log to Cloud Logging (no legacy GCS log bucket)
+
+timeout: 1800s   # 30 min — the Playwright/OpenCV image build is slow

--- a/deploy/gcp/phase0-foundation/00-enable-apis.sh
+++ b/deploy/gcp/phase0-foundation/00-enable-apis.sh
@@ -9,6 +9,7 @@ require_cmd gcloud
 
 APIS=(
   run.googleapis.com                # Cloud Run (Phase 1)
+  cloudbuild.googleapis.com         # Cloud Build pipeline (Phase 1)
   artifactregistry.googleapis.com   # container images (Phase 1)
   secretmanager.googleapis.com      # secrets (Phase 0)
   sqladmin.googleapis.com           # Cloud SQL (Phase 2)

--- a/deploy/gcp/phase0-foundation/20-service-accounts.sh
+++ b/deploy/gcp/phase0-foundation/20-service-accounts.sh
@@ -42,6 +42,7 @@ grant "serviceAccount:${RUNTIME_SA}" "roles/logging.logWriter"             # str
 log "Granting deployer SA roles…"
 grant "serviceAccount:${DEPLOYER_SA}" "roles/run.admin"                    # deploy Cloud Run
 grant "serviceAccount:${DEPLOYER_SA}" "roles/artifactregistry.writer"      # push images
+grant "serviceAccount:${DEPLOYER_SA}" "roles/cloudbuild.builds.editor"     # submit Cloud Build
 # deployer must be able to run the service *as* the runtime SA:
 grant "serviceAccount:${DEPLOYER_SA}" "roles/iam.serviceAccountUser"
 

--- a/deploy/gcp/phase0-foundation/25-cloud-build-iam.sh
+++ b/deploy/gcp/phase0-foundation/25-cloud-build-iam.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Phase 0 — grant the Cloud Build service account the roles it needs to build the
+# image, push it to Artifact Registry, and deploy to Cloud Run.
+#
+# Which SA runs a build differs by project age:
+#   - legacy default : PROJECT_NUMBER@cloudbuild.gserviceaccount.com
+#   - newer default  : PROJECT_NUMBER-compute@developer.gserviceaccount.com
+# Rather than guess, this grants the roles to whichever of the two exists (both,
+# if both do). Idempotent.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+
+PROJECT_NUMBER="$(gc projects describe "${GCP_PROJECT_ID}" --format='value(projectNumber)')"
+
+CANDIDATES=(
+  "${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
+  "${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+)
+
+ROLES=(
+  roles/run.admin                    # deploy Cloud Run
+  roles/artifactregistry.writer      # push images
+  roles/iam.serviceAccountUser       # deploy the service AS the runtime SA
+  roles/secretmanager.viewer         # validate --set-secrets references
+  roles/logging.logWriter            # build logs (options.logging=CLOUD_LOGGING_ONLY)
+)
+
+granted_any=0
+for sa in "${CANDIDATES[@]}"; do
+  if gc iam service-accounts describe "${sa}" >/dev/null 2>&1; then
+    granted_any=1
+    log "Granting Cloud Build roles to ${sa}…"
+    for role in "${ROLES[@]}"; do
+      log "  ${role}"
+      gc projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+        --member="serviceAccount:${sa}" --role="${role}" --condition=None >/dev/null
+    done
+  else
+    warn "build SA candidate not found (skipping): ${sa}"
+  fi
+done
+
+[[ "${granted_any}" -eq 1 ]] || die "no Cloud Build service account found — run 00-enable-apis.sh first (cloudbuild.googleapis.com creates it)."
+
+ok "Cloud Build service account(s) can now build, push, and deploy."
+warn "roles/run.admin + project-level serviceAccountUser are broad for simplicity"
+warn "(matches the deployer-SA note in 20-service-accounts.sh). Tighten later if desired."

--- a/deploy/gcp/phase1-cloud-run/README.md
+++ b/deploy/gcp/phase1-cloud-run/README.md
@@ -7,9 +7,32 @@ moves in Phase 2.
 
 ## How it deploys
 
-Normally via GitHub Actions: **Actions → Deploy to GCP → Run workflow** with
-`deploy_backend = true`. The workflow builds the image, pushes it to Artifact
-Registry, and runs `gcloud run deploy` with `env.production.yaml` + Secret Manager.
+The build/push/deploy is a **Cloud Build pipeline** (`deploy/gcp/cloudbuild.yaml`):
+it builds `backend/Dockerfile`, pushes to Artifact Registry, and runs
+`gcloud run deploy` with `env.production.yaml` + Secret Manager. Three ways to run it:
+
+1. **GitHub Actions (recommended):** **Actions → Deploy to GCP → Run workflow**
+   with `deploy_backend = true`. The job authenticates keylessly via WIF and
+   calls `gcloud builds submit --config deploy/gcp/cloudbuild.yaml` — the heavy
+   image build runs on Cloud Build, not the runner.
+2. **Auto-deploy on merge (opt-in):** set the repo Actions Variable
+   `GCP_AUTO_DEPLOY=true`. Then a push to `main` touching `backend/**` or
+   `deploy/gcp/**` deploys the backend automatically. Leave it unset for
+   manual-only (a push still triggers the workflow but the deploy job is skipped).
+3. **Native Cloud Build trigger (alternative):**
+   `create-cloud-build-trigger.sh` wires Cloud Build to watch GitHub directly
+   (needs a one-time console repo connection). Use this OR the Actions path.
+
+IAM for the Cloud Build service account is granted by
+`deploy/gcp/phase0-foundation/25-cloud-build-iam.sh`.
+
+### Manual submit (no CI)
+
+```bash
+gcloud builds submit --project="$GCP_PROJECT_ID" --region="$GCP_REGION" \
+  --config=deploy/gcp/cloudbuild.yaml \
+  --substitutions="SHORT_SHA=manual,_REGION=$GCP_REGION" .
+```
 
 ## Why it works unchanged on Cloud Run
 

--- a/deploy/gcp/phase1-cloud-run/create-cloud-build-trigger.sh
+++ b/deploy/gcp/phase1-cloud-run/create-cloud-build-trigger.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Phase 1 (optional) — create a NATIVE Cloud Build trigger that watches GitHub
+# directly, instead of driving Cloud Build from GitHub Actions.
+#
+# Use this only if you prefer Cloud Build to own CI/CD end-to-end. The GitHub
+# Actions path (.github/workflows/deploy-gcp.yml) needs none of this — pick one.
+#
+# ⚠️  ONE-TIME MANUAL STEP FIRST: connect the repo to Cloud Build. The 2nd-gen
+#     GitHub connection uses OAuth and cannot be fully scripted headlessly:
+#       Console → Cloud Build → Repositories → 2nd gen → "Create host connection"
+#       (installs the Cloud Build GitHub App), then "Link repository".
+#     Then set CB_CONNECTION and CB_REMOTE_REPO below (or export them) and run.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_cmd gcloud
+require_config GITHUB_REPO GCP_REGION
+
+# The 2nd-gen connection name and linked-repo resource created in the console step.
+CB_CONNECTION="${CB_CONNECTION:-github}"
+CB_REMOTE_REPO="${CB_REMOTE_REPO:-wolf-goat-pig}"
+TRIGGER_NAME="${TRIGGER_NAME:-wgp-backend-main}"
+
+REPO_RESOURCE="projects/${GCP_PROJECT_ID}/locations/${GCP_REGION}/connections/${CB_CONNECTION}/repositories/${CB_REMOTE_REPO}"
+
+log "Creating Cloud Build trigger '${TRIGGER_NAME}' on push to main (${GITHUB_REPO})…"
+warn "This deploys on every matching push to main. Comment out / delete the"
+warn "trigger if you want manual-only deploys."
+
+gc builds triggers create github \
+  --name="${TRIGGER_NAME}" \
+  --region="${GCP_REGION}" \
+  --repository="${REPO_RESOURCE}" \
+  --branch-pattern='^main$' \
+  --included-files='backend/**;deploy/gcp/**' \
+  --build-config='deploy/gcp/cloudbuild.yaml' \
+  --substitutions="_REGION=${GCP_REGION}"
+
+ok "Trigger created. It uses deploy/gcp/cloudbuild.yaml; \$SHORT_SHA is supplied"
+ok "automatically by the trigger. Manage it under Cloud Build → Triggers."


### PR DESCRIPTION
## Summary

Follow-up to the GCP migration scaffolding (#328). Makes **Cloud Build** the build/deploy engine for the backend and wires it to GitHub keylessly (reusing the Workload Identity Federation from #328). Still scaffolding — nothing is applied to the live project, and it can't surprise-deploy.

## What's included

**Cloud Build pipeline** — `deploy/gcp/cloudbuild.yaml`
- Build `backend/Dockerfile` → push to Artifact Registry → deploy to Cloud Run, with the same `env.production.yaml` + Secret Manager wiring as before. Uses a bigger machine (`E2_HIGHCPU_8`) and 30-min timeout because the image bundles OpenCV/numpy/Pillow + a Playwright Chromium shell. Logs to Cloud Logging (no legacy GCS bucket).

**GitHub Actions → Cloud Build** — `.github/workflows/deploy-gcp.yml`
- Backend job now runs `gcloud builds submit --config deploy/gcp/cloudbuild.yaml`, so the heavy build runs on Cloud Build rather than the runner. Auth stays keyless via WIF.
- **Opt-in auto-deploy on merge:** a `push` to `main` touching `backend/**` or `deploy/gcp/**` deploys the backend **only if** the repo variable `GCP_AUTO_DEPLOY == 'true'`. Unset (default) = the run starts but the deploy job is skipped — no surprise deploys. Frontend (Firebase Hosting) stays manual-only.

**IAM + API** — `phase0-foundation/`
- New `25-cloud-build-iam.sh` grants the Cloud Build service account (handles both the legacy `@cloudbuild` and newer `-compute@developer` default SAs) the deploy roles: `run.admin`, `artifactregistry.writer`, `iam.serviceAccountUser`, `secretmanager.viewer`, `logging.logWriter`.
- Enable `cloudbuild.googleapis.com`; add `cloudbuild.builds.editor` to the deployer SA.

**Native trigger (optional alternative)** — `phase1-cloud-run/create-cloud-build-trigger.sh`
- Wires Cloud Build to watch GitHub directly (needs a one-time console repo connection), for teams that prefer Cloud Build to own CI/CD instead of Actions.

**`.gcloudignore`** — keeps `gcloud builds submit` source uploads lean (excludes node_modules, venv, build artifacts).

## Verification

- All shell scripts pass `bash -n`; `cloudbuild.yaml` and the updated workflow validate as YAML.
- No app/CI-behavior change: the workflow is still WIF-keyless, the new `push` trigger's deploy job is gated off by default, and no existing frontend/backend CI is touched.
- `SHORT_SHA` is passed explicitly on manual/Actions submits (`manual` / `${GITHUB_SHA::12}`) and provided automatically by native triggers.

## New repo variable (optional)

| Variable | Effect |
|---|---|
| `GCP_AUTO_DEPLOY=true` | Auto-deploy the backend on merge to `main`. Unset = manual-only. |

## Notes

- One-time `25-cloud-build-iam.sh` must run after `00-enable-apis.sh` (the Cloud Build SA doesn't exist until the API is enabled).
- Choose **one** of: GitHub Actions → Cloud Build (default) *or* the native trigger — not both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PECBxBQSJrbU9xeALaYqeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PECBxBQSJrbU9xeALaYqeN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Google Cloud Build support for building and deploying the backend to Cloud Run.
  * Added optional automatic backend deployment on pushes to `main`.
  * Added support for native Cloud Build triggers and manual build submissions.
  * Added deployment configuration for Artifact Registry, scaling, resources, secrets, and runtime settings.

* **Documentation**
  * Updated GCP deployment guides with setup steps, deployment modes, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->