### PR TITLE
fix(stats): make quarters the only club standing metric

### DIFF
--- a/backend/app/routers/commissioner.py
+++ b/backend/app/routers/commissioner.py
@@ -228,9 +228,9 @@ DATA_SCHEMA = """
 - `player_statistics` / `game_records` / `game_player_results` cover ONLY games
   scored live inside this app (a small subset). Never use them for the club
   season leaderboard — they will look empty or absurdly thin.
-- Club currency is quarters (`score` / SUM(score)), not "wins". A positive
-  score for a round is a winning round; win rate ≈
-  COUNT(*) FILTER (WHERE score > 0) / COUNT(*).
+- Club standings are determined ONLY by total quarters (`SUM(score)`).
+  Do not calculate, rank by, or narrate wins, win percentage, or winning
+  rounds. Round count may be shown only as supporting sample-size context.
 
 ### legacy_rounds_official
 Columns: id, date, "group", member, score, location, duration, source, synced_at
@@ -497,12 +497,14 @@ Default to `legacy_rounds_official` for ANY season / leaderboard / standings /
 "who's ahead" / rounds-played / historical-performance question. Only use
 `player_statistics` when the question explicitly asks about in-app live games,
 solo rates, streaks, or hole-by-hole app scoring.
+For club standings, total quarters is the only ranking metric. Do not select,
+calculate, or discuss wins or win percentage unless the user explicitly asks.
 
 If the question is purely about rules (not data), respond directly without SQL.
 If you're unsure which player is meant, use ILIKE with wildcards for fuzzy matching.
 
 Example queries:
-- "Who is leading / leaderboard / standings?" → SELECT member, SUM(score) AS total_quarters, COUNT(*) AS rounds, ROUND(SUM(score)::numeric / COUNT(*), 1) AS avg_quarters, COUNT(*) FILTER (WHERE score > 0) AS rounds_won FROM legacy_rounds_official GROUP BY member ORDER BY total_quarters DESC LIMIT 20
+- "Who is leading / leaderboard / standings?" → SELECT member, SUM(score) AS total_quarters, COUNT(*) AS rounds FROM legacy_rounds_official GROUP BY member ORDER BY total_quarters DESC LIMIT 20
 - "Who has the most quarters?" → SELECT member, SUM(score) as total_quarters FROM legacy_rounds_official GROUP BY member ORDER BY total_quarters DESC LIMIT 10
 - "Stuart's handicap history" → SELECT effective_date, handicap_index FROM ghin_handicap_history gh JOIN player_profiles pp ON gh.player_profile_id = pp.id WHERE pp.name ILIKE '%Stuart%' ORDER BY effective_date
 - "How many rounds per player?" → SELECT member, COUNT(*) as rounds FROM legacy_rounds_official GROUP BY member ORDER BY rounds DESC
@@ -556,7 +558,10 @@ Example queries:
         "You are Commissioner Hover Over — the all-knowing statistician and "
         "historian of Wolf Goat Pig. Narrate the following query results in "
         "your voice: authoritative, colorful golf commentary, using specific "
-        "numbers from the data. Keep it concise but entertaining."
+        "numbers from the data. Keep it concise but entertaining. For club "
+        "standings, total quarters is the only meaningful outcome: never "
+        "invent or emphasize wins, win percentage, or placement based on "
+        "anything other than total quarters. Round count is context only."
     )
 
     narration_prompt = (

--- a/backend/app/routers/member_rounds.py
+++ b/backend/app/routers/member_rounds.py
@@ -77,7 +77,6 @@ def _history_from_rounds(member: str, rounds: list[Any], *, recent_limit: int = 
             "found": False,
             "member": member,
             "rounds_played": 0,
-            "games_won": 0,
             "total_quarters": 0,
             "average_per_round": 0.0,
             "best_round": None,
@@ -87,7 +86,6 @@ def _history_from_rounds(member: str, rounds: list[Any], *, recent_limit: int = 
 
     total_quarters = sum(r.score for r in rounds)
     round_count = len(rounds)
-    games_won = sum(1 for r in rounds if r.score > 0)
     best = max(r.score for r in rounds)
     worst = min(r.score for r in rounds)
     recent = [
@@ -106,7 +104,6 @@ def _history_from_rounds(member: str, rounds: list[Any], *, recent_limit: int = 
         "found": True,
         "member": rounds[0].member,
         "rounds_played": round_count,
-        "games_won": games_won,
         "total_quarters": total_quarters,
         "average_per_round": round(total_quarters / round_count, 1) if round_count else 0.0,
         "best_round": best,

--- a/backend/app/routers/sheet_integration.py
+++ b/backend/app/routers/sheet_integration.py
@@ -475,17 +475,12 @@ async def sync_wgp_sheet_data(
                 player_stats_record.games_played = rounds_played
                 player_stats_record.total_earnings = total_earnings
 
-                # Calculate win percentage based on average earnings per game
-                if rounds_played > 0 and avg_earnings > 0:
-                    # If average is positive, estimate wins based on that
-                    # Assuming positive average means winning more often
-                    estimated_win_rate = safe_float((avg_earnings + 50) / 100 * 50, 0.0, min_val=0.0, max_val=100.0)
-                    estimated_wins = safe_int(rounds_played * estimated_win_rate / 100, 0, min_val=0)
-                    player_stats_record.win_percentage = estimated_win_rate
-                    player_stats_record.games_won = estimated_wins
-                else:
-                    player_stats_record.win_percentage = 0.0
-                    player_stats_record.games_won = 0
+                # The sheet records quarters per round, not wins. Zero these
+                # rather than deriving them from earnings — a guessed win count
+                # is indistinguishable from a real one once it's in the table,
+                # and quarters are the club's only standing metric anyway.
+                player_stats_record.win_percentage = 0.0
+                player_stats_record.games_won = 0
 
                 # Store additional metrics
                 player_stats_record.avg_earnings_per_game = avg_earnings

--- a/backend/app/services/leaderboard_service.py
+++ b/backend/app/services/leaderboard_service.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import HTTPException
-from sqlalchemy import Float, and_, case, cast, desc, func
+from sqlalchemy import and_, desc, func
 from sqlalchemy.orm import Session
 
 from ..models import GamePlayerResult, PlayerAchievement, PlayerBadgeEarned, PlayerProfile, PlayerStatistics
@@ -120,7 +120,6 @@ class LeaderboardService:
     # Supported leaderboard types
     LEADERBOARD_TYPES = [
         "total_earnings",
-        "win_rate",
         "games_played",
         "average_score",
         "partnerships_won",
@@ -145,7 +144,7 @@ class LeaderboardService:
         Get leaderboard by type.
 
         Args:
-            leaderboard_type: Type of leaderboard (total_earnings, win_rate, etc.)
+            leaderboard_type: Type of leaderboard (total_earnings, games_played, etc.)
             db: Database session
             limit: Maximum number of entries to return
             offset: Number of entries to skip (for pagination)
@@ -391,7 +390,6 @@ class LeaderboardService:
         # Map leaderboard type to query method
         query_methods = {
             "total_earnings": self._query_total_earnings,
-            "win_rate": self._query_win_rate,
             "games_played": self._query_games_played,
             "average_score": self._query_average_score,
             "partnerships_won": self._query_partnerships_won,
@@ -439,7 +437,6 @@ class LeaderboardService:
                 PlayerProfile.name.label("player_name"),
                 func.sum(GamePlayerResult.total_earnings).label("total_earnings"),
                 func.count(GamePlayerResult.id).label("games_played"),
-                func.sum(case((GamePlayerResult.final_position == 1, 1), else_=0)).label("wins"),
                 func.sum(GamePlayerResult.partnerships_won).label("partnerships_won"),
                 func.avg(GamePlayerResult.final_position).label("avg_position"),
             )
@@ -458,16 +455,6 @@ class LeaderboardService:
         # Apply ordering based on leaderboard type
         if leaderboard_type == "total_earnings":
             results_query = results_query.order_by(desc("total_earnings"))
-        elif leaderboard_type == "win_rate":
-            results_query = results_query.order_by(
-                desc(
-                    cast(
-                        func.sum(case((GamePlayerResult.final_position == 1, 1), else_=0)),
-                        Float,
-                    )
-                    / cast(func.count(GamePlayerResult.id), Float)
-                )
-            )
         elif leaderboard_type == "games_played":
             results_query = results_query.order_by(desc("games_played"))
         elif leaderboard_type == "partnerships_won":
@@ -484,14 +471,10 @@ class LeaderboardService:
         leaderboard = []
         for rank, result in enumerate(results, start=1):
             games_played = result.games_played or 1
-            wins = result.wins or 0
-            win_rate = (wins / games_played) * 100 if games_played > 0 else 0.0
 
             # Determine value based on leaderboard type
             if leaderboard_type == "total_earnings":
                 value = float(result.total_earnings or 0)
-            elif leaderboard_type == "win_rate":
-                value = round(win_rate, 1)
             elif leaderboard_type == "games_played":
                 value = int(games_played)
             elif leaderboard_type == "partnerships_won":
@@ -539,44 +522,6 @@ class LeaderboardService:
                     "player_id": result.id,
                     "player_name": result.name,
                     "value": round(float(result.total_earnings), 2),
-                }
-            )
-
-        return leaderboard
-
-    def _query_win_rate(self, db: Session, limit: int, offset: int) -> list[dict[str, Any]]:
-        """Query win rate leaderboard."""
-        query = (
-            db.query(
-                PlayerProfile.id,
-                PlayerProfile.name,
-                PlayerStatistics.games_played,
-                PlayerStatistics.games_won,
-            )
-            .join(PlayerStatistics, PlayerProfile.id == PlayerStatistics.player_id)
-            .filter(
-                and_(
-                    PlayerProfile.is_active == 1,
-                    PlayerProfile.is_ai == 0,
-                    PlayerStatistics.games_played >= 5,  # Minimum games for win rate
-                )
-            )
-            .order_by(desc(cast(PlayerStatistics.games_won, Float) / cast(PlayerStatistics.games_played, Float)))
-            .limit(limit)
-            .offset(offset)
-        )
-
-        results = query.all()
-
-        leaderboard = []
-        for rank, result in enumerate(results, start=offset + 1):
-            win_rate = (result.games_won / result.games_played) * 100
-            leaderboard.append(
-                {
-                    "rank": rank,
-                    "player_id": result.id,
-                    "player_name": result.name,
-                    "value": round(win_rate, 1),
                 }
             )
 

--- a/backend/tests/unit/routers/test_commissioner_router.py
+++ b/backend/tests/unit/routers/test_commissioner_router.py
@@ -260,6 +260,8 @@ class TestDataSchemaGuidance:
         assert "In-app WGP game aggregates ONLY" in DATA_SCHEMA
         assert "Never use them for the club" in DATA_SCHEMA
         assert "season leaderboard" in DATA_SCHEMA
+        assert "determined ONLY by total quarters" in DATA_SCHEMA
+        assert "Do not calculate, rank by, or narrate wins" in DATA_SCHEMA
 
     def test_data_chat_system_prompt_includes_season_context_and_guidance(self):
         """Leaderboard questions must see season standings + table-selection rules."""
@@ -292,3 +294,5 @@ class TestDataSchemaGuidance:
         assert "Steve Sutorius" in system
         assert "Default to `legacy_rounds_official`" in system
         assert "Who is leading / leaderboard / standings?" in system
+        assert "total quarters is the only ranking metric" in system
+        assert "win percentage" in system

--- a/backend/tests/unit/routers/test_member_rounds_router.py
+++ b/backend/tests/unit/routers/test_member_rounds_router.py
@@ -438,7 +438,7 @@ def test_history_aggregates_club_rounds(client, monkeypatch):
     data = resp.json()
     assert data["found"] is True
     assert data["rounds_played"] == 3
-    assert data["games_won"] == 2
+    assert "games_won" not in data
     assert data["total_quarters"] == -58 + 80 + 153
     assert data["average_per_round"] == round((-58 + 80 + 153) / 3, 1)
     assert data["best_round"] == 153

--- a/backend/tests/unit/services/test_leaderboard_service.py
+++ b/backend/tests/unit/services/test_leaderboard_service.py
@@ -142,7 +142,6 @@ class TestLeaderboardService:
 
         expected_types = [
             "total_earnings",
-            "win_rate",
             "games_played",
             "average_score",
             "partnerships_won",
@@ -173,17 +172,14 @@ class TestLeaderboardService:
         # Highest earner should be first
         assert leaderboard[0]["value"] >= leaderboard[1]["value"]
 
-    def test_get_win_rate_leaderboard(self, db, test_players):
-        """Test getting win rate leaderboard."""
+    def test_win_rate_is_not_a_supported_leaderboard(self, db):
+        """Quarters are the club's only standing metric — win rate was removed."""
         service = LeaderboardService(db)
 
