### PR TITLE
feat(booking): Gemini Computer Use agent on Cloud Run

### DIFF
--- a/backend/app/routers/foretees.py
+++ b/backend/app/routers/foretees.py
@@ -264,6 +264,10 @@ async def book_tee_time(
             message=result["messages"][0] if result.get("messages") else "Booking confirmed",
         )
 
+    # Computer Use agent paused for SPA confirmation (login / submit / safety).
+    if result.get("status") == "needs_confirmation":
+        return ApiResponse.success(data=result, message=result.get("explanation") or "Confirmation required")
+
     # If there's debug info from a form parse failure, return it directly
     if result.get("debug"):
         return ApiResponse.success(data=result, message=result.get("message", "Booking failed"))
@@ -276,6 +280,42 @@ async def book_tee_time(
         if msg and msg != result.get("title"):
             parts.append(msg)
     error_msg = result.get("message") or result.get("error") or ". ".join(parts) or "Booking failed"
+    raise ValueError(error_msg)
+
+
+class ConfirmBookingJobRequest(BaseModel):
+    job_id: str
+    confirm: bool = True
+
+
+@router.post("/book/confirm")
+@handle_api_errors(operation_name="confirm booking step")
+async def confirm_booking_step(
+    request: ConfirmBookingJobRequest,
+    current_user: models.PlayerProfile = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Resume a paused Computer Use book/cancel job after user confirmation."""
+    service = _get_user_service(current_user)
+    if not service.config.enabled:
+        raise ValueError("ForeTees integration is disabled")
+
+    try:
+        result = await service.confirm_booking_job(request.job_id, request.confirm)
+    finally:
+        if service is not get_foretees_service():
+            await service.close()
+
+    if result.get("status") == "needs_confirmation":
+        return ApiResponse.success(
+            data=result,
+            message=result.get("explanation") or "Confirmation required",
+        )
+    if result.get("success"):
+        return ApiResponse.success(
+            data=result,
+            message=result["messages"][0] if result.get("messages") else "Booking step completed",
+        )
+    error_msg = result.get("message") or result.get("error") or "Booking confirmation failed"
     raise ValueError(error_msg)
 
 
@@ -305,6 +345,9 @@ async def cancel_tee_time(
             data=result,
             message=result["messages"][0] if result.get("messages") else "Tee time cancelled",
         )
+
+    if result.get("status") == "needs_confirmation":
+        return ApiResponse.success(data=result, message=result.get("explanation") or "Confirmation required")
 
     parts = []
     if result.get("title"):

--- a/backend/app/services/foretees_service.py
+++ b/backend/app/services/foretees_service.py
@@ -411,75 +411,22 @@ class ForeteesService:
                 "message": "ForeTees credentials not configured — please add them in Account settings",
             }
 
-        booking_url = os.getenv("BOOKING_SERVICE_URL", "http://localhost:3001")
-        booking_secret = os.getenv("BOOKING_SERVICE_SECRET", "")
-
-        headers = {"Content-Type": "application/json"}
-        if booking_secret:
-            headers["Authorization"] = f"Bearer {booking_secret}"
-
-        payload = {
-            "username": self.config.username,
-            "password": self.config.password,
-            "date": date,
-            "time": slot_time,
-            "ttdata": ttdata,
-        }
-
-        logger.info(
-            "Calling booking service: POST %s/cancel date=%s time=%s ttdata_set=%s username_set=%s",
-            booking_url,
-            date,
-            slot_time,
-            bool(ttdata),
-            bool(self.config.username),
+        return await self._call_booking_service(
+            "/cancel",
+            {
+                "username": self.config.username,
+                "password": self.config.password,
+                "date": date,
+                "time": slot_time,
+                "ttdata": ttdata,
+            },
+            action="cancel",
         )
-        try:
-            async with httpx.AsyncClient(timeout=120.0) as client:
-                # Wake up the booking service
-                try:
-                    await client.get(f"{booking_url}/health", timeout=60.0)
-                except Exception:
-                    logger.warning("Booking service health check failed, trying anyway")
-                resp = await client.post(
-                    f"{booking_url}/cancel",
-                    json=payload,
-                    headers=headers,
-                )
-                if resp.status_code == 401:
-                    return {"success": False, "message": "Booking service auth failed — check BOOKING_SERVICE_SECRET"}
-                if resp.status_code == 503:
-                    return {
-                        "success": False,
-                        "message": "Booking service is starting up — please wait 30 seconds and try again",
-                    }
-                ct = resp.headers.get("content-type", "")
-                if "json" not in ct:
-                    logger.warning("Cancel service returned non-JSON: %d %s %s", resp.status_code, ct, resp.text[:200])
-                    return {
-                        "success": False,
-                        "message": f"Booking service unavailable (HTTP {resp.status_code}). Try again in 30 seconds.",
-                    }
-                result = resp.json()
-                logger.info("Cancel result: success=%s, status=%d", result.get("success"), resp.status_code)
-                return result
-        except httpx.TimeoutException:
-            return {
-                "success": False,
-                "message": "Cancel timed out — the service may still be waking up. Wait 30 seconds and try again.",
-            }
-        except Exception as exc:
-            logger.error("Cancel service error: %s", exc)
-            return {"success": False, "message": f"Cancel error: {exc}"}
 
     async def _book_via_browser(
         self, date: str, slot_time: str, transport_mode: str, players: list[str] | None = None
     ) -> dict[str, Any]:
-        """Book a tee time via the headless browser microservice.
-
-        Calls the separate Node.js booking service which uses Playwright
-        to authenticate with ForeTees and submit the booking.
-        """
+        """Book a tee time via the Computer Use / Playwright booking agent."""
         if not self.config.username or not self.config.password:
             logger.error("Book: no ForeTees credentials configured (username_set=%s)", bool(self.config.username))
             return {
@@ -487,43 +434,49 @@ class ForeteesService:
                 "message": "ForeTees credentials not configured — please add them in Account settings",
             }
 
-        booking_url = os.getenv("BOOKING_SERVICE_URL", "http://localhost:3001")
-        booking_secret = os.getenv("BOOKING_SERVICE_SECRET", "")
+        return await self._call_booking_service(
+            "/book",
+            {
+                "username": self.config.username,
+                "password": self.config.password,
+                "date": date,
+                "time": slot_time,
+                "transport_mode": transport_mode,
+                "players": [p for p in (players or []) if p],
+            },
+            action="book",
+        )
 
+    async def confirm_booking_job(self, job_id: str, confirm: bool = True) -> dict[str, Any]:
+        """Resume a paused Computer Use booking/cancel job after SPA confirmation."""
+        return await self._call_booking_service(
+            f"/jobs/{job_id}/confirm",
+            {"confirm": confirm},
+            action="confirm",
+        )
+
+    async def _call_booking_service(self, path: str, payload: dict[str, Any], *, action: str) -> dict[str, Any]:
+        booking_url = os.getenv("BOOKING_SERVICE_URL", "http://localhost:8080")
+        booking_secret = os.getenv("BOOKING_SERVICE_SECRET", "")
         headers = {"Content-Type": "application/json"}
         if booking_secret:
             headers["Authorization"] = f"Bearer {booking_secret}"
 
-        payload = {
-            "username": self.config.username,
-            "password": self.config.password,
-            "date": date,
-            "time": slot_time,
-            "transport_mode": transport_mode,
-            "players": [p for p in (players or []) if p],
-        }
-
-        logger.info(
-            "Calling booking service: POST %s/book date=%s time=%s username_set=%s",
-            booking_url,
-            date,
-            slot_time,
-            bool(self.config.username),
-        )
+        # Computer Use loops can take several minutes across confirm pauses.
+        timeout = httpx.Timeout(300.0, connect=30.0)
+        logger.info("Calling booking service: POST %s%s action=%s", booking_url, path, action)
         try:
-            async with httpx.AsyncClient(timeout=120.0) as booking_client:
-                # Wake up the booking service (Render free tier sleeps after inactivity)
+            async with httpx.AsyncClient(timeout=timeout) as client:
                 try:
-                    await booking_client.get(f"{booking_url}/health", timeout=60.0)
+                    await client.get(f"{booking_url}/health", timeout=30.0)
                 except Exception:
                     logger.warning("Booking service health check failed, trying anyway")
-                resp = await booking_client.post(
-                    f"{booking_url}/book",
-                    json=payload,
-                    headers=headers,
-                )
+                resp = await client.post(f"{booking_url}{path}", json=payload, headers=headers)
                 if resp.status_code == 401:
-                    return {"success": False, "message": "Booking service auth failed — check BOOKING_SERVICE_SECRET"}
+                    return {
+                        "success": False,
+                        "message": "Booking service auth failed — check BOOKING_SERVICE_SECRET",
+                    }
                 if resp.status_code == 503:
                     return {
                         "success": False,
@@ -531,28 +484,33 @@ class ForeteesService:
                     }
                 ct = resp.headers.get("content-type", "")
                 if "json" not in ct:
-                    logger.warning("Booking service returned non-JSON: %d %s %s", resp.status_code, ct, resp.text[:200])
+                    logger.warning(
+                        "Booking service returned non-JSON: %d %s %s",
+                        resp.status_code,
+                        ct,
+                        resp.text[:200],
+                    )
                     return {
                         "success": False,
-                        "message": f"Booking service unavailable (HTTP {resp.status_code}). Try again in 30 seconds.",
+                        "message": f"Booking service unavailable (HTTP {resp.status_code}). Try again shortly.",
                     }
                 result = resp.json()
                 logger.info(
-                    "Booking service result: success=%s, status=%d, error=%s, messages=%s",
+                    "Booking service %s: status=%s success=%s job=%s",
+                    action,
+                    result.get("status"),
                     result.get("success"),
-                    resp.status_code,
-                    result.get("error"),
-                    result.get("messages"),
+                    result.get("job_id"),
                 )
                 return result
         except httpx.TimeoutException:
-            logger.error("Booking service timed out")
+            logger.error("Booking service timed out action=%s", action)
             return {
                 "success": False,
-                "message": "Booking timed out — the service may still be waking up. Wait 30 seconds and try again.",
+                "message": f"{action.capitalize()} timed out — wait a moment and try again.",
             }
         except Exception as exc:
-            logger.error("Booking service error: %s", exc)
+            logger.error("Booking service error action=%s: %s", action, exc)
             return {"success": False, "message": f"Booking service error: {exc}"}
 
     async def close(self) -> None:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -211,7 +211,7 @@
       "Body_import_course_from_file_courses_import_file_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -225,7 +225,7 @@
       "Body_scan_scorecard_photo_scorecard_scan_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           },
@@ -250,7 +250,7 @@
       "Body_upload_gmail_credentials_admin_upload_credentials_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -264,7 +264,7 @@
       "Body_upload_my_avatar_players_me_avatar_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -399,6 +399,24 @@
           "sheet_data"
         ],
         "title": "CompareSheetRequest",
+        "type": "object"
+      },
+      "ConfirmBookingJobRequest": {
+        "properties": {
+          "confirm": {
+            "default": true,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id"
+        ],
+        "title": "ConfirmBookingJobRequest",
         "type": "object"
       },
       "CourseCreate": {
@@ -3795,13 +3813,6 @@
       },
       "ValidationError": {
         "properties": {
-          "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "input": {
-            "title": "Input"
-          },
           "loc": {
             "items": {
               "anyOf": [
@@ -6570,6 +6581,55 @@
           }
         ],
         "summary": "Book Tee Time",
+        "tags": [
+          "foretees"
+        ]
+      }
+    },
+    "/api/foretees/book/confirm": {
+      "post": {
+        "description": "Resume a paused Computer Use book/cancel job after user confirmation.",
+        "operationId": "confirm_booking_step_api_foretees_book_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmBookingJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Confirm Booking Step Api Foretees Book Confirm Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Confirm Booking Step",
         "tags": [
           "foretees"
         ]

--- a/booking-agent/.gitignore
+++ b/booking-agent/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.env
+.pytest_cache/

--- a/booking-agent/Dockerfile
+++ b/booking-agent/Dockerfile
@@ -1,0 +1,27 @@
+# ForeTees Computer Use booking agent (Chromium + Vertex Gemini).
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+    PORT=8080
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && playwright install --with-deps --only-shell chromium
+
+COPY app ./app
+
+RUN useradd -r -u 1001 -m agent \
+    && mkdir -p /opt/pw-browsers \
+    && chown -R agent:agent /app /opt/pw-browsers
+USER agent
+
+EXPOSE 8080
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--timeout-keep-alive", "75"]

--- a/booking-agent/README.md
+++ b/booking-agent/README.md
@@ -1,0 +1,27 @@
+# ForeTees booking agent (Gemini Computer Use)
+
+Python FastAPI service that books/cancels Wingpoint ForeTees tee times using
+Vertex Gemini Computer Use + local Playwright Chromium.
+
+See [`docs/architecture/COMPUTER_USE_BOOKING.md`](../docs/architecture/COMPUTER_USE_BOOKING.md)
+and [`deploy/gcp/phase7-booking/README.md`](../deploy/gcp/phase7-booking/README.md).
+
+## Local run
+
+```bash
+cd booking-agent
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+playwright install chromium
+export GCP_PROJECT_ID=seventh-country-232522
+export BOOKING_SERVICE_SECRET=dev-secret
+# ADC: gcloud auth application-default login
+uvicorn app.main:app --reload --port 8080
+```
+
+## Endpoints
+
+- `GET /health`
+- `POST /book` — start book job (Bearer `BOOKING_SERVICE_SECRET`)
+- `POST /cancel` — start cancel job
+- `POST /jobs/{job_id}/confirm` — `{ "confirm": true|false }`

--- a/booking-agent/app/__init__.py
+++ b/booking-agent/app/__init__.py
@@ -1,0 +1,1 @@
+# Booking agent package

--- a/booking-agent/app/agent.py
+++ b/booking-agent/app/agent.py
@@ -1,0 +1,459 @@
+"""Gemini Computer Use agent loop for ForeTees book/cancel."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from google import genai
+from google.genai import types
+
+from . import browser as browser_ops
+from .config import Settings, get_settings
+from .jobs import BookingJob, JobKind, JobStatus, job_store, screenshot_to_b64
+
+logger = logging.getLogger("booking_agent.agent")
+
+SYSTEM_INSTRUCTION = """
+You are automating Wingpoint Golf Club / ForeTees tee-time booking in a browser.
+
+RULES:
+1. Never type usernames or passwords. For login:
+   - Navigate to the Wingpoint member login page if needed.
+   - Call request_confirmation(kind="login", explanation=...).
+   - After the user confirms, call enter_foretees_credentials().
+2. Before clicking Submit Request, Submit Changes, or Cancel Reservation:
+   - Call request_confirmation(kind="submit", explanation=...).
+   - Only click the button after the user confirms.
+3. Stay on wingpointgolf.com and ftapp.wingpointgolf.com only.
+4. When the booking/cancel outcome is clear from the page (success or ForeTees
+   error messages), call report_booking_result(...).
+5. Prefer precise clicks on visible tee-time links and form controls.
+6. If stuck after several attempts, call report_booking_result(success=false, ...).
+""".strip()
+
+REQUEST_CONFIRMATION_DECL = types.FunctionDeclaration(
+    name="request_confirmation",
+    description=(
+        "Pause and ask the end user to confirm before a sensitive step "
+        "(login or final submit/cancel)."
+    ),
+    parameters_json_schema={
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["login", "submit", "safety"],
+                "description": "Which sensitive step needs confirmation",
+            },
+            "explanation": {
+                "type": "string",
+                "description": "Short human-readable explanation for the user",
+            },
+        },
+        "required": ["kind", "explanation"],
+    },
+)
+
+ENTER_CREDENTIALS_DECL = types.FunctionDeclaration(
+    name="enter_foretees_credentials",
+    description=(
+        "Fill and submit the Wingpoint login form using server-side credentials. "
+        "Call only after request_confirmation(kind='login') was approved."
+    ),
+    parameters_json_schema={"type": "object", "properties": {}},
+)
+
+REPORT_RESULT_DECL = types.FunctionDeclaration(
+    name="report_booking_result",
+    description="Report the final booking or cancel outcome and end the task.",
+    parameters_json_schema={
+        "type": "object",
+        "properties": {
+            "success": {"type": "boolean"},
+            "title": {"type": "string"},
+            "messages": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "required": ["success"],
+    },
+)
+
+
+def _client(settings: Settings) -> genai.Client:
+    return genai.Client(
+        vertexai=True,
+        project=settings.gcp_project_id,
+        location=settings.gcp_location,
+    )
+
+
+def _generate_config(settings: Settings) -> types.GenerateContentConfig:
+    return types.GenerateContentConfig(
+        system_instruction=SYSTEM_INSTRUCTION,
+        temperature=0.2,
+        tools=[
+            types.Tool(
+                computer_use=types.ComputerUse(
+                    environment=types.Environment.ENVIRONMENT_BROWSER,
+                    excluded_predefined_functions=["drag_and_drop"],
+                )
+            ),
+            types.Tool(
+                function_declarations=[
+                    REQUEST_CONFIRMATION_DECL,
+                    ENTER_CREDENTIALS_DECL,
+                    REPORT_RESULT_DECL,
+                ]
+            ),
+        ],
+    )
+
+
+def _goal_text(job: BookingJob, settings: Settings) -> str:
+    args = job.args
+    login_url = f"{settings.wingpoint_base}{settings.login_page}"
+    tee_url = f"{settings.wingpoint_base}{settings.tee_time_page}"
+    ft_base = settings.foretees_base
+
+    if job.kind == JobKind.BOOK:
+        players = args.get("players") or []
+        players_line = ", ".join(players) if players else "(none — book solo)"
+        return (
+            f"Book a ForeTees tee time.\n"
+            f"- Login page: {login_url}\n"
+            f"- After login, open tee-time entry: {tee_url} (extract SSO into ForeTees)\n"
+            f"- ForeTees base: {ft_base}\n"
+            f"- Date (YYYY-MM-DD): {args.get('date')}\n"
+            f"- Time label exactly: {args.get('time')}\n"
+            f"- Transport mode select value: {args.get('transport_mode') or 'WLK'} "
+            f"(WLK=Walking, CRT=Cart, PC=Push Cart)\n"
+            f"- Co-players to add: {players_line}\n"
+            f"Use Member_sheet?calDate=MM/DD/YYYY after SSO. Click the exact time link, "
+            f"add co-players if listed, set transport, then submit."
+        )
+
+    ttdata = args.get("ttdata")
+    return (
+        f"Cancel a ForeTees tee time.\n"
+        f"- Login page: {login_url}\n"
+        f"- ForeTees base: {ft_base}\n"
+        f"- Preferred: open {ft_base}/Member_teelist_list and cancel the booking "
+        f"with ttdata={ttdata!r}\n"
+        f"- Fallback date/time: {args.get('date')} / {args.get('time')}\n"
+        f"Click Cancel Reservation only after confirmation."
+    )
+
+
+def _function_calls(response: Any) -> list[Any]:
+    calls: list[Any] = []
+    if not response.candidates:
+        return calls
+    content = response.candidates[0].content
+    if not content or not content.parts:
+        return calls
+    for part in content.parts:
+        if part.function_call:
+            calls.append(part.function_call)
+    return calls
+
+
+def _safety_decision(fc: Any) -> dict[str, Any] | None:
+    args = dict(fc.args or {})
+    decision = args.get("safety_decision")
+    if isinstance(decision, dict):
+        return decision
+    return None
+
+
+async def _pause_for_confirm(
+    job: BookingJob,
+    kind: str,
+    explanation: str,
+    page: Any,
+) -> bool:
+    png = await page.screenshot(type="png", full_page=False)
+    job.status = JobStatus.NEEDS_CONFIRMATION
+    job.confirm_kind = kind
+    job.explanation = explanation
+    job.screenshot_b64 = screenshot_to_b64(png)
+    job.confirm_event = asyncio.Event()
+    job.confirm_decision = None
+    job.touch()
+    logger.info("job %s waiting for confirm kind=%s", job.id, kind)
+    await job.confirm_event.wait()
+    approved = bool(job.confirm_decision)
+    job.status = JobStatus.RUNNING
+    job.confirm_kind = None
+    job.explanation = None
+    job.screenshot_b64 = None
+    job.touch()
+    return approved
+
+
+async def _function_response_part(
+    name: str,
+    page: Any,
+    payload: dict[str, Any],
+    extra: dict[str, Any] | None = None,
+) -> types.Part:
+    png = await page.screenshot(type="png", full_page=False)
+    response_body = {"url": page.url, **payload}
+    if extra:
+        response_body.update(extra)
+    return types.Part(
+        function_response=types.FunctionResponse(
+            name=name,
+            response=response_body,
+            parts=[
+                types.FunctionResponsePart(
+                    inline_data=types.FunctionResponseBlob(
+                        mime_type="image/png",
+                        data=png,
+                    )
+                )
+            ],
+        )
+    )
+
+
+async def run_job(job: BookingJob) -> dict[str, Any]:
+    settings = get_settings()
+    client = _client(settings)
+    config = _generate_config(settings)
+
+    browser = await browser_ops.launch_browser(settings)
+    context, page = await browser_ops.new_page(browser, settings)
+    job.browser = browser
+    job.context = context
+    job.page = page
+
+    try:
+        await page.goto(
+            f"{settings.wingpoint_base}{settings.login_page}",
+            wait_until="domcontentloaded",
+        )
+        png = await page.screenshot(type="png", full_page=False)
+        job.contents = [
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part(text=_goal_text(job, settings)),
+                    types.Part.from_bytes(data=png, mime_type="image/png"),
+                ],
+            )
+        ]
+
+        for turn in range(settings.max_agent_turns):
+            job.touch()
+            logger.info("job %s turn %s url=%s", job.id, turn + 1, page.url)
+            response = await asyncio.to_thread(
+                lambda: client.models.generate_content(
+                    model=settings.computer_use_model,
+                    contents=job.contents,
+                    config=config,
+                )
+            )
+            job.contents.append(response.candidates[0].content)
+
+            calls = _function_calls(response)
+            if not calls:
+                text = getattr(response, "text", None) or "Agent stopped without a result"
+                job.status = JobStatus.FAILED
+                job.error = text
+                return job.to_response()
+
+            fr_parts: list[types.Part] = []
+            terminal: dict[str, Any] | None = None
+
+            for fc in calls:
+                name = fc.name
+                args = dict(fc.args or {})
+                extra_fr: dict[str, Any] = {}
+
+                safety = _safety_decision(fc)
+                if safety and str(safety.get("decision", "")).lower() in {
+                    "require_confirmation",
+                    "require_user_confirmation",
+                }:
+                    explanation = str(
+                        safety.get("explanation")
+                        or args.get("explanation")
+                        or "The safety system requires your confirmation."
+                    )
+                    approved = await _pause_for_confirm(job, "safety", explanation, page)
+                    if not approved:
+                        job.status = JobStatus.FAILED
+                        job.error = "User denied safety confirmation"
+                        await job.close_browser()
+                        return job.to_response()
+                    extra_fr["safety_acknowledgement"] = "true"
+
+                if name == "request_confirmation":
+                    kind = str(args.get("kind") or "safety")
+                    explanation = str(args.get("explanation") or "Confirmation required")
+                    approved = await _pause_for_confirm(job, kind, explanation, page)
+                    if not approved:
+                        job.status = JobStatus.FAILED
+                        job.error = "User denied confirmation"
+                        await job.close_browser()
+                        return job.to_response()
+                    fr_parts.append(
+                        await _function_response_part(
+                            name,
+                            page,
+                            {"result": "confirmed"},
+                            extra_fr,
+                        )
+                    )
+                    continue
+
+                if name == "enter_foretees_credentials":
+                    username = job.args.get("username") or ""
+                    password = job.args.get("password") or ""
+                    result = await browser_ops.enter_credentials(page, username, password)
+                    await browser_ops.settle(page, 800)
+                    fr_parts.append(
+                        await _function_response_part(
+                            name,
+                            page,
+                            {"result": result},
+                            extra_fr,
+                        )
+                    )
+                    continue
+
+                if name == "report_booking_result":
+                    messages = args.get("messages") or []
+                    if isinstance(messages, str):
+                        messages = [messages]
+                    terminal = {
+                        "success": bool(args.get("success")),
+                        "title": str(args.get("title") or ""),
+                        "messages": [str(m) for m in messages],
+                    }
+                    fr_parts.append(
+                        await _function_response_part(
+                            name,
+                            page,
+                            {"result": "acknowledged"},
+                            extra_fr,
+                        )
+                    )
+                    continue
+
+                # Heuristic: treat credential typing attempts as forbidden.
+                if name == "type_text_at" and "password" in page.url.lower():
+                    fr_parts.append(
+                        await _function_response_part(
+                            name,
+                            page,
+                            {
+                                "result": (
+                                    "blocked: use enter_foretees_credentials after "
+                                    "request_confirmation(kind=login)"
+                                )
+                            },
+                            extra_fr,
+                        )
+                    )
+                    continue
+
+                result = await browser_ops.execute_computer_action(
+                    page,
+                    name,
+                    args,
+                    settings.screen_width,
+                    settings.screen_height,
+                )
+                await browser_ops.settle(page, 500)
+                fr_parts.append(
+                    await _function_response_part(
+                        name,
+                        page,
+                        {"result": result},
+                        extra_fr,
+                    )
+                )
+
+            job.contents.append(types.Content(role="user", parts=fr_parts))
+
+            if terminal is not None:
+                job.status = JobStatus.COMPLETED
+                job.result = terminal
+                await job.close_browser()
+                return job.to_response()
+
+        job.status = JobStatus.FAILED
+        job.error = f"Exceeded max agent turns ({settings.max_agent_turns})"
+        await job.close_browser()
+        return job.to_response()
+    except Exception as exc:
+        logger.exception("job %s crashed", job.id)
+        job.status = JobStatus.FAILED
+        job.error = str(exc)
+        await job.close_browser()
+        return job.to_response()
+
+
+async def start_job(kind: JobKind, args: dict[str, Any]) -> dict[str, Any]:
+    job = await job_store.create(kind, args)
+
+    async def _runner() -> None:
+        async with job.lock:
+            await run_job(job)
+
+    asyncio.create_task(_runner())
+
+    # Wait until the job either needs confirmation or finishes the first stretch.
+    for _ in range(600):  # up to ~5 minutes of polling at 0.5s
+        await asyncio.sleep(0.5)
+        if job.status in {
+            JobStatus.NEEDS_CONFIRMATION,
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+        }:
+            return job.to_response()
+    job.status = JobStatus.FAILED
+    job.error = "Timed out waiting for agent progress"
+    await job.close_browser()
+    return job.to_response()
+
+
+async def confirm_job(job_id: str, confirm: bool) -> dict[str, Any]:
+    job = await job_store.get(job_id)
+    if not job:
+        return {"status": "failed", "success": False, "error": "Unknown job_id"}
+
+    if job.status != JobStatus.NEEDS_CONFIRMATION:
+        # Idempotent: if already terminal, return that.
+        if job.status in {JobStatus.COMPLETED, JobStatus.FAILED}:
+            return job.to_response()
+        return {
+            "status": "failed",
+            "success": False,
+            "error": f"Job is {job.status.value}, not awaiting confirmation",
+            "job_id": job_id,
+        }
+
+    job.confirm_decision = confirm
+    job.confirm_event.set()
+
+    for _ in range(600):
+        await asyncio.sleep(0.5)
+        if job.status in {
+            JobStatus.NEEDS_CONFIRMATION,
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+        }:
+            return job.to_response()
+
+    return {
+        "status": "failed",
+        "success": False,
+        "error": "Timed out after confirmation",
+        "job_id": job_id,
+    }

