### PR TITLE
chore(deploy): auto-deploy Computer Use booking agent on push

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -1,17 +1,15 @@
 name: Deploy to GCP
 
-# Deploys the FastAPI backend to Cloud Run via the Cloud Build pipeline
-# (deploy/gcp/cloudbuild.yaml) and the React SPA to Firebase Hosting,
-# authenticating keylessly through Workload Identity Federation — no
-# service-account JSON key.
+# Deploys:
+#   - FastAPI backend → Cloud Run (cloudbuild.yaml)
+#   - React SPA → Firebase Hosting
+#   - Computer Use booking agent → Cloud Run (cloudbuild-booking.yaml)
+# Auth: Workload Identity Federation (no SA JSON key).
 #
 # Triggers:
 #   - workflow_dispatch — always available (manual button), never surprises.
-#   - push to main      — deploys backend and/or frontend when the matching
-#                         paths change AND the repo variable GCP_AUTO_DEPLOY
-#                         == "true". Unset (the default) = the push run starts
-#                         but deploy jobs are skipped, so a merge can never
-#                         surprise-deploy until you opt in.
+#   - push to main      — deploys matching targets when paths change AND
+#                         GCP_AUTO_DEPLOY == "true".
 #
 # Prerequisites (one-time, see deploy/gcp/README.md):
 #   - Run deploy/gcp/phase0-foundation/*.sh  (incl. 25-cloud-build-iam.sh)
@@ -31,11 +29,16 @@ on:
         description: "Build + deploy the React SPA to Firebase Hosting (Phase 3)"
         type: boolean
         default: false
+      deploy_booking:
+        description: "Build + deploy the Computer Use booking agent (Phase 7)"
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
       - "backend/**"
       - "frontend/**"
+      - "booking-agent/**"
       - "deploy/gcp/**"
       - ".github/workflows/deploy-gcp.yml"
 
@@ -45,17 +48,18 @@ permissions:
 
 env:
   RUN_SERVICE: wolf-goat-pig-api
+  BOOKING_SERVICE: wgp-booking
 
 jobs:
-  # Path filter so a frontend-only push does not rebuild Cloud Run and a
-  # backend-only push does not rebuild Firebase Hosting. Skipped on
-  # workflow_dispatch (manual checkboxes decide).
+  # Path filter so each target only rebuilds when its sources change.
+  # Skipped on workflow_dispatch (manual checkboxes decide).
   changes:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      booking: ${{ steps.filter.outputs.booking }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -70,16 +74,19 @@ jobs:
               - 'deploy/gcp/phase2-cloud-sql/**'
               - 'deploy/gcp/phase4-scheduling/**'
               - 'deploy/gcp/phase5-storage/**'
-              - 'deploy/gcp/phase7-booking/**'
               - '.github/workflows/deploy-gcp.yml'
             frontend:
               - 'frontend/**'
               - 'deploy/gcp/phase3-hosting/**'
               - '.github/workflows/deploy-gcp.yml'
+            booking:
+              - 'booking-agent/**'
+              - 'deploy/gcp/cloudbuild-booking.yaml'
+              - 'deploy/gcp/phase7-booking/**'
+              - '.github/workflows/deploy-gcp.yml'
 
   deploy-backend:
     needs: [changes]
-    # workflow_dispatch: honor the checkbox. push: only if opted in + paths match.
     # `always()` so a skipped `changes` job (manual run) does not cancel this job.
     if: >-
       ${{ always() &&
@@ -211,3 +218,75 @@ jobs:
           firebase deploy --only hosting \
             --project "${{ vars.GCP_PROJECT_ID }}" \
             --non-interactive
+
+  deploy-booking:
+    needs: [changes]
+    if: >-
+      ${{ always() &&
+          (needs.changes.result == 'success' || needs.changes.result == 'skipped') &&
+          ((github.event_name == 'workflow_dispatch' && inputs.deploy_booking) ||
+           (github.event_name == 'push' && vars.GCP_AUTO_DEPLOY == 'true' &&
+            needs.changes.outputs.booking == 'true')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to GCP (keyless, WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOYER_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build & deploy booking agent via Cloud Build
+        run: |
+          set -euo pipefail
+          PROJECT="${{ vars.GCP_PROJECT_ID }}"
+          REGION="${{ vars.GCP_REGION }}"
+          BUILD_ID="$(
+            gcloud builds submit \
+              --async \
+              --project="${PROJECT}" \
+              --region="${REGION}" \
+              --config=deploy/gcp/cloudbuild-booking.yaml \
+              --substitutions="SHORT_SHA=${GITHUB_SHA::12},_REGION=${REGION}" \
+              --format='value(id)' \
+              .
+          )"
+          echo "Cloud Build id: ${BUILD_ID}"
+          for attempt in $(seq 1 60); do
+            STATUS="$(
+              gcloud builds describe "${BUILD_ID}" \
+                --project="${PROJECT}" \
+                --region="${REGION}" \
+                --format='value(status)'
+            )"
+            echo "[$attempt] build status=${STATUS}"
+            case "${STATUS}" in
+              SUCCESS) exit 0 ;;
+              FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED)
+                gcloud builds log "${BUILD_ID}" --project="${PROJECT}" --region="${REGION}" | tail -80
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+          echo "Timed out waiting for Cloud Build ${BUILD_ID}"
+          exit 1
+
+      - name: Smoke test /health
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${BOOKING_SERVICE}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" --region="${{ vars.GCP_REGION }}" \
+            --format='value(status.url)')"
+          echo "Booking URL: ${URL}"
+          code="$(curl -sS -o /tmp/booking-health.json -w '%{http_code}' "${URL}/health")"
+          echo "GET /health -> ${code}"
+          cat /tmp/booking-health.json
+          test "${code}" = "200"
+          grep -q '"status"[[:space:]]*:[[:space:]]*"ok"' /tmp/booking-health.json

--- a/deploy/gcp/DECOMMISSION.md
+++ b/deploy/gcp/DECOMMISSION.md
@@ -48,7 +48,9 @@ Remove all `*.vercel.app` entries.
 
 1. https://dashboard.render.com → `wolf-goat-pig` web service → **Suspend**
 2. Leave the Postgres instance running for ~7 days
-3. Booking microservice (`wolf-goat-pig-booking`) — leave running if ForeTees booking is still needed; it is still referenced by Cloud Run `BOOKING_SERVICE_URL`
+3. Booking microservice (`wolf-goat-pig-booking`) — **no longer needed for prod**
+   (API `BOOKING_SERVICE_URL` → `wgp-booking` on Cloud Run). Suspend after a
+   successful book+cancel soak on the Computer Use agent.
 
 ```bash
 render login

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -99,8 +99,10 @@ export INTERNAL_JOB_TOKEN="$(gcloud secrets versions access latest --secret=INTE
 ./deploy/gcp/phase6-monitoring/30-alert-policies.sh
 
 # Phase 7 — ForeTees booking via Computer Use (replaces Render booking-service)
-./deploy/gcp/phase7-booking/10-deploy.sh
+# With GCP_AUTO_DEPLOY=true, booking-agent/** pushes deploy wgp-booking.
+# Manual: Actions → deploy_booking=true  or  ./phase7-booking/10-deploy.sh
 # then set BOOKING_SERVICE_URL on wolf-goat-pig-api to the printed URL
+# (already set in phase1-cloud-run/env.production.yaml for production)
 ```
 
 ## GitHub Actions variables

--- a/deploy/gcp/cloudbuild-booking.yaml
+++ b/deploy/gcp/cloudbuild-booking.yaml
@@ -1,0 +1,69 @@
+# Cloud Build pipeline — build the Computer Use booking agent, push to Artifact
+# Registry, and deploy to Cloud Run (`wgp-booking`).
+#
+# Run:
+#   gcloud builds submit --config deploy/gcp/cloudbuild-booking.yaml \
+#     --substitutions=SHORT_SHA=$(git rev-parse --short HEAD) .
+# Or via GitHub Actions "Deploy to GCP" (deploy_booking / booking-agent/** push).
+
+substitutions:
+  _REGION: us-central1
+  _AR_REPO: wolf-goat-pig
+  _SERVICE: wgp-booking
+  _RUNTIME_SA_NAME: wgp-run
+  _SECRETS: "BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest"
+  # Vertex model for Gemini Computer Use (global endpoint).
+  _COMPUTER_USE_MODEL: gemini-3.5-flash
+
+images:
+  - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:${SHORT_SHA}"
+  - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:latest"
+
+steps:
+  - id: build
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - booking-agent/Dockerfile
+      - -t
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:${SHORT_SHA}"
+      - -t
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:latest"
+      - booking-agent
+
+  - id: push
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - --all-tags
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}"
+
+  - id: deploy
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - "${_SERVICE}"
+      - --project=${PROJECT_ID}
+      - --region=${_REGION}
+      - --image=${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:${SHORT_SHA}
+      - --service-account=${_RUNTIME_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+      - --allow-unauthenticated
+      - --session-affinity
+      - --min-instances=0
+      - --max-instances=2
+      - --cpu=2
+      - --memory=2Gi
+      - --timeout=300
+      - --concurrency=1
+      - --port=8080
+      - --set-env-vars=GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=global,COMPUTER_USE_MODEL=${_COMPUTER_USE_MODEL},HEADLESS=true
+      - --set-secrets=${_SECRETS}
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+# Chromium + Playwright image build is the slow part.
+timeout: 1800s

--- a/deploy/gcp/phase7-booking/10-deploy.sh
+++ b/deploy/gcp/phase7-booking/10-deploy.sh
@@ -10,8 +10,6 @@ require_config GCP_PROJECT_ID GCP_REGION RUNTIME_SA_NAME
 
 REPO_ROOT="$(cd "${GCP_DIR}/../.." && pwd)"
 SERVICE="${BOOKING_RUN_SERVICE:-wgp-booking}"
-AR_REPO="${AR_REPO:-wolf-goat-pig}"
-IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${AR_REPO}/${SERVICE}:$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
 RUNTIME_SA="${RUNTIME_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
 
 log "Ensuring Vertex AI API…"
@@ -23,30 +21,13 @@ gc projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
   --role="roles/aiplatform.user" \
   --condition=None >/dev/null || true
 
-log "Building ${IMAGE}…"
+log "Building + deploying ${SERVICE} via Cloud Build…"
 gc builds submit \
   --project="${GCP_PROJECT_ID}" \
   --region="${GCP_REGION}" \
-  --tag="${IMAGE}" \
-  "${REPO_ROOT}/booking-agent"
-
-log "Deploying Cloud Run service ${SERVICE}…"
-gc run deploy "${SERVICE}" \
-  --project="${GCP_PROJECT_ID}" \
-  --region="${GCP_REGION}" \
-  --image="${IMAGE}" \
-  --service-account="${RUNTIME_SA}" \
-  --allow-unauthenticated \
-  --session-affinity \
-  --min-instances=0 \
-  --max-instances=2 \
-  --cpu=2 \
-  --memory=2Gi \
-  --timeout=300 \
-  --concurrency=1 \
-  --port=8080 \
-  --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},GCP_LOCATION=global,COMPUTER_USE_MODEL=gemini-3.5-flash,HEADLESS=true" \
-  --set-secrets="BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest"
+  --config="${GCP_DIR}/cloudbuild-booking.yaml" \
+  --substitutions="SHORT_SHA=$(git -C "${REPO_ROOT}" rev-parse --short HEAD),_REGION=${GCP_REGION}" \
+  "${REPO_ROOT}"
 
 URL="$(gc run services describe "${SERVICE}" --region="${GCP_REGION}" --format='value(status.url)')"
 ok "Booking agent live at ${URL}"

--- a/deploy/gcp/phase7-booking/README.md
+++ b/deploy/gcp/phase7-booking/README.md
@@ -6,12 +6,21 @@ Computer Use. Design: [`docs/architecture/COMPUTER_USE_BOOKING.md`](../../../doc
 
 ## Deploy
 
+**Auto on push to `main`** when `GCP_AUTO_DEPLOY=true` and `booking-agent/**`
+(or this directory / `cloudbuild-booking.yaml`) changes.
+
+Manual:
+
 ```bash
 source deploy/gcp/config.env
 ./deploy/gcp/phase7-booking/10-deploy.sh
 ```
 
-Then point the main API at the new service:
+Or **Actions → Deploy to GCP → Run workflow** with `deploy_booking = true`
+(uses `deploy/gcp/cloudbuild-booking.yaml`).
+
+Then point the main API at the new service (already set in
+`phase1-cloud-run/env.production.yaml` for production):
 
 ```bash
 # After first deploy prints the URL:


### PR DESCRIPTION
## Summary
- Add `deploy/gcp/cloudbuild-booking.yaml` (build Playwright image → push → Cloud Run `wgp-booking` with session affinity / 2Gi / concurrency 1).
- Wire `deploy-booking` into Deploy to GCP: auto on `booking-agent/**` push when `GCP_AUTO_DEPLOY=true`, plus a manual checkbox.
- Point local `phase7-booking/10-deploy.sh` at the same Cloud Build config so local and CI stay in sync.

`wgp-booking` is already live and `BOOKING_SERVICE_URL` on the API already points at it — this only automates redeploys.

## Test plan
- [ ] Merge — expect `deploy-booking` (and likely frontend/backend because the workflow file is shared) on the push to main
- [ ] Confirm `/health` on https://wgp-booking-i5v2shrpoa-uc.a.run.app returns `{"status":"ok"}`
- [ ] Optional: SPA book/cancel smoke with confirm gates
- [ ] After soak: suspend Render `wolf-goat-pig-booking`