-        leaderboard = service.get_leaderboard("win_rate", db, limit=5)
-
-        # Win rate leaderboard requires minimum games
-        for entry in leaderboard:
-            assert "value" in entry
-            assert entry["value"] >= 0
-            assert entry["value"] <= 100
+        assert "win_rate" not in service.LEADERBOARD_TYPES
+        with pytest.raises(HTTPException) as exc_info:
+            service.get_leaderboard("win_rate", db, limit=5)
+        assert exc_info.value.status_code == 400
 
     def test_get_games_played_leaderboard(self, db, test_players):
         """Test getting games played leaderboard."""
@@ -262,8 +258,8 @@ class TestLeaderboardService:
 
         assert isinstance(all_boards, dict)
         assert "total_earnings" in all_boards
-        assert "win_rate" in all_boards
         assert "games_played" in all_boards
+        assert "win_rate" not in all_boards
 
     def test_refresh_leaderboard_cache(self, db):
         """Test refreshing the leaderboard cache."""

--- a/frontend/src/components/analytics/WGPAnalyticsDashboard.jsx
+++ b/frontend/src/components/analytics/WGPAnalyticsDashboard.jsx
@@ -149,8 +149,6 @@ const WGPAnalyticsDashboard = () => {
         .map(player => ({
           player_name: player.player_name || player.name,
           games_played: player.games_played || 0,
-          games_won: player.games_won || 0,
-          win_rate: player.win_percentage ? player.win_percentage / 100 : 0,
           total_earnings: player.total_earnings || 0,
           avg_earnings_per_game: player.avg_earnings || 0,
           best_finish: player.best_finish || 99,

--- a/frontend/src/components/integration/SheetIntegrationDashboard.jsx
+++ b/frontend/src/components/integration/SheetIntegrationDashboard.jsx
@@ -14,6 +14,14 @@ import { getStoredUserEmail } from '../../utils/adminAuth';
  * - Comparison reports
  * - Direct Google Sheets URL sync
  */
+
+// Quarters are signed wager deltas, so the sign carries the meaning and has to
+// stay visible even when the value is positive.
+const formatQuarters = (value, decimals = 0) => {
+    const n = Number(value) || 0;
+    return `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}`;
+};
+
 const SheetIntegrationDashboard = () => {
     const API_URL = apiConfig.baseUrl;
 
@@ -303,13 +311,13 @@ const SheetIntegrationDashboard = () => {
                             Player
                         </th>
                         <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                            Games Played
+                            Rounds Played
                         </th>
                         <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                            Win Rate
+                            Quarters
                         </th>
                         <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                            Total Earnings
+                            Avg Quarters
                         </th>
                     </tr>
                 </thead>
@@ -326,10 +334,13 @@ const SheetIntegrationDashboard = () => {
                                 {player.games_played || 0}
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                {player.win_rate ? `${(player.win_rate * 100).toFixed(1)}%` : '0%'}
+                                {formatQuarters(player.total_earnings)}
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                ${player.total_earnings ? player.total_earnings.toFixed(2) : '0.00'}
+                                {formatQuarters(
+                                    player.games_played ? (player.total_earnings || 0) / player.games_played : 0,
+                                    1,
+                                )}
                             </td>
                         </tr>
                     ))}

--- a/frontend/src/pages/AccountPage.jsx
+++ b/frontend/src/pages/AccountPage.jsx
@@ -34,7 +34,6 @@ const saveSettings = (settings) => {
 const gatherStats = () => {
   const stats = {
     gamesPlayed: 0,
-    gamesWon: 0,
     totalEarnings: 0,
     averageScore: 0,
     bestScore: null,
@@ -56,7 +55,6 @@ const gatherStats = () => {
         const data = JSON.parse(localStorage.getItem(key));
         if (data) {
           stats.gamesPlayed++;
-          if (data.won || data.position === 1) stats.gamesWon++;
           if (typeof data.earnings === 'number') stats.totalEarnings += data.earnings;
           if (typeof data.totalScore === 'number') {
             totalScores += data.totalScore;
@@ -122,7 +120,6 @@ export const mapClubHistoryToStats = (history) => {
 
   return {
     gamesPlayed: history.rounds_played,
-    gamesWon: history.games_won ?? 0,
     totalEarnings: history.total_quarters ?? 0,
     averageScore: history.average_per_round ?? 0,
     bestScore: history.best_round ?? null,
@@ -385,11 +382,7 @@ function AccountPage() {
             }}>
               <div style={statBoxStyle}>
                 <div style={statValueStyle}>{stats.gamesPlayed}</div>
-                <div style={statLabelStyle}>Games Played</div>
-              </div>
-              <div style={statBoxStyle}>
-                <div style={statValueStyle}>{stats.gamesWon}</div>
-                <div style={statLabelStyle}>Wins</div>
+                <div style={statLabelStyle}>Rounds Played</div>
               </div>
               <div style={statBoxStyle}>
                 <div style={{
@@ -428,14 +421,6 @@ function AccountPage() {
                     {stats.bestScore >= 0 ? '+' : ''}{stats.bestScore}
                   </div>
                   <div style={statLabelStyle}>Best Round</div>
-                </div>
-              )}
-              {stats.gamesPlayed > 0 && (
-                <div style={statBoxStyle}>
-                  <div style={statValueStyle}>
-                    {stats.gamesPlayed > 0 ? Math.round((stats.gamesWon / stats.gamesPlayed) * 100) : 0}%
-                  </div>
-                  <div style={statLabelStyle}>Win Rate</div>
                 </div>
               )}
             </div>

--- a/frontend/src/pages/PlayerProfilePage.jsx
+++ b/frontend/src/pages/PlayerProfilePage.jsx
@@ -164,7 +164,7 @@ const PlayerProfilePage = () => {
     );
   }
 
-  const { name, handicap, handicap_source, ghin_last_updated, description, avatar_url, has_avatar_image, last_played, created_at, available_days, game_history, badges, total_badges, stats } = profile;
+  const { name, handicap, handicap_source, ghin_last_updated, description, avatar_url, has_avatar_image, last_played, created_at, available_days, game_history, badges, total_badges } = profile;
   const handicapPending = isPendingHandicap(handicap_source) || handicap == null;
   const ghinFreshness = handicap_source === 'ghin' ? formatGhinFreshness(ghin_last_updated) : null;
   const avatarSrc = has_avatar_image
@@ -179,6 +179,12 @@ const PlayerProfilePage = () => {
   const lockedSlots = Math.min(remainingBadges, LOCKED_PREVIEW_COUNT);
 
   const roundsWithoutDetail = game_history.filter(g => !g.holes || g.holes.length === 0).length;
+
+  // Quarters are the club's only standing metric, and `game_history` (sheet +
+  // attested + in-app) is the complete record — the player_statistics table
+  // only covers rounds scored live in the app.
+  const totalQuarters = game_history.reduce((sum, g) => sum + (g.score || 0), 0);
+  const avgQuarters = game_history.length ? totalQuarters / game_history.length : 0;
 
   return (
     <div className="wgp-clubhouse wgp-profile">
@@ -245,9 +251,9 @@ const PlayerProfilePage = () => {
 
           <div className="wgp-profile__scoreboard">
             {[
-              { label: 'Games', value: stats.games_played },
-              { label: 'Wins', value: stats.games_won },
-              { label: 'Earnings', value: `${stats.total_earnings >= 0 ? '+' : ''}${stats.total_earnings.toFixed(0)}¢` },
+              { label: 'Rounds', value: game_history.length },
+              { label: 'Quarters', value: formatScore(totalQuarters) },
+              { label: 'Avg Quarters', value: formatScore(Number(avgQuarters.toFixed(1))) },
             ].map(({ label, value }) => (
               <div key={label} className="wgp-profile__stat">
                 <div className="wgp-profile__stat-value">{value}</div>

--- a/frontend/src/pages/__tests__/AccountPage.stats.test.js
+++ b/frontend/src/pages/__tests__/AccountPage.stats.test.js
@@ -16,7 +16,6 @@ describe('mapClubHistoryToStats', () => {
       mapClubHistoryToStats({
         found: true,
         rounds_played: 61,
-        games_won: 20,
         total_quarters: -3372,
         average_per_round: -55.3,
         best_round: 716,
@@ -31,7 +30,6 @@ describe('mapClubHistoryToStats', () => {
       }),
     ).toEqual({
       gamesPlayed: 61,
-      gamesWon: 20,
       totalEarnings: -3372,
       averageScore: -55.3,
       bestScore: 716,
@@ -59,7 +57,6 @@ describe('fetchClubHistory', () => {
       json: async () => ({
         found: true,
         rounds_played: 2,
-        games_won: 1,
         total_quarters: 10,
         average_per_round: 5,
         best_round: 12,

--- a/frontend/src/pages/__tests__/PlayerProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/PlayerProfilePage.test.jsx
@@ -72,6 +72,18 @@ describe('PlayerProfilePage game history', () => {
     expect(screen.getByText('-2')).toBeInTheDocument();
   });
 
+  test('scoreboard totals quarters from the full round history, not in-app wins', async () => {
+    mockUsePlayerProfile.mockReturnValue({ profile: { id: 999 } });
+    renderPage();
+
+    expect(await screen.findByText('Quarters')).toBeInTheDocument();
+    expect(screen.getByText('Avg Quarters')).toBeInTheDocument();
+    expect(screen.queryByText('Wins')).toBeNull();
+
+    const scoreboard = [...document.querySelectorAll('.wgp-profile__stat')].map(el => el.textContent);
+    expect(scoreboard).toEqual(['2Rounds', '+2Quarters', '+1Avg Quarters']);
+  });
+
   test('shows empty state when no rounds recorded', async () => {
     mockUsePlayerProfile.mockReturnValue({ profile: { id: 999 } });
     global.fetch = vi.fn(async (url) => {
@@ -108,11 +120,12 @@ describe('PlayerProfilePage game history', () => {
     renderPage();
 
     expect(await screen.findByText('▾ hole-by-hole')).toBeInTheDocument();
-    expect(screen.queryByText('+2')).toBeNull(); // collapsed by default
+    const holeQuarters = () =>
+      [...document.querySelectorAll('.wgp-profile__hole-quarters')].map(el => el.textContent);
+    expect(holeQuarters()).toEqual([]); // collapsed by default
 
     fireEvent.click(screen.getByText('▾ hole-by-hole'));
-    expect(screen.getByText('+2')).toBeInTheDocument();
-    expect(screen.getByText('-1')).toBeInTheDocument();
+    expect(holeQuarters()).toEqual(['+2', '-1']);
 
     expect(screen.getByText(/Score live in the app or scan your scorecard/)).toBeInTheDocument();
     expect(screen.getByText(/1 of 2 rounds already have it/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Drop wins/win-rate from Account, public profiles, Commissioner guidance, sheet sync, and leaderboard types so club standings rank by total quarters only.
- Stop inventing `games_won` / `win_percentage` during sheet sync; zero those fields instead of estimating them from average earnings.
- Surface Rounds / Quarters / Avg Quarters on public profiles from full club history (`game_history`), not the sparse in-app `player_statistics` table.

## Test plan
- [x] Backend: `ruff check` + `ruff format --check` + full `pytest` (1617 passed)
- [x] Frontend: `npm run typecheck` + full vitest (583 passed) + `npm run build`
- [ ] Spot-check Account stats panel: no Wins / Win Rate tiles; quarters labels present
- [ ] Spot-check a public player profile: scoreboard shows Rounds / Quarters / Avg Quarters from sheet history
- [ ] Ask Commissioner for the leaderboard: answer should cite quarters, not wins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player profiles now highlight rounds played, total quarters, and average quarters.
  * Sheet integration previews display quarter-based metrics with signed formatting.
* **Updates**
  * Personal stats no longer include wins or win rate.
  * Club standings and leaderboards now rank exclusively by total quarters.
  * Win-rate leaderboards are no longer available.
  * Analytics and history views no longer display win-related metrics.
* **Bug Fixes**
  * Prevented unreliable win and win-percentage calculations from being inferred from quarter data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->