--- a/booking-agent/app/browser.py
+++ b/booking-agent/app/browser.py
@@ -1,0 +1,174 @@
+"""Playwright helpers for Computer Use action execution."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from playwright.async_api import Browser, Page, async_playwright
+
+from .config import Settings
+
+logger = logging.getLogger("booking_agent.browser")
+
+WINGPOINT_LOGIN_SELECTORS = {
+    "username": 'input[name="UserLOGIN"]',
+    "password": 'input[name="UserPWD"]',
+    "submit": 'input[name="btnLogon"]',
+}
+
+
+def normalize_x(x: int, screen_width: int) -> int:
+    return int(x / 1000 * screen_width)
+
+
+def normalize_y(y: int, screen_height: int) -> int:
+    return int(y / 1000 * screen_height)
+
+
+async def launch_browser(settings: Settings) -> Browser:
+    pw = await async_playwright().start()
+    browser = await pw.chromium.launch(
+        headless=settings.headless,
+        args=["--disable-dev-shm-usage", "--no-sandbox"],
+    )
+    # Keep playwright manager on the browser object for cleanup.
+    browser._wgp_playwright = pw  # type: ignore[attr-defined]
+    return browser
+
+
+async def new_page(browser: Browser, settings: Settings) -> tuple[Any, Page]:
+    context = await browser.new_context(
+        viewport={"width": settings.screen_width, "height": settings.screen_height},
+        ignore_https_errors=True,
+    )
+    page = await context.new_page()
+    return context, page
+
+
+async def enter_credentials(page: Page, username: str, password: str) -> str:
+    """Fill Wingpoint login without sending the password through the model."""
+    await page.wait_for_selector(WINGPOINT_LOGIN_SELECTORS["username"], timeout=15000)
+    await page.fill(WINGPOINT_LOGIN_SELECTORS["username"], username)
+    await page.fill(WINGPOINT_LOGIN_SELECTORS["password"], password)
+    await page.click(WINGPOINT_LOGIN_SELECTORS["submit"])
+    await page.wait_for_load_state("networkidle")
+    return "credentials_submitted"
+
+
+async def execute_computer_action(
+    page: Page,
+    name: str,
+    args: dict[str, Any],
+    screen_width: int,
+    screen_height: int,
+) -> str:
+    """Execute a Gemini Computer Use predefined function via Playwright."""
+    try:
+        if name == "open_web_browser":
+            return "success"
+
+        if name == "wait_5_seconds":
+            await page.wait_for_timeout(5000)
+            return "success"
+
+        if name == "go_back":
+            await page.go_back(wait_until="domcontentloaded")
+            return "success"
+
+        if name == "go_forward":
+            await page.go_forward(wait_until="domcontentloaded")
+            return "success"
+
+        if name == "search":
+            return "unsupported_in_this_environment"
+
+        if name == "navigate":
+            url = args.get("url") or args.get("address")
+            if not url:
+                return "error: missing url"
+            await page.goto(str(url), wait_until="domcontentloaded")
+            return "success"
+
+        if name in {"click_at", "hover_at"}:
+            x = normalize_x(int(args["x"]), screen_width)
+            y = normalize_y(int(args["y"]), screen_height)
+            if name == "hover_at":
+                await page.mouse.move(x, y)
+            else:
+                await page.mouse.click(x, y)
+            return "success"
+
+        if name == "type_text_at":
+            x = normalize_x(int(args["x"]), screen_width)
+            y = normalize_y(int(args["y"]), screen_height)
+            text = str(args.get("text", ""))
+            press_enter = bool(args.get("press_enter", False))
+            clear_before = bool(args.get("clear_before_typing", True))
+            await page.mouse.click(x, y)
+            await page.wait_for_timeout(100)
+            if clear_before:
+                await page.keyboard.press("Meta+A")
+                await page.keyboard.press("Backspace")
+            await page.keyboard.type(text, delay=20)
+            if press_enter:
+                await page.keyboard.press("Enter")
+            return "success"
+
+        if name == "key_combination":
+            keys = args.get("keys") or args.get("key")
+            if isinstance(keys, list):
+                await page.keyboard.press("+".join(str(k) for k in keys))
+            elif keys:
+                await page.keyboard.press(str(keys))
+            return "success"
+
+        if name == "scroll_document":
+            direction = str(args.get("direction", "down")).lower()
+            delta = 600 if direction in {"down", "right"} else -600
+            if direction in {"left", "right"}:
+                await page.mouse.wheel(delta, 0)
+            else:
+                await page.mouse.wheel(0, delta)
+            return "success"
+
+        if name == "scroll_at":
+            x = normalize_x(int(args.get("x", 500)), screen_width)
+            y = normalize_y(int(args.get("y", 500)), screen_height)
+            direction = str(args.get("direction", "down")).lower()
+            magnitude = int(args.get("magnitude", 800))
+            await page.mouse.move(x, y)
+            dx = dy = 0
+            if direction == "down":
+                dy = magnitude
+            elif direction == "up":
+                dy = -magnitude
+            elif direction == "right":
+                dx = magnitude
+            elif direction == "left":
+                dx = -magnitude
+            await page.mouse.wheel(dx, dy)
+            return "success"
+
+        if name == "drag_and_drop":
+            x = normalize_x(int(args["x"]), screen_width)
+            y = normalize_y(int(args["y"]), screen_height)
+            dest_x = normalize_x(int(args.get("destination_x", args["x"])), screen_width)
+            dest_y = normalize_y(int(args.get("destination_y", args["y"])), screen_height)
+            await page.mouse.move(x, y)
+            await page.mouse.down()
+            await page.mouse.move(dest_x, dest_y, steps=12)
+            await page.mouse.up()
+            return "success"
+
+        logger.warning("Unrecognized computer action: %s", name)
+        return f"unknown_function:{name}"
+    except Exception as exc:
+        logger.exception("Action %s failed", name)
+        return f"error: {exc}"
+
+
+async def settle(page: Page, ms: int = 400) -> None:
+    await page.wait_for_timeout(ms)
+    await asyncio.sleep(0)

--- a/booking-agent/app/config.py
+++ b/booking-agent/app/config.py
@@ -1,0 +1,32 @@
+"""ForeTees booking agent — Gemini Computer Use + Playwright on Cloud Run."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    booking_service_secret: str = ""
+    gcp_project_id: str = "seventh-country-232522"
+    gcp_location: str = "global"
+    computer_use_model: str = "gemini-3.5-flash"
+    max_agent_turns: int = 40
+    job_ttl_seconds: int = 900
+    screen_width: int = 1280
+    screen_height: int = 720
+    headless: bool = True
+    wingpoint_base: str = "https://www.wingpointgolf.com"
+    login_page: str = "/public/member-login-465.html"
+    tee_time_page: str = "/members/golf/make-a-tee-time-703.html"
+    foretees_base: str = "https://ftapp.wingpointgolf.com/v5/wingpointgcc_flxrez0_m30"
+    port: int = int(os.getenv("PORT", "8080"))
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/booking-agent/app/jobs.py
+++ b/booking-agent/app/jobs.py
@@ -1,0 +1,133 @@
+"""In-memory booking jobs (requires Cloud Run session affinity for confirm)."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from playwright.async_api import Browser, BrowserContext, Page
+
+
+class JobKind(str, Enum):
+    BOOK = "book"
+    CANCEL = "cancel"
+
+
+class JobStatus(str, Enum):
+    RUNNING = "running"
+    NEEDS_CONFIRMATION = "needs_confirmation"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class BookingJob:
+    id: str
+    kind: JobKind
+    args: dict[str, Any]
+    status: JobStatus = JobStatus.RUNNING
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    confirm_kind: str | None = None
+    explanation: str | None = None
+    screenshot_b64: str | None = None
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    # Agent runtime (owned by the job until terminal)
+    browser: Browser | None = None
+    context: BrowserContext | None = None
+    page: Page | None = None
+    contents: list[Any] = field(default_factory=list)
+    pending_function_calls: list[Any] = field(default_factory=list)
+    confirm_event: asyncio.Event = field(default_factory=asyncio.Event)
+    confirm_decision: bool | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    def touch(self) -> None:
+        self.updated_at = time.time()
+
+    async def close_browser(self) -> None:
+        try:
+            if self.context:
+                await self.context.close()
+        except Exception:
+            pass
+        pw = getattr(self.browser, "_wgp_playwright", None) if self.browser else None
+        try:
+            if self.browser:
+                await self.browser.close()
+        except Exception:
+            pass
+        if pw is not None:
+            try:
+                await pw.stop()
+            except Exception:
+                pass
+        self.context = None
+        self.browser = None
+        self.page = None
+
+    def to_response(self) -> dict[str, Any]:
+        if self.status == JobStatus.NEEDS_CONFIRMATION:
+            return {
+                "status": JobStatus.NEEDS_CONFIRMATION.value,
+                "job_id": self.id,
+                "kind": self.confirm_kind or "safety",
+                "explanation": self.explanation or "Confirmation required",
+                "screenshot_b64": self.screenshot_b64,
+                "success": False,
+            }
+        if self.status == JobStatus.COMPLETED and self.result is not None:
+            return {
+                "status": JobStatus.COMPLETED.value,
+                **self.result,
+            }
+        if self.status == JobStatus.FAILED:
+            return {
+                "status": JobStatus.FAILED.value,
+                "success": False,
+                "error": self.error or "Booking agent failed",
+                "job_id": self.id,
+            }
+        return {
+            "status": self.status.value,
+            "job_id": self.id,
+            "success": False,
+        }
+
+
+class JobStore:
+    def __init__(self) -> None:
+        self._jobs: dict[str, BookingJob] = {}
+        self._lock = asyncio.Lock()
+
+    async def create(self, kind: JobKind, args: dict[str, Any]) -> BookingJob:
+        job = BookingJob(id=str(uuid.uuid4()), kind=kind, args=args)
+        async with self._lock:
+            self._jobs[job.id] = job
+        return job
+
+    async def get(self, job_id: str) -> BookingJob | None:
+        async with self._lock:
+            return self._jobs.get(job_id)
+
+    async def purge_expired(self, ttl_seconds: int) -> None:
+        cutoff = time.time() - ttl_seconds
+        async with self._lock:
+            expired = [j.id for j in self._jobs.values() if j.updated_at < cutoff]
+            for job_id in expired:
+                job = self._jobs.pop(job_id, None)
+                if job:
+                    await job.close_browser()
+
+
+def screenshot_to_b64(png: bytes) -> str:
+    return base64.b64encode(png).decode("ascii")
+
+
+job_store = JobStore()

--- a/booking-agent/app/main.py
+++ b/booking-agent/app/main.py
@@ -1,0 +1,126 @@
+"""HTTP API for the ForeTees Computer Use booking agent."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from .agent import confirm_job, start_job
+from .config import get_settings
+from .jobs import JobKind, job_store
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+logger = logging.getLogger("booking_agent")
+
+app = FastAPI(title="WGP ForeTees Booking Agent", version="0.1.0")
+
+
+class BookRequest(BaseModel):
+    username: str
+    password: str
+    date: str
+    time: str
+    transport_mode: str = "WLK"
+    players: list[str] = Field(default_factory=list)
+
+
+class CancelRequest(BaseModel):
+    username: str
+    password: str
+    date: str = ""
+    time: str = ""
+    ttdata: str | None = None
+
+
+class ConfirmRequest(BaseModel):
+    confirm: bool = True
+
+
+def _check_auth(authorization: str | None) -> None:
+    secret = get_settings().booking_service_secret
+    if not secret:
+        return
+    if authorization != f"Bearer {secret}":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    settings = get_settings()
+    logger.info(
+        "booking-agent starting model=%s project=%s",
+        settings.computer_use_model,
+        settings.gcp_project_id,
+    )
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/book")
+async def book(
+    body: BookRequest,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _check_auth(authorization)
+    logger.info("POST /book date=%s time=%s", body.date, body.time)
+    return await start_job(
+        JobKind.BOOK,
+        {
+            "username": body.username,
+            "password": body.password,
+            "date": body.date,
+            "time": body.time,
+            "transport_mode": body.transport_mode,
+            "players": [p for p in body.players if p],
+        },
+    )
+
+
+@app.post("/cancel")
+async def cancel(
+    body: CancelRequest,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _check_auth(authorization)
+    if not body.ttdata and not (body.date and body.time):
+        raise HTTPException(status_code=400, detail="ttdata or date+time required")
+    logger.info("POST /cancel date=%s time=%s", body.date, body.time)
+    return await start_job(
+        JobKind.CANCEL,
+        {
+            "username": body.username,
+            "password": body.password,
+            "date": body.date,
+            "time": body.time,
+            "ttdata": body.ttdata,
+        },
+    )
+
+
+@app.post("/jobs/{job_id}/confirm")
+async def confirm(
+    job_id: str,
+    body: ConfirmRequest,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _check_auth(authorization)
+    logger.info("POST /jobs/%s/confirm confirm=%s", job_id, body.confirm)
+    return await confirm_job(job_id, body.confirm)
+
+
+@app.get("/jobs/{job_id}")
+async def get_job(
+    job_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _check_auth(authorization)
+    job = await job_store.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Unknown job")
+    return job.to_response()

--- a/booking-agent/requirements.txt
+++ b/booking-agent/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+pydantic>=2.9.0
+pydantic-settings>=2.6.0
+playwright>=1.49.0
+google-genai>=1.20.0

--- a/deploy/gcp/DECOMMISSION.md
+++ b/deploy/gcp/DECOMMISSION.md
@@ -23,6 +23,8 @@ Vercel + Render are being frozen / decommissioned.
 - [ ] Remove Vercel URLs from Auth0 (Firebase + localhost only)
 - [x] Suspend Render web services `wolf-goat-pig` + `wolf-goat-pig-api` (2026-07-27; Postgres kept warm; booking left running)
 - [x] Pause / archive Vercel project (paused 2026-07-27 via Pause Vercel workflow)
+- [x] Deploy Computer Use booking agent (`wgp-booking`) and flip `BOOKING_SERVICE_URL` (2026-07-28)
+- [ ] Suspend Render `wolf-goat-pig-booking` after booking soak
 - [ ] After ≥7 days with no rollback need: delete Render Postgres
 - [ ] Delete secret `RENDER_DATABASE_URL` after Postgres is gone
 

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -16,6 +16,7 @@ Infrastructure-as-code for the migration designed in
 | 4 Cloud Scheduler | Live — 6 jobs → `/internal/jobs/*` |
 | 5 Cloud Storage | Live — `wgp-media-seventh-country-232522` (avatars) |
 | 6 Monitoring | Live — Cloud Monitoring uptime + alerts; **no Sentry** ([phase6-monitoring](phase6-monitoring/README.md)) |
+| 7 Booking agent | **Production** — `wgp-booking` (Computer Use); Render booking can be suspended |
 | Decommission | In progress — freeze Vercel/Render ([DECOMMISSION.md](DECOMMISSION.md)) |
 
 **Production SPA:** https://seventh-country-232522.web.app  
@@ -31,7 +32,8 @@ Auth stays on **Auth0** throughout (design decision D4). Firebase-only URLs: [ph
 Auth0 (unchanged) → JWT
 Firebase Hosting (SPA)  →  Cloud Run (FastAPI container, as-is)  →  Cloud SQL (Postgres)
                                      │                                Secret Manager
-Cloud Scheduler → Cloud Run jobs     └→ Cloud Storage (future: scorecard images)
+Cloud Scheduler → Cloud Run jobs     └→ Cloud Storage (avatars)
+Booking agent (Computer Use + Playwright) → Wingpoint / ForeTees
 ```
 
 ## Layout
@@ -48,6 +50,7 @@ Cloud Scheduler → Cloud Run jobs     └→ Cloud Storage (future: scorecard i
 | `phase4-scheduling/` | 4 | Cloud Scheduler → Cloud Run jobs. |
 | `phase5-storage/` | 5 | GCS media bucket for avatars. |
 | `phase6-monitoring/` | 6 | Uptime checks + alert policies (email). |
+| `phase7-booking/` | 7 | ForeTees Computer Use booking agent (Cloud Run). |
 | `secrets.md` | — | Secret Manager ↔ render.yaml mapping. |
 | `DECOMMISSION.md` | 5 | Render/Vercel cutover checklist. |
 | `../../.github/workflows/deploy-gcp.yml` | 1, 3 | GitHub Actions → Cloud Build (keyless WIF). |
@@ -93,6 +96,10 @@ export INTERNAL_JOB_TOKEN="$(gcloud secrets versions access latest --secret=INTE
 ./deploy/gcp/phase6-monitoring/10-notification-channel.sh
 ./deploy/gcp/phase6-monitoring/20-uptime-checks.sh
 ./deploy/gcp/phase6-monitoring/30-alert-policies.sh
+
+# Phase 7 — ForeTees booking via Computer Use (replaces Render booking-service)
+./deploy/gcp/phase7-booking/10-deploy.sh
+# then set BOOKING_SERVICE_URL on wolf-goat-pig-api to the printed URL
 ```
 
 ## GitHub Actions variables

--- a/deploy/gcp/phase1-cloud-run/env.production.yaml
+++ b/deploy/gcp/phase1-cloud-run/env.production.yaml
@@ -46,8 +46,8 @@ EMAIL_PROVIDER: "resend"
 FROM_EMAIL: "onboarding@resend.dev"
 FROM_NAME: "Wolf Goat Pig"
 
-# ForeTees booking microservice. Still on Render for now; secret is separate.
-BOOKING_SERVICE_URL: "https://wolf-goat-pig-booking.onrender.com"
+# ForeTees booking agent (Computer Use on Cloud Run).
+BOOKING_SERVICE_URL: "https://wgp-booking-i5v2shrpoa-uc.a.run.app"
 FORETEES_ENABLED: "true"
 
 # Server tuning. WEB_CONCURRENCY=1 matches Render; Cloud Run scales by instance,

--- a/deploy/gcp/phase7-booking/10-deploy.sh
+++ b/deploy/gcp/phase7-booking/10-deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Phase 7 — build + deploy the Computer Use booking agent to Cloud Run.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+require_config GCP_PROJECT_ID GCP_REGION RUNTIME_SA_NAME
+
+REPO_ROOT="$(cd "${GCP_DIR}/../.." && pwd)"
+SERVICE="${BOOKING_RUN_SERVICE:-wgp-booking}"
+AR_REPO="${AR_REPO:-wolf-goat-pig}"
+IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${AR_REPO}/${SERVICE}:$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+RUNTIME_SA="${RUNTIME_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+
+log "Ensuring Vertex AI API…"
+gc services enable aiplatform.googleapis.com --project="${GCP_PROJECT_ID}" >/dev/null
+
+log "Granting aiplatform.user to ${RUNTIME_SA}…"
+gc projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+  --member="serviceAccount:${RUNTIME_SA}" \
+  --role="roles/aiplatform.user" \
+  --condition=None >/dev/null || true
+
+log "Building ${IMAGE}…"
+gc builds submit \
+  --project="${GCP_PROJECT_ID}" \
+  --region="${GCP_REGION}" \
+  --tag="${IMAGE}" \
+  "${REPO_ROOT}/booking-agent"
+
+log "Deploying Cloud Run service ${SERVICE}…"
+gc run deploy "${SERVICE}" \
+  --project="${GCP_PROJECT_ID}" \
+  --region="${GCP_REGION}" \
+  --image="${IMAGE}" \
+  --service-account="${RUNTIME_SA}" \
+  --allow-unauthenticated \
+  --session-affinity \
+  --min-instances=0 \
+  --max-instances=2 \
+  --cpu=2 \
+  --memory=2Gi \
+  --timeout=300 \
+  --concurrency=1 \
+  --port=8080 \
+  --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},GCP_LOCATION=global,COMPUTER_USE_MODEL=gemini-3.5-flash,HEADLESS=true" \
+  --set-secrets="BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest"
+
+URL="$(gc run services describe "${SERVICE}" --region="${GCP_REGION}" --format='value(status.url)')"
+ok "Booking agent live at ${URL}"
+warn "Set BOOKING_SERVICE_URL=${URL} on wolf-goat-pig-api and redeploy (or update env.production.yaml)."

--- a/deploy/gcp/phase7-booking/README.md
+++ b/deploy/gcp/phase7-booking/README.md
@@ -1,0 +1,45 @@
+# Phase 7 — ForeTees booking agent (Computer Use)
+
+Moves tee-time book/cancel from Render Node/Playwright
+(`wolf-goat-pig-booking`) to a GCP Cloud Run service driven by Gemini
+Computer Use. Design: [`docs/architecture/COMPUTER_USE_BOOKING.md`](../../../docs/architecture/COMPUTER_USE_BOOKING.md).
+
+## Deploy
+
+```bash
+source deploy/gcp/config.env
+./deploy/gcp/phase7-booking/10-deploy.sh
+```
+
+Then point the main API at the new service:
+
+```bash
+# After first deploy prints the URL:
+gcloud run services update wolf-goat-pig-api --region=us-central1 \
+  --update-env-vars=BOOKING_SERVICE_URL=https://wgp-booking-….run.app
+```
+
+Or set `BOOKING_SERVICE_URL` in `phase1-cloud-run/env.production.yaml` and redeploy the API.
+
+## Requirements
+
+- Vertex AI API enabled (`aiplatform.googleapis.com`) — Phase 0 already enables
+  core APIs; this script enables Vertex if missing.
+- Runtime SA `wgp-run` needs `roles/aiplatform.user`.
+- Same `BOOKING_SERVICE_SECRET` as today (Secret Manager).
+- **Session affinity** is required so `/jobs/{id}/confirm` hits the instance
+  holding the Playwright browser.
+
+## Verify
+
+```bash
+curl -sS "$BOOKING_URL/health"
+# From a logged-in SPA: book a tee time → expect login confirm → submit confirm.
+```
+
+## Cutover
+
+1. Deploy `wgp-booking`, smoke `/health`.
+2. Flip `BOOKING_SERVICE_URL` on `wolf-goat-pig-api`.
+3. Book + cancel once in production with confirm gates.
+4. Suspend Render `wolf-goat-pig-booking`.

--- a/docs/architecture/COMPUTER_USE_BOOKING.md
+++ b/docs/architecture/COMPUTER_USE_BOOKING.md
@@ -1,0 +1,95 @@
+# ForeTees booking via Gemini Computer Use
+
+Replaces the Node/Playwright microservice on Render
+(`booking-service` → `wolf-goat-pig-booking.onrender.com`) with a GCP-native
+**Computer Use** agent on Cloud Run.
+
+## Decision (2026-07-28)
+
+| Choice | Value |
+|---|---|
+| Approach | Full Computer Use rewrite (not lift-and-shift of scripted Playwright) |
+| Speed | Not a hard requirement — multi-turn agent loop is OK |
+| Safety | Hybrid: auto-run low-risk nav; **SPA must confirm login + final submit/cancel** |
+| Credentials | Never sent through the model — custom tool `enter_foretees_credentials` |
+
+Google’s Computer Use ToS: when the model returns `require_confirmation`, the
+end user must confirm. We never auto-ack those. Separately, our policy always
+pauses before credential entry and before irreversible ForeTees submit/cancel.
+
+## Architecture
+
+```
+SPA (Firebase)  →  Cloud Run API (FastAPI)
+                        │  BOOKING_SERVICE_URL
+                        ▼
+                   Cloud Run booking-agent (Python)
+                        │  Playwright Chromium (local)
+                        │  Vertex Gemini Computer Use
+                        ▼
+                   Wingpoint / ForeTees v5
+```
+
+The agent still needs a real browser. Computer Use is the **decision layer**;
+Playwright executes `click_at` / `type_text_at` / etc. from model function calls.
+
+## HTTP contract (booking-agent)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Liveness |
+| `POST` | `/book` | Start book job |
+| `POST` | `/cancel` | Start cancel job |
+| `POST` | `/jobs/{job_id}/confirm` | Resume after SPA confirm (`{ "confirm": true\|false }`) |
+
+### Responses
+
+```jsonc
+// Pause for user
+{
+  "status": "needs_confirmation",
+  "job_id": "…",
+  "kind": "login" | "submit" | "safety",
+  "explanation": "About to log in to Wingpoint…",
+  "screenshot_b64": "…",   // optional PNG
+  "success": false
+}
+
+// Done
+{ "status": "completed", "success": true, "title": "…", "messages": ["…"] }
+
+// Failed / denied
+{ "status": "failed", "success": false, "error": "…" }
+```
+
+FastAPI proxies these shapes on `/api/foretees/book`, `/cancel`, and
+`/api/foretees/book/confirm` (Auth0-protected). The SPA loops until
+`completed` / `failed`, showing a confirm step when `needs_confirmation`.
+
+## Agent tools
+
+Built-in Computer Use (`ENVIRONMENT_BROWSER`) plus:
+
+1. **`request_confirmation(kind, explanation)`** — pauses the job for the SPA.
+   Required before login and before Submit Request / Cancel Reservation.
+2. **`enter_foretees_credentials()`** — fills Wingpoint login from job-scoped
+   secrets (never included in model prompts or `type_text_at`).
+3. **`report_booking_result(success, title, messages)`** — terminal structured
+   result when ForeTees responds.
+
+## Deploy notes
+
+- Service: `wgp-booking` in `us-central1`, session affinity on, timeout ≥ 300s,
+  memory ≥ 2Gi (Chromium).
+- Runtime SA needs Vertex AI user + Secret Manager access to
+  `BOOKING_SERVICE_SECRET`.
+- Main API `BOOKING_SERVICE_URL` points at the booking-agent Cloud Run URL.
+- After soak: suspend Render `wolf-goat-pig-booking`.
+
+See `deploy/gcp/phase7-booking/`.
+
+## Non-goals
+
+- Same-origin Firebase `/api` rewrite.
+- Replacing ForeTees tee-sheet **reads** (those stay on FastAPI/httpx).
+- Auto-acking Google `require_confirmation` (forbidden by ToS).

--- a/frontend/src/components/foretees/AgentConfirmDialog.jsx
+++ b/frontend/src/components/foretees/AgentConfirmDialog.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { useTheme } from '../../theme/Provider';
+
+const KIND_LABELS = {
+  login: 'Allow ForeTees login',
+  submit: 'Confirm final submit',
+  safety: 'Safety confirmation required',
+};
+
+/**
+ * Mid-flow confirmation for the Computer Use booking agent.
+ * Shown for login, final submit/cancel, and Google safety gates.
+ */
+const AgentConfirmDialog = ({ pendingConfirm, onResolve }) => {
+  const theme = useTheme();
+  if (!pendingConfirm) return null;
+
+  const confirmKind = pendingConfirm.kind || 'safety';
+  const confirmTitle = KIND_LABELS[confirmKind] || KIND_LABELS.safety;
+
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.5)',
+          zIndex: 2100,
+        }}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        style={{
+          position: 'fixed',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          zIndex: 2101,
+          ...theme.cardStyle,
+          padding: 24,
+          minWidth: 320,
+          maxWidth: 420,
+          width: '90vw',
+        }}
+      >
+        <h3 style={{ color: theme.colors.primary, margin: '0 0 12px' }}>
+          {confirmTitle}
+        </h3>
+        <p style={{ margin: '0 0 16px', color: theme.colors.textPrimary, fontSize: 14, lineHeight: 1.45 }}>
+          {pendingConfirm.explanation || 'Please confirm to continue this ForeTees action.'}
+        </p>
+        {pendingConfirm.screenshot_b64 && (
+          <img
+            alt="Current ForeTees page"
+            src={`data:image/png;base64,${pendingConfirm.screenshot_b64}`}
+            style={{
+              width: '100%',
+              maxHeight: 220,
+              objectFit: 'contain',
+              borderRadius: 8,
+              border: `1px solid ${theme.colors.border || '#ddd'}`,
+              marginBottom: 16,
+              background: '#0f172a',
+            }}
+          />
+        )}
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button
+            type="button"
+            onClick={() => onResolve?.(false)}
+            style={{
+              flex: 1,
+              padding: '12px 16px',
+              borderRadius: 8,
+              border: `1px solid ${theme.colors.border || '#ccc'}`,
+              background: 'transparent',
+              color: theme.colors.textPrimary,
+              fontSize: 15,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            onClick={() => onResolve?.(true)}
+            style={{
+              flex: 1,
+              padding: '12px 16px',
+              borderRadius: 8,
+              border: 'none',
+              background: '#10b981',
+              color: '#fff',
+              fontSize: 15,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Allow
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AgentConfirmDialog;

--- a/frontend/src/components/foretees/BookingModal.jsx
+++ b/frontend/src/components/foretees/BookingModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useTheme } from '../../theme/Provider';
+import AgentConfirmDialog from './AgentConfirmDialog';
 
 const TRANSPORT_OPTIONS = [
   { value: 'WLK', label: 'Walking' },
@@ -7,7 +8,15 @@ const TRANSPORT_OPTIONS = [
   { value: 'PC', label: 'Push Cart' },
 ];
 
-const BookingModal = ({ isOpen, onClose, onConfirm, slot, loading }) => {
+const BookingModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  slot,
+  loading,
+  pendingConfirm,
+  onResolveConfirm,
+}) => {
   const theme = useTheme();
   const [transportMode, setTransportMode] = useState('WLK');
 
@@ -17,18 +26,23 @@ const BookingModal = ({ isOpen, onClose, onConfirm, slot, loading }) => {
 
   useEffect(() => {
     if (!isOpen) return;
-    const handleKey = (e) => { if (e.key === 'Escape') onClose(); };
+    const handleKey = (e) => { if (e.key === 'Escape' && !loading && !pendingConfirm) onClose(); };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, loading, pendingConfirm]);
+
+  if (pendingConfirm) {
+    return <AgentConfirmDialog pendingConfirm={pendingConfirm} onResolve={onResolveConfirm} />;
+  }
 
   if (!isOpen || !slot) return null;
 
   return (
     <>
-      {/* Backdrop */}
       <div
-        onClick={onClose}
+        onClick={() => {
+          if (!loading) onClose();
+        }}
         style={{
           position: 'fixed',
           inset: 0,
@@ -37,7 +51,6 @@ const BookingModal = ({ isOpen, onClose, onConfirm, slot, loading }) => {
         }}
       />
 
-      {/* Modal */}
       <div
         role="dialog"
         aria-modal="true"
@@ -111,6 +124,7 @@ const BookingModal = ({ isOpen, onClose, onConfirm, slot, loading }) => {
 
         <div style={{ display: 'flex', gap: 12 }}>
           <button
+            type="button"
             onClick={onClose}
             disabled={loading}
             style={{
@@ -128,6 +142,7 @@ const BookingModal = ({ isOpen, onClose, onConfirm, slot, loading }) => {
             Cancel
           </button>
           <button
+            type="button"
             onClick={() => onConfirm({ transportMode })}
             disabled={loading}
             style={{
@@ -142,7 +157,7 @@ const BookingModal = ({ isOpen, onClose, onConfirm, slot, loading }) => {
               cursor: loading ? 'not-allowed' : 'pointer',
             }}
           >
-            {loading ? 'Booking...' : 'Confirm Booking'}
+            {loading ? 'Working…' : 'Confirm Booking'}
           </button>
         </div>
 
@@ -157,7 +172,7 @@ const BookingModal = ({ isOpen, onClose, onConfirm, slot, loading }) => {
             color: '#1e40af',
             textAlign: 'center',
           }}>
-            This may take 30-60 seconds while the booking service processes your request.
+            The booking agent is driving ForeTees. You may be asked to approve login and final submit.
           </div>
         )}
       </div>

--- a/frontend/src/components/foretees/ForeTeesTeeSheet.jsx
+++ b/frontend/src/components/foretees/ForeTeesTeeSheet.jsx
@@ -13,6 +13,7 @@ const ForeTeesTeeSheet = () => {
     teeTimes, bookings, loading, error,
     fetchTeeTimes, fetchBookings,
     bookTeeTime, cancelTeeTime, bookingLoading, clearBookingError,
+    pendingConfirm, resolvePendingConfirm,
   } = useTeeTimes();
   const [selectedDate, setSelectedDate] = useState(formatDate(new Date()));
   const [bookingSlot, setBookingSlot] = useState(null);
@@ -25,8 +26,6 @@ const ForeTeesTeeSheet = () => {
 
   useEffect(() => {
     fetchBookings();
-    // Pre-wake the booking service so it's ready when user clicks Book
-    fetch('https://wolf-goat-pig-booking.onrender.com/health', { mode: 'no-cors' }).catch(() => {});
   }, [fetchBookings]);
 
   useEffect(() => {
@@ -459,12 +458,15 @@ const ForeTeesTeeSheet = () => {
       <BookingModal
         isOpen={bookingSlot !== null}
         onClose={() => {
+          if (pendingConfirm) return;
           setBookingSlot(null);
           clearBookingError();
         }}
         onConfirm={handleBookConfirm}
         slot={bookingSlot}
         loading={bookingLoading}
+        pendingConfirm={pendingConfirm}
+        onResolveConfirm={resolvePendingConfirm}
       />
     </div>
   );

--- a/frontend/src/components/signup/MatchmakingSuggestions.jsx
+++ b/frontend/src/components/signup/MatchmakingSuggestions.jsx
@@ -40,6 +40,7 @@ const MatchmakingSuggestions = () => {
   const {
     fetchTeeTimes,
     bookTeeTime, bookingLoading, clearBookingError,
+    pendingConfirm, resolvePendingConfirm,
   } = useTeeTimes();
 
   const [matches, setMatches] = useState([]);
@@ -611,12 +612,15 @@ const MatchmakingSuggestions = () => {
       <BookingModal
         isOpen={bookingSlot !== null}
         onClose={() => {
+          if (pendingConfirm) return;
           setBookingSlot(null);
           clearBookingError();
         }}
         onConfirm={handleBookConfirm}
         slot={bookingSlot}
         loading={bookingLoading}
+        pendingConfirm={pendingConfirm}
+        onResolveConfirm={resolvePendingConfirm}
       />
     </div>
   );

--- a/frontend/src/components/signup/MyMatches.jsx
+++ b/frontend/src/components/signup/MyMatches.jsx
@@ -41,7 +41,7 @@ const formatDateDisplay = (dateStr) => {
 const MyMatches = () => {
   const navigate = useNavigate();
   const { getToken } = useAccessToken();
-  const { fetchTeeTimes, bookTeeTime, bookingLoading, bookingError, clearBookingError } = useTeeTimes();
+  const { fetchTeeTimes, bookTeeTime, bookingLoading, bookingError, clearBookingError, pendingConfirm, resolvePendingConfirm } = useTeeTimes();
 
   const [matches, setMatches] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -501,10 +501,16 @@ const MyMatches = () => {
       {/* Booking Modal */}
       <BookingModal
         isOpen={bookingSlot !== null}
-        onClose={() => { setBookingSlot(null); clearBookingError(); }}
+        onClose={() => {
+          if (pendingConfirm) return;
+          setBookingSlot(null);
+          clearBookingError();
+        }}
         onConfirm={handleBookConfirm}
         slot={bookingSlot}
         loading={bookingLoading}
+        pendingConfirm={pendingConfirm}
+        onResolveConfirm={resolvePendingConfirm}
       />
     </div>
   );

--- a/frontend/src/hooks/useTeeTimes.js
+++ b/frontend/src/hooks/useTeeTimes.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { acquireAccessToken } from '../services/authToken';
 import { apiConfig } from '../config/api.config';
@@ -14,6 +14,8 @@ const useTeeTimes = () => {
   const [bookingLoading, setBookingLoading] = useState(false);
   const [bookingError, setBookingError] = useState(null);
   const [credentialsStatus, setCredentialsStatus] = useState(null);
+  const [pendingConfirm, setPendingConfirm] = useState(null);
+  const confirmResolverRef = useRef(null);
 
   const clearError = useCallback(() => setError(null), []);
   const clearBookingError = useCallback(() => setBookingError(null), []);
@@ -29,6 +31,45 @@ const useTeeTimes = () => {
       },
     });
   }, [getAccessTokenSilently]);
+
+  const resolvePendingConfirm = useCallback((approved) => {
+    const resolver = confirmResolverRef.current;
+    confirmResolverRef.current = null;
+    setPendingConfirm(null);
+    if (resolver) resolver(approved);
+  }, []);
+
+  const waitForUserConfirm = useCallback((confirmPayload) => {
+    setPendingConfirm(confirmPayload);
+    setBookingLoading(false);
+    return new Promise((resolve) => {
+      confirmResolverRef.current = resolve;
+    });
+  }, []);
+
+  const runWithConfirmLoop = useCallback(async (initialJson) => {
+    let json = initialJson;
+    // Computer Use agent may pause multiple times (login, then submit, plus safety).
+    while (json?.data?.status === 'needs_confirmation') {
+      const approved = await waitForUserConfirm(json.data);
+      setBookingLoading(true);
+      if (!approved) {
+        setBookingError('Cancelled — confirmation denied');
+        return { denied: true, data: { success: false, status: 'failed', error: 'User denied confirmation' } };
+      }
+      const resp = await authFetch('/api/foretees/book/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ job_id: json.data.job_id, confirm: true }),
+      });
+      json = await resp.json();
+      if (!resp.ok && json?.data?.status !== 'needs_confirmation') {
+        setBookingError(json?.detail || json?.message || 'Booking confirmation failed');
+        return json;
+      }
+    }
+    return json;
+  }, [authFetch, waitForUserConfirm]);
 
   const fetchCredentialsStatus = useCallback(async () => {
     try {
@@ -104,15 +145,23 @@ const useTeeTimes = () => {
   const bookTeeTime = useCallback(async (ttdata, transportMode = 'WLK', date = null, time = null, players = null) => {
     setBookingLoading(true);
     setBookingError(null);
+    setPendingConfirm(null);
     try {
       const resp = await authFetch('/api/foretees/book', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ttdata, transport_mode: transportMode, date, time, players }),
       });
-      const json = await resp.json();
-      if (!resp.ok) {
+      let json = await resp.json();
+      if (!resp.ok && json?.data?.status !== 'needs_confirmation') {
         setBookingError(json?.detail || json?.message || 'Booking failed');
+        return json;
+      }
+      json = await runWithConfirmLoop(json);
+      if (!json?.denied && !(json?.data?.success || json?.success) && json?.data?.status !== 'needs_confirmation') {
+        if (!json?.denied) {
+          setBookingError(json?.detail || json?.message || json?.data?.error || 'Booking failed');
+        }
       }
       return json;
     } catch (err) {
@@ -120,21 +169,28 @@ const useTeeTimes = () => {
       return null;
     } finally {
       setBookingLoading(false);
+      setPendingConfirm(null);
     }
-  }, [authFetch]);
+  }, [authFetch, runWithConfirmLoop]);
 
   const cancelTeeTime = useCallback(async (date, time, ttdata) => {
     setBookingLoading(true);
     setBookingError(null);
+    setPendingConfirm(null);
     try {
       const resp = await authFetch('/api/foretees/cancel', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ date, time, ttdata }),
       });
-      const json = await resp.json();
-      if (!resp.ok) {
+      let json = await resp.json();
+      if (!resp.ok && json?.data?.status !== 'needs_confirmation') {
         setBookingError(json?.detail || json?.message || 'Cancellation failed');
+        return json;
+      }
+      json = await runWithConfirmLoop(json);
+      if (!json?.denied && !(json?.data?.success || json?.success)) {
+        setBookingError(json?.detail || json?.message || json?.data?.error || 'Cancellation failed');
       }
       return json;
     } catch (err) {
@@ -142,8 +198,9 @@ const useTeeTimes = () => {
       return null;
     } finally {
       setBookingLoading(false);
+      setPendingConfirm(null);
     }
-  }, [authFetch]);
+  }, [authFetch, runWithConfirmLoop]);
 
   return {
     teeTimes,
@@ -162,6 +219,8 @@ const useTeeTimes = () => {
     fetchCredentialsStatus,
     saveCredentials,
     removeCredentials,
+    pendingConfirm,
+    resolvePendingConfirm,
   };
 };
 


### PR DESCRIPTION
## Summary
- Add `booking-agent` (Vertex Gemini Computer Use + Playwright) on Cloud Run (`wgp-booking`)
- FastAPI + SPA confirm loop for login / final submit / safety gates
- Point production `BOOKING_SERVICE_URL` at GCP; Render booking can be suspended after soak

## Test plan
- [x] Frontend: typecheck + vitest + build
- [x] Backend: ruff + pytest
- [x] `wgp-booking` `/health` 200; secret auth 401/400 verified
- [ ] After merge deploy: `/api/foretees/book/confirm` returns 401 (not 404) for junk token
- [ ] SPA smoke: book/cancel with Allow on login + submit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added approval prompts during tee-time booking and cancellation when additional confirmation is required.
  - Confirmation dialogs display an explanation and optional screenshot, with Allow and Deny actions.
  - Booking and cancellation workflows now resume after each approval and report completion or failure.
  - Added a new Computer Use booking agent for automated ForeTees interactions.

- **Documentation**
  - Added setup, deployment, architecture, and operational guidance for the new booking service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->