### PR TITLE
feat(booking-agent): POST /tee-times day sheet under member login

### DIFF
--- a/booking-agent/README.md
+++ b/booking-agent/README.md
@@ -25,3 +25,11 @@ uvicorn app.main:app --reload --port 8080
 - `POST /book` — start book job (Bearer `BOOKING_SERVICE_SECRET`)
 - `POST /cancel` — start cancel job
 - `POST /jobs/{job_id}/confirm` — `{ "confirm": true|false }`
+- `POST /tee-times` — list day's slots + players (body: `username`, `password`, `date`; httpx scrape, not Computer Use)
+
+```bash
+curl -sS -X POST "$BOOKING_URL/tee-times" \
+  -H "Authorization: Bearer $BOOKING_SERVICE_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"…","password":"…","date":"2026-07-28"}'
+```

--- a/booking-agent/app/main.py
+++ b/booking-agent/app/main.py
@@ -6,11 +6,13 @@ import logging
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from .agent import confirm_job, start_job
 from .config import get_settings
 from .jobs import JobKind, job_store
+from .tee_sheet import ForeteesAuthError, ForeteesSheetError, fetch_tee_times
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
 logger = logging.getLogger("booking_agent")
@@ -33,6 +35,12 @@ class CancelRequest(BaseModel):
     date: str = ""
     time: str = ""
     ttdata: str | None = None
+
+
+class TeeTimesRequest(BaseModel):
+    username: str
+    password: str
+    date: str
 
 
 class ConfirmRequest(BaseModel):
@@ -60,6 +68,35 @@ async def _startup() -> None:
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.post("/tee-times")
+async def tee_times(
+    body: TeeTimesRequest,
+    authorization: str | None = Header(default=None),
+) -> Any:
+    _check_auth(authorization)
+    username = body.username.strip()
+    date = body.date.strip()
+    if not username or not body.password:
+        raise HTTPException(status_code=400, detail="username and password required")
+    if not date:
+        raise HTTPException(status_code=400, detail="date required (YYYY-MM-DD)")
+    try:
+        slots = await fetch_tee_times(username, body.password, date)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ForeteesAuthError:
+        return JSONResponse(
+            status_code=502,
+            content={"status": "failed", "error": "foretees_auth_failed"},
+        )
+    except ForeteesSheetError:
+        return JSONResponse(
+            status_code=502,
+            content={"status": "failed", "error": "foretees_sheet_failed"},
+        )
+    return {"status": "ok", "date": date, "slots": slots}
 
 
 @app.post("/book")

--- a/booking-agent/app/tee_sheet.py
+++ b/booking-agent/app/tee_sheet.py
@@ -6,9 +6,98 @@ import html
 import json
 import logging
 import re
+from datetime import datetime
 from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from app.config import Settings, get_settings
 
 logger = logging.getLogger(__name__)
+
+
+class ForeteesAuthError(Exception):
+    """Raised when Wing Point or ForeTees authentication fails."""
+
+
+class ForeteesSheetError(Exception):
+    """Raised when the ForeTees Member_sheet request fails."""
+
+
+def _build_url(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _validate_sheet_date(date: str) -> str:
+    dt = datetime.strptime(date, "%Y-%m-%d")
+    return dt.strftime("%m/%d/%Y")
+
+
+async def fetch_tee_times(
+    username: str,
+    password: str,
+    date: str,
+    *,
+    settings: Settings | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch and parse a member tee sheet through the Wing Point ForeTees SSO flow."""
+    ft_date = _validate_sheet_date(date)
+    resolved_settings = settings or get_settings()
+
+    login_url = _build_url(resolved_settings.wingpoint_base, resolved_settings.login_page)
+    tee_time_url = _build_url(resolved_settings.wingpoint_base, resolved_settings.tee_time_page)
+    foretees_base = resolved_settings.foretees_base.rstrip("/")
+
+    async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
+        try:
+            login_resp = await client.get(login_url)
+            login_resp.raise_for_status()
+
+            login_post_resp = await client.post(
+                login_url,
+                data={
+                    "UserLOGIN": username,
+                    "UserPWD": password,
+                    "btnLogon": "Log On",
+                    "Action": "Authenticate",
+                    "DocID": "465",
+                    "LogonRequest": "",
+                    "R": "0",
+                },
+                headers={"Referer": login_url},
+            )
+            login_post_resp.raise_for_status()
+
+            tee_page_resp = await client.get(tee_time_url)
+            tee_page_resp.raise_for_status()
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            raise ForeteesAuthError("ForeTees authentication request failed") from exc
+
+        sso_key_match = re.search(r"ftSSOKey\s*=\s*'([^']+)'", tee_page_resp.text)
+        sso_iv_match = re.search(r"ftSSOIV\s*=\s*'([^']+)'", tee_page_resp.text)
+        if not sso_key_match or not sso_iv_match:
+            raise ForeteesAuthError("ForeTees SSO parameters were not found")
+
+        sso_key = sso_key_match.group(1)
+        sso_iv = sso_iv_match.group(1)
+        try:
+            sso_url = f"{foretees_base}/Member_select?sso_uid={quote(sso_key)}&sso_iv={quote(sso_iv)}"
+            sso_resp = await client.get(sso_url)
+            sso_resp.raise_for_status()
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            raise ForeteesAuthError("ForeTees SSO request failed") from exc
+
+        try:
+            sheet_resp = await client.get(
+                f"{foretees_base}/Member_sheet",
+                params={"calDate": ft_date, "course": "", "displayOpt": "0"},
+            )
+            sheet_resp.raise_for_status()
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            raise ForeteesSheetError("ForeTees sheet request failed") from exc
+
+    return parse_tee_sheet(sheet_resp.text, date)
 
 
 def parse_tee_sheet(html_content: str, date: str) -> list[dict[str, Any]]:

--- a/booking-agent/app/tee_sheet.py
+++ b/booking-agent/app/tee_sheet.py
@@ -1,0 +1,114 @@
+"""ForeTees Member_sheet HTML parser."""
+
+from __future__ import annotations
+
+import html
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def parse_tee_sheet(html_content: str, date: str) -> list[dict[str, Any]]:
+    """Parse the Member_sheet HTML to extract tee time data.
+
+    The key data lives in data-ftjson attributes on time slot links:
+    <a class="teetime_button" data-ftjson="{...}">11:00 AM</a>
+
+    Player transport modes are in sibling divs:
+    <div><span>Player Name</span><span>PC</span></div>
+    """
+    slots: list[dict[str, Any]] = []
+
+    pattern = re.compile(r'data-ftjson="([^"]+)"')
+    matches = pattern.findall(html_content)
+
+    row_pattern = re.compile(
+        r'<div\s+class="rwdTr[^"]*">(.*?)</div>\s*(?=<div\s+class="rwdTr|$)',
+        re.DOTALL,
+    )
+    rows = row_pattern.findall(html_content)
+
+    transport_map: dict[int, list[str]] = {}
+    player_transport_pattern = re.compile(
+        r'class="rwdTd pgCol">\s*<div>\s*<span>([^<]+)</span>\s*<span>([^<]*)</span>',
+    )
+
+    for row_html in rows:
+        ftjson_match = pattern.search(row_html)
+        if not ftjson_match:
+            continue
+        try:
+            row_data = json.loads(html.unescape(ftjson_match.group(1)))
+            jump = row_data.get("jump", 0)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        transports = []
+        for _name, mode in player_transport_pattern.findall(row_html):
+            transports.append(mode.strip())
+        transport_map[jump] = transports
+
+    open_slots_pattern = re.compile(
+        r'class="slotCount[^"]*openSlots(\d+)\s+maxPlayers(\d+)"',
+    )
+    open_slots_map: dict[int, dict[str, int]] = {}
+    for row_html in rows:
+        ftjson_match = pattern.search(row_html)
+        if not ftjson_match:
+            continue
+        try:
+            row_data = json.loads(html.unescape(ftjson_match.group(1)))
+            jump = row_data.get("jump", 0)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        slots_match = open_slots_pattern.search(row_html)
+        if slots_match:
+            open_slots_map[jump] = {
+                "open_slots": int(slots_match.group(1)),
+                "max_players": int(slots_match.group(2)),
+            }
+
+    for raw_json in matches:
+        try:
+            data = json.loads(html.unescape(raw_json))
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        if data.get("type") != "Member_slot":
+            continue
+
+        players = []
+        for i in range(1, 6):
+            name = data.get(f"wasP{i}", "")
+            if name:
+                transport = ""
+                jump = data.get("jump", 0)
+                transports = transport_map.get(jump, [])
+                if i - 1 < len(transports):
+                    transport = transports[i - 1]
+                players.append({"name": name, "transport": transport})
+
+        slot_info = open_slots_map.get(data.get("jump", 0), {})
+        max_players = slot_info.get("max_players", 4)
+        open_count = max_players - len(players)
+
+        slots.append(
+            {
+                "date": date,
+                "time": data.get("time:0", ""),
+                "front_back": "F",
+                "players": players,
+                "open_slots": open_count,
+                "max_players": max_players,
+                "ttdata": data.get("ttdata", ""),
+                "jump": data.get("jump", 0),
+                "p5_allowed": data.get("p5", "No") == "Yes",
+            }
+        )
+
+    logger.info("Parsed %d tee time slots for %s", len(slots), date)
+    return slots

--- a/booking-agent/requirements-testing.txt
+++ b/booking-agent/requirements-testing.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.24.0
+respx>=0.21.0
+httpx>=0.27.0

--- a/booking-agent/requirements.txt
+++ b/booking-agent/requirements.txt
@@ -4,3 +4,4 @@ pydantic>=2.9.0
 pydantic-settings>=2.6.0
 playwright>=1.49.0
 google-genai>=1.20.0
+httpx>=0.27.0

--- a/booking-agent/tests/conftest.py
+++ b/booking-agent/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/booking-agent/tests/fixtures/member_sheet_sample.html
+++ b/booking-agent/tests/fixtures/member_sheet_sample.html
@@ -1,0 +1,8 @@
+<div class="rwdTr">
+  <a class="teetime_button" data-ftjson="{&quot;type&quot;:&quot;Member_slot&quot;,&quot;time:0&quot;:&quot;11:00 AM&quot;,&quot;ttdata&quot;:&quot;abc123&quot;,&quot;jump&quot;:7,&quot;p5&quot;:&quot;No&quot;,&quot;wasP1&quot;:&quot;Jane D&quot;,&quot;wasP2&quot;:&quot;&quot;,&quot;wasP3&quot;:&quot;&quot;,&quot;wasP4&quot;:&quot;&quot;,&quot;wasP5&quot;:&quot;&quot;}">11:00 AM</a>
+  <div class="rwdTd pgCol"><div><span>Jane D</span><span>WLK</span></div></div>
+  <div class="slotCount openSlots3 maxPlayers4"></div>
+</div>
+<div class="rwdTr">
+  <a class="teetime_button" data-ftjson="{&quot;type&quot;:&quot;Other&quot;,&quot;jump&quot;:8}">ignore</a>
+</div>

--- a/booking-agent/tests/test_tee_sheet_fetch.py
+++ b/booking-agent/tests/test_tee_sheet_fetch.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from app.config import Settings
+from app.tee_sheet import ForeteesAuthError, ForeteesSheetError, fetch_tee_times
+
+settings = Settings(
+    wingpoint_base="https://www.wingpointgolf.com",
+    login_page="/public/member-login-465.html",
+    tee_time_page="/members/golf/make-a-tee-time-703.html",
+    foretees_base="https://ftapp.example/v5/club",
+)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_tee_times_happy_path(tmp_path):
+    html = (Path(__file__).parent / "fixtures" / "member_sheet_sample.html").read_text()
+    respx.get("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="login")
+    )
+    respx.post("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="ok")
+    )
+    respx.get("https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html").mock(
+        return_value=httpx.Response(
+            200,
+            text="var ftSSOKey = 'KEY'; var ftSSOIV = 'IV';",
+        )
+    )
+    respx.get("https://ftapp.example/v5/club/Member_select").mock(
+        return_value=httpx.Response(200, text="sso")
+    )
+    respx.get("https://ftapp.example/v5/club/Member_sheet").mock(
+        return_value=httpx.Response(200, text=html)
+    )
+
+    slots = await fetch_tee_times("u", "p", "2026-07-28", settings=settings)
+    assert len(slots) == 1
+    assert slots[0]["time"] == "11:00 AM"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_tee_times_auth_fails_without_sso():
+    respx.get("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="login")
+    )
+    respx.post("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="ok")
+    )
+    respx.get("https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html").mock(
+        return_value=httpx.Response(200, text="no sso vars here")
+    )
+    with pytest.raises(ForeteesAuthError):
+        await fetch_tee_times("u", "p", "2026-07-28", settings=settings)
+
+
+@pytest.mark.asyncio
+async def test_fetch_tee_times_rejects_invalid_date():
+    with pytest.raises(ValueError):
+        await fetch_tee_times("u", "p", "07/28/2026", settings=settings)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_tee_times_sheet_http_error_is_typed():
+    respx.get("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="login")
+    )
+    respx.post("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="ok")
+    )
+    respx.get("https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html").mock(
+        return_value=httpx.Response(
+            200,
+            text="var ftSSOKey = 'KEY'; var ftSSOIV = 'IV';",
+        )
+    )
+    respx.get("https://ftapp.example/v5/club/Member_select").mock(
+        return_value=httpx.Response(200, text="sso")
+    )
+    respx.get("https://ftapp.example/v5/club/Member_sheet").mock(
+        return_value=httpx.Response(500, text="down")
+    )
+
+    with pytest.raises(ForeteesSheetError):
+        await fetch_tee_times("u", "p", "2026-07-28", settings=settings)

--- a/booking-agent/tests/test_tee_sheet_parse.py
+++ b/booking-agent/tests/test_tee_sheet_parse.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from app.tee_sheet import parse_tee_sheet
+
+FIXTURE = Path(__file__).parent / "fixtures" / "member_sheet_sample.html"
+
+
+def test_parse_tee_sheet_extracts_players_and_open_slots():
+    html = FIXTURE.read_text()
+    slots = parse_tee_sheet(html, "2026-07-28")
+    assert len(slots) == 1
+    slot = slots[0]
+    assert slot["date"] == "2026-07-28"
+    assert slot["time"] == "11:00 AM"
+    assert slot["ttdata"] == "abc123"
+    assert slot["jump"] == 7
+    assert slot["p5_allowed"] is False
+    assert slot["players"] == [{"name": "Jane D", "transport": "WLK"}]
+    assert slot["max_players"] == 4
+    assert slot["open_slots"] == 3
+    assert slot["front_back"] == "F"
+
+
+def test_parse_tee_sheet_skips_non_member_slot():
+    html = '<a data-ftjson="{&quot;type&quot;:&quot;Event&quot;,&quot;jump&quot;:1}"></a>'
+    assert parse_tee_sheet(html, "2026-07-28") == []

--- a/booking-agent/tests/test_tee_times_endpoint.py
+++ b/booking-agent/tests/test_tee_times_endpoint.py
@@ -1,0 +1,129 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import get_settings
+from app.main import app
+from app.tee_sheet import ForeteesAuthError, ForeteesSheetError
+
+AUTH_HEADERS = {"Authorization": "Bearer test-secret"}
+TEE_TIMES_PAYLOAD = {"username": "u", "password": "p", "date": "2026-07-28"}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("BOOKING_SERVICE_SECRET", "test-secret")
+
+    get_settings.cache_clear()
+    with TestClient(app) as c:
+        yield c
+    get_settings.cache_clear()
+
+
+def test_tee_times_unauthorized(client):
+    resp = client.post(
+        "/tee-times",
+        json=TEE_TIMES_PAYLOAD,
+    )
+    assert resp.status_code == 401
+
+
+def test_tee_times_missing_creds(client):
+    resp = client.post(
+        "/tee-times",
+        headers=AUTH_HEADERS,
+        json={**TEE_TIMES_PAYLOAD, "username": ""},
+    )
+    assert resp.status_code == 400
+
+
+def test_tee_times_missing_date(client):
+    resp = client.post(
+        "/tee-times",
+        headers=AUTH_HEADERS,
+        json={**TEE_TIMES_PAYLOAD, "date": " "},
+    )
+    assert resp.status_code == 400
+
+
+def test_tee_times_ok(client):
+    slots = [
+        {
+            "date": "2026-07-28",
+            "time": "11:00 AM",
+            "front_back": "F",
+            "players": [{"name": "Jane D", "transport": "WLK"}],
+            "open_slots": 3,
+            "max_players": 4,
+            "ttdata": "abc",
+            "jump": 7,
+            "p5_allowed": False,
+        }
+    ]
+    with patch("app.main.fetch_tee_times", new=AsyncMock(return_value=slots)):
+        resp = client.post(
+            "/tee-times",
+            headers=AUTH_HEADERS,
+            json=TEE_TIMES_PAYLOAD,
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["date"] == "2026-07-28"
+    assert body["slots"] == slots
+
+
+def test_tee_times_strips_username_and_date(client):
+    slots = []
+    fetch_mock = AsyncMock(return_value=slots)
+    with patch("app.main.fetch_tee_times", new=fetch_mock):
+        resp = client.post(
+            "/tee-times",
+            headers=AUTH_HEADERS,
+            json={"username": " u ", "password": "p", "date": " 2026-07-28 "},
+        )
+    assert resp.status_code == 200
+    fetch_mock.assert_awaited_once_with("u", "p", "2026-07-28")
+    assert resp.json() == {"status": "ok", "date": "2026-07-28", "slots": slots}
+
+
+def test_tee_times_value_error_is_400(client):
+    with patch(
+        "app.main.fetch_tee_times",
+        new=AsyncMock(side_effect=ValueError("invalid date")),
+    ):
+        resp = client.post(
+            "/tee-times",
+            headers=AUTH_HEADERS,
+            json={**TEE_TIMES_PAYLOAD, "date": "not-a-date"},
+        )
+    assert resp.status_code == 400
+
+
+def test_tee_times_auth_failure_is_502(client):
+    with patch(
+        "app.main.fetch_tee_times",
+        new=AsyncMock(side_effect=ForeteesAuthError("no sso")),
+    ):
+        resp = client.post(
+            "/tee-times",
+            headers=AUTH_HEADERS,
+            json=TEE_TIMES_PAYLOAD,
+        )
+    assert resp.status_code == 502
+    assert resp.json() == {"status": "failed", "error": "foretees_auth_failed"}
+
+
+def test_tee_times_sheet_failure_is_502(client):
+    with patch(
+        "app.main.fetch_tee_times",
+        new=AsyncMock(side_effect=ForeteesSheetError("sheet unavailable")),
+    ):
+        resp = client.post(
+            "/tee-times",
+            headers=AUTH_HEADERS,
+            json=TEE_TIMES_PAYLOAD,
+        )
+    assert resp.status_code == 502
+    assert resp.json() == {"status": "failed", "error": "foretees_sheet_failed"}

--- a/docs/architecture/COMPUTER_USE_BOOKING.md
+++ b/docs/architecture/COMPUTER_USE_BOOKING.md
@@ -41,6 +41,7 @@ Playwright executes `click_at` / `type_text_at` / etc. from model function calls
 | `POST` | `/book` | Start book job |
 | `POST` | `/cancel` | Start cancel job |
 | `POST` | `/jobs/{job_id}/confirm` | Resume after SPA confirm (`{ "confirm": true\|false }`) |
+| `POST` | `/tee-times` | List day sheet + players via httpx |
 
 ### Responses
 
@@ -91,5 +92,5 @@ See `deploy/gcp/phase7-booking/`.
 ## Non-goals
 
 - Same-origin Firebase `/api` rewrite.
-- Replacing ForeTees tee-sheet **reads** (those stay on FastAPI/httpx).
+- SPA/FastAPI still own the product list path (`GET /api/foretees/tee-times`); booking-agent also exposes `POST /tee-times` (httpx) for direct callers. Computer Use is not used for reads.
 - Auto-acking Google `require_confirmation` (forbidden by ToS).

--- a/docs/superpowers/plans/2026-07-28-booking-agent-tee-times.md
+++ b/docs/superpowers/plans/2026-07-28-booking-agent-tee-times.md
@@ -1,0 +1,529 @@
+# Booking-agent Tee-Times Read API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `POST /tee-times` on the booking agent so a caller can list a day's ForeTees slots and who is playing, under that member's credentials, via httpx scrape.
+
+**Architecture:** New `booking-agent/app/tee_sheet.py` ports Wingpoint login + ForeTees SSO + `Member_sheet` parse from the FastAPI ForeTees service. `main.py` exposes Bearer-authed `POST /tee-times`. SPA and FastAPI list paths stay unchanged. No Computer Use / Playwright for reads.
+
+**Tech Stack:** FastAPI, httpx, pydantic-settings, pytest, pytest-asyncio, respx (mocked httpx).
+
+**Spec:** `docs/superpowers/specs/2026-07-28-booking-agent-tee-times-design.md`
+
+## Global Constraints
+
+- Per-user ForeTees identity only: request body must include `username` and `password` (same pattern as `/book`).
+- Slot JSON field names must match FastAPI `_parse_tee_sheet`: `date`, `time`, `front_back`, `players` (`name`/`transport`), `open_slots`, `max_players`, `ttdata`, `jump`, `p5_allowed`.
+- Auth failure / sheet failure → HTTP `502` with `{ "status": "failed", "error": "…" }` — never disguise as empty `slots`.
+- Empty `slots` only when auth + fetch succeeded and the sheet has no `Member_slot` rows.
+- Do not import `backend/` packages into booking-agent.
+- Do not wire SPA or FastAPI to this endpoint in this plan.
+- NEVER edit source containing `!` via shell heredoc/perl/zsh — use Edit/Write tools.
+- Booking-agent tests: `cd booking-agent && python -m pytest tests/ -q` (after creating venv + deps).
+
+---
+
+## File Structure
+
+- Create: `booking-agent/app/tee_sheet.py` — login/SSO, fetch sheet, parse slots, typed errors.
+- Modify: `booking-agent/app/main.py` — `TeeTimesRequest` + `POST /tee-times`.
+- Modify: `booking-agent/requirements.txt` — add `httpx`.
+- Create: `booking-agent/requirements-testing.txt` — pytest stack for local/CI agent tests.
+- Create: `booking-agent/tests/conftest.py`, `booking-agent/tests/test_tee_sheet_parse.py`, `booking-agent/tests/test_tee_times_endpoint.py`, `booking-agent/tests/fixtures/member_sheet_sample.html`.
+- Modify: `booking-agent/README.md` — document `/tee-times`.
+- Modify: `docs/architecture/COMPUTER_USE_BOOKING.md` — reads available on agent via httpx; SPA still uses FastAPI.
+
+---
+
+### Task 1: Parser unit tests + `parse_tee_sheet`
+
+**Files:**
+- Create: `booking-agent/tests/fixtures/member_sheet_sample.html`
+- Create: `booking-agent/tests/conftest.py`
+- Create: `booking-agent/tests/test_tee_sheet_parse.py`
+- Create: `booking-agent/app/tee_sheet.py` (parser only first)
+- Create: `booking-agent/requirements-testing.txt`
+- Modify: `booking-agent/requirements.txt`
+
+**Interfaces:**
+- Produces: `parse_tee_sheet(html_content: str, date: str) -> list[dict[str, Any]]`
+
+- [ ] **Step 1: Add dependencies**
+
+Append to `booking-agent/requirements.txt`:
+
+```
+httpx>=0.27.0
+```
+
+Create `booking-agent/requirements-testing.txt`:
+
+```
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.24.0
+respx>=0.21.0
+httpx>=0.27.0
+```
+
+- [ ] **Step 2: Write sample fixture HTML**
+
+Create `booking-agent/tests/fixtures/member_sheet_sample.html` with one real-shaped row (escape quotes in `data-ftjson` as HTML entities are fine; use `&quot;` or keep JSON simple):
+
+```html
+<div class="rwdTr">
+  <a class="teetime_button" data-ftjson="{&quot;type&quot;:&quot;Member_slot&quot;,&quot;time:0&quot;:&quot;11:00 AM&quot;,&quot;ttdata&quot;:&quot;abc123&quot;,&quot;jump&quot;:7,&quot;p5&quot;:&quot;No&quot;,&quot;wasP1&quot;:&quot;Jane D&quot;,&quot;wasP2&quot;:&quot;&quot;,&quot;wasP3&quot;:&quot;&quot;,&quot;wasP4&quot;:&quot;&quot;,&quot;wasP5&quot;:&quot;&quot;}">11:00 AM</a>
+  <div class="rwdTd pgCol"><div><span>Jane D</span><span>WLK</span></div></div>
+  <div class="slotCount openSlots3 maxPlayers4"></div>
+</div>
+<div class="rwdTr">
+  <a class="teetime_button" data-ftjson="{&quot;type&quot;:&quot;Other&quot;,&quot;jump&quot;:8}">ignore</a>
+</div>
+```
+
+- [ ] **Step 3: Write the failing parser test**
+
+```python
+# booking-agent/tests/test_tee_sheet_parse.py
+from pathlib import Path
+
+from app.tee_sheet import parse_tee_sheet
+
+FIXTURE = Path(__file__).parent / "fixtures" / "member_sheet_sample.html"
+
+
+def test_parse_tee_sheet_extracts_players_and_open_slots():
+    html = FIXTURE.read_text()
+    slots = parse_tee_sheet(html, "2026-07-28")
+    assert len(slots) == 1
+    slot = slots[0]
+    assert slot["date"] == "2026-07-28"
+    assert slot["time"] == "11:00 AM"
+    assert slot["ttdata"] == "abc123"
+    assert slot["jump"] == 7
+    assert slot["p5_allowed"] is False
+    assert slot["players"] == [{"name": "Jane D", "transport": "WLK"}]
+    assert slot["max_players"] == 4
+    assert slot["open_slots"] == 3
+    assert slot["front_back"] == "F"
+
+
+def test_parse_tee_sheet_skips_non_member_slot():
+    html = '<a data-ftjson="{&quot;type&quot;:&quot;Event&quot;,&quot;jump&quot;:1}"></a>'
+    assert parse_tee_sheet(html, "2026-07-28") == []
+```
+
+Create empty `booking-agent/tests/conftest.py` (and `booking-agent/tests/__init__.py` if needed for imports). Prefer running pytest with `cd booking-agent` and `pythonpath=.` or install the package; simplest: put this in `conftest.py`:
+
+```python
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+```
+
+- [ ] **Step 4: Run to verify fail**
+
+```bash
+cd booking-agent
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements-testing.txt
+pytest tests/test_tee_sheet_parse.py -q
+```
+
+Expected: `ModuleNotFoundError: No module named 'app.tee_sheet'` (or import error for `parse_tee_sheet`).
+
+- [ ] **Step 5: Implement `parse_tee_sheet`**
+
+Create `booking-agent/app/tee_sheet.py` with parser logic ported from `backend/app/services/foretees_service.py` `_parse_tee_sheet` (lines ~750–858). Keep the same regexes and field mapping. Export only:
+
+```python
+def parse_tee_sheet(html_content: str, date: str) -> list[dict[str, Any]]:
+    ...
+```
+
+When CSS open-slot class is present, prefer `open_slots` from the class; if absent, use `max_players - len(players)` with default `max_players=4` (match FastAPI behavior: FastAPI overwrites open_count from max−players even when CSS present — **copy FastAPI exactly**: it sets `open_count = max_players - len(players)` after reading max from CSS). Mirror FastAPI literally so shapes stay identical.
+
+- [ ] **Step 6: Run tests — expect PASS**
+
+```bash
+cd booking-agent && source .venv/bin/activate && pytest tests/test_tee_sheet_parse.py -q
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add booking-agent/requirements.txt booking-agent/requirements-testing.txt \
+  booking-agent/app/tee_sheet.py booking-agent/tests/
+git commit -m "$(cat <<'EOF'
+feat(booking-agent): parse ForeTees Member_sheet slots
+
+Port the FastAPI tee-sheet HTML parser so the booking agent can list
+day slots and players without Computer Use.
+EOF
+)"
+```
+
+---
+
+### Task 2: ForeTees session + fetch with typed failures
+
+**Files:**
+- Modify: `booking-agent/app/tee_sheet.py`
+- Modify: `booking-agent/tests/test_tee_sheet_parse.py` (or new `test_tee_sheet_fetch.py`)
+
+**Interfaces:**
+- Consumes: `parse_tee_sheet`, `Settings` URLs from `get_settings()`
+- Produces:
+  - `class ForeteesAuthError(Exception)`
+  - `class ForeteesSheetError(Exception)`
+  - `async def fetch_tee_times(username: str, password: str, date: str, *, settings: Settings | None = None) -> list[dict[str, Any]]`
+
+- [ ] **Step 1: Write failing fetch tests with respx**
+
+```python
+# booking-agent/tests/test_tee_sheet_fetch.py
+import httpx
+import pytest
+import respx
+
+from app.config import Settings
+from app.tee_sheet import ForeteesAuthError, ForeteesSheetError, fetch_tee_times
+
+settings = Settings(
+    wingpoint_base="https://www.wingpointgolf.com",
+    login_page="/public/member-login-465.html",
+    tee_time_page="/members/golf/make-a-tee-time-703.html",
+    foretees_base="https://ftapp.example/v5/club",
+)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_tee_times_happy_path(tmp_path):
+    from pathlib import Path
+
+    html = (Path(__file__).parent / "fixtures" / "member_sheet_sample.html").read_text()
+    respx.get("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="login")
+    )
+    respx.post("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="ok")
+    )
+    respx.get("https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html").mock(
+        return_value=httpx.Response(
+            200,
+            text="var ftSSOKey = 'KEY'; var ftSSOIV = 'IV';",
+        )
+    )
+    respx.get("https://ftapp.example/v5/club/Member_select").mock(
+        return_value=httpx.Response(200, text="sso")
+    )
+    respx.get("https://ftapp.example/v5/club/Member_sheet").mock(
+        return_value=httpx.Response(200, text=html)
+    )
+
+    slots = await fetch_tee_times("u", "p", "2026-07-28", settings=settings)
+    assert len(slots) == 1
+    assert slots[0]["time"] == "11:00 AM"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_tee_times_auth_fails_without_sso():
+    respx.get("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="login")
+    )
+    respx.post("https://www.wingpointgolf.com/public/member-login-465.html").mock(
+        return_value=httpx.Response(200, text="ok")
+    )
+    respx.get("https://www.wingpointgolf.com/members/golf/make-a-tee-time-703.html").mock(
+        return_value=httpx.Response(200, text="no sso vars here")
+    )
+    with pytest.raises(ForeteesAuthError):
+        await fetch_tee_times("u", "p", "2026-07-28", settings=settings)
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`ForeteesAuthError` / `fetch_tee_times` missing)
+
+- [ ] **Step 3: Implement session + fetch in `tee_sheet.py`**
+
+Port the login sequence from `ForeteesService._ensure_session` / `get_tee_times`:
+
+1. GET login page, POST `UserLOGIN` / `UserPWD` / `btnLogon=Log On` / `Action=Authenticate` / `DocID=465` / etc. (same fields as backend).
+2. GET tee time page; regex `ftSSOKey\s*=\s*'([^']+)'` and `ftSSOIV`.
+3. Missing SSO → raise `ForeteesAuthError`.
+4. GET `{foretees_base}/Member_select?sso_uid=…&sso_iv=…`.
+5. GET `{foretees_base}/Member_sheet?calDate=MM/DD/YYYY&course=&displayOpt=0` (convert `YYYY-MM-DD` → `%m/%d/%Y`).
+6. Sheet HTTP errors → `ForeteesSheetError`.
+7. Return `parse_tee_sheet(resp.text, date)`.
+
+Use a single `async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:` per call (no shared session store).
+
+Validate `date` as `%Y-%m-%d` before fetch; invalid → raise `ValueError` (endpoint maps to 400).
+
+- [ ] **Step 4: Run fetch tests — expect PASS**
+
+```bash
+cd booking-agent && source .venv/bin/activate && pytest tests/test_tee_sheet_fetch.py -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add booking-agent/app/tee_sheet.py booking-agent/tests/test_tee_sheet_fetch.py
+git commit -m "$(cat <<'EOF'
+feat(booking-agent): fetch day sheet under member ForeTees login
+
+httpx login + SSO + Member_sheet; auth/sheet failures are typed so the
+API can return 502 instead of an empty list.
+EOF
+)"
+```
+
+---
+
+### Task 3: `POST /tee-times` endpoint
+
+**Files:**
+- Modify: `booking-agent/app/main.py`
+- Create: `booking-agent/tests/test_tee_times_endpoint.py`
+
+**Interfaces:**
+- Consumes: `fetch_tee_times`, `ForeteesAuthError`, `ForeteesSheetError`, `_check_auth`
+- Produces: `POST /tee-times` → `{ status, date, slots }` or error bodies per spec
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+```python
+# booking-agent/tests/test_tee_times_endpoint.py
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.tee_sheet import ForeteesAuthError
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("BOOKING_SERVICE_SECRET", "test-secret")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    with TestClient(app) as c:
+        yield c
+    get_settings.cache_clear()
+
+
+def test_tee_times_unauthorized(client):
+    resp = client.post("/tee-times", json={"username": "u", "password": "p", "date": "2026-07-28"})
+    assert resp.status_code == 401
+
+
+def test_tee_times_missing_creds(client):
+    resp = client.post(
+        "/tee-times",
+        headers={"Authorization": "Bearer test-secret"},
+        json={"username": "", "password": "p", "date": "2026-07-28"},
+    )
+    assert resp.status_code == 400
+
+
+def test_tee_times_ok(client):
+    slots = [
+        {
+            "date": "2026-07-28",
+            "time": "11:00 AM",
+            "front_back": "F",
+            "players": [{"name": "Jane D", "transport": "WLK"}],
+            "open_slots": 3,
+            "max_players": 4,
+            "ttdata": "abc",
+            "jump": 7,
+            "p5_allowed": False,
+        }
+    ]
+    with patch("app.main.fetch_tee_times", new=AsyncMock(return_value=slots)):
+        resp = client.post(
+            "/tee-times",
+            headers={"Authorization": "Bearer test-secret"},
+            json={"username": "u", "password": "p", "date": "2026-07-28"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["date"] == "2026-07-28"
+    assert body["slots"] == slots
+
+
+def test_tee_times_auth_failure_is_502(client):
+    with patch(
+        "app.main.fetch_tee_times",
+        new=AsyncMock(side_effect=ForeteesAuthError("no sso")),
+    ):
+        resp = client.post(
+            "/tee-times",
+            headers={"Authorization": "Bearer test-secret"},
+            json={"username": "u", "password": "p", "date": "2026-07-28"},
+        )
+    assert resp.status_code == 502
+    assert resp.json() == {"status": "failed", "error": "foretees_auth_failed"}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (404 on `/tee-times`)
+
+- [ ] **Step 3: Implement endpoint in `main.py`**
+
+```python
+class TeeTimesRequest(BaseModel):
+    username: str
+    password: str
+    date: str
+
+
+@app.post("/tee-times")
+async def tee_times(
+    body: TeeTimesRequest,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _check_auth(authorization)
+    if not body.username.strip() or not body.password:
+        raise HTTPException(status_code=400, detail="username and password required")
+    if not body.date.strip():
+        raise HTTPException(status_code=400, detail="date required (YYYY-MM-DD)")
+    try:
+        slots = await fetch_tee_times(body.username.strip(), body.password, body.date.strip())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ForeteesAuthError:
+        raise HTTPException(
+            status_code=502,
+            detail={"status": "failed", "error": "foretees_auth_failed"},
+        ) from None
+    except ForeteesSheetError:
+        raise HTTPException(
+            status_code=502,
+            detail={"status": "failed", "error": "foretees_sheet_failed"},
+        ) from None
+    return {"status": "ok", "date": body.date.strip(), "slots": slots}
+```
+
+**Note:** FastAPI wraps `detail` dicts as `{"detail": {…}}`. Spec wants top-level `{status, error}` on 502. Prefer returning via:
+
+```python
+from fastapi.responses import JSONResponse
+
+return JSONResponse(
+    status_code=502,
+    content={"status": "failed", "error": "foretees_auth_failed"},
+)
+```
+
+for auth/sheet failures (and keep `HTTPException` for 400/401). Update the test to match whichever you implement — **must match the spec's top-level body**.
+
+- [ ] **Step 4: Run all booking-agent tests — expect PASS**
+
+```bash
+cd booking-agent && source .venv/bin/activate && pytest tests/ -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add booking-agent/app/main.py booking-agent/tests/test_tee_times_endpoint.py
+git commit -m "$(cat <<'EOF'
+feat(booking-agent): expose POST /tee-times for day sheet reads
+
+Bearer-authed, per-member ForeTees credentials; returns slots and
+players without changing the SPA/FastAPI list path.
+EOF
+)"
+```
+
+---
+
+### Task 4: Docs + architecture note
+
+**Files:**
+- Modify: `booking-agent/README.md`
+- Modify: `docs/architecture/COMPUTER_USE_BOOKING.md`
+
+- [ ] **Step 1: Update README endpoints list**
+
+Add under Endpoints:
+
+```markdown
+- `POST /tee-times` — list day's slots + players (body: `username`, `password`, `date`; httpx scrape, not Computer Use)
+```
+
+Add a short example:
+
+```bash
+curl -sS -X POST "$BOOKING_URL/tee-times" \
+  -H "Authorization: Bearer $BOOKING_SERVICE_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"…","password":"…","date":"2026-07-28"}'
+```
+
+- [ ] **Step 2: Update architecture doc**
+
+In `docs/architecture/COMPUTER_USE_BOOKING.md`:
+
+1. Add `/tee-times` to the HTTP contract table (Purpose: list day sheet + players via httpx).
+2. Replace the Non-goals bullet that says tee-sheet reads stay on FastAPI with:
+
+```markdown
+- SPA/FastAPI still own the product list path (`GET /api/foretees/tee-times`); booking-agent also exposes `POST /tee-times` (httpx) for direct callers. Computer Use is not used for reads.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add booking-agent/README.md docs/architecture/COMPUTER_USE_BOOKING.md
+git commit -m "$(cat <<'EOF'
+docs(booking-agent): document POST /tee-times day sheet API
+EOF
+)"
+```
+
+---
+
+### Task 5: Manual smoke (optional, post-deploy)
+
+Not a code commit. After merge auto-deploys `wgp-booking`:
+
+```bash
+curl -sS -o /tmp/tt.json -w '%{http_code}\n' -X POST \
+  "https://wgp-booking-i5v2shrpoa-uc.a.run.app/tee-times" \
+  -H "Authorization: Bearer $BOOKING_SERVICE_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"<member>","password":"<pass>","date":"2026-07-28"}'
+# expect 200 + status ok, or 502 with foretees_auth_failed
+# junk Bearer → 401
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|---|---|
+| `POST /tee-times` + Bearer auth | Task 3 |
+| Body username/password/date | Task 3 |
+| httpx login + Member_sheet | Task 2 |
+| Slot shape matches FastAPI | Task 1 |
+| 502 auth/sheet (not empty list) | Tasks 2–3 |
+| No SPA/FastAPI wiring | (explicit non-goal) |
+| Docs update | Task 4 |
+| Parser unit tests | Task 1 |
+| Auth 401 / validation 400 | Task 3 |
+
+## Placeholder / consistency self-review
+
+- No TBD/TODO left in steps.
+- `fetch_tee_times` / `ForeteesAuthError` / `ForeteesSheetError` / `parse_tee_sheet` names are consistent across tasks.
+- 502 response uses top-level `{status, error}` via `JSONResponse` (called out so tests match spec, not FastAPI `detail` wrapping).

--- a/docs/superpowers/specs/2026-07-28-booking-agent-tee-times-design.md
+++ b/docs/superpowers/specs/2026-07-28-booking-agent-tee-times-design.md
@@ -1,0 +1,162 @@
+# Booking-agent tee-times read API
+
+**Date:** 2026-07-28  
+**Status:** Approved for implementation planning  
+**Scope:** Add a read-only day sheet endpoint to `wgp-booking` (Computer Use booking agent). Do **not** change the SPA or FastAPI list path in this pass.
+
+## Problem
+
+The booking agent (`booking-agent` / Cloud Run `wgp-booking`) only books and cancels. Listing available tee times and who is already on them lives entirely on the main FastAPI ForeTees scrape (`GET /api/foretees/tee-times`). Callers that talk only to the booking service cannot browse the day sheet under a member’s ForeTees identity.
+
+## Goals
+
+- Expose **available tee times for a given date** and **who is playing on each slot** from the booking agent.
+- Run the read **as the calling member** (caller-supplied ForeTees username/password), matching `/book` and `/cancel`.
+- Keep the existing SPA → FastAPI → httpx scrape path unchanged.
+
+## Non-goals
+
+- Wiring FastAPI or the SPA to call the new booking-agent endpoint.
+- Gemini Computer Use / Playwright for listing (too slow/fragile for structured reads).
+- Shared library extraction between FastAPI and booking-agent (defer until a second consumer needs DRY).
+- `GET`/`POST` “my bookings” (`Member_teelist_list`) — out of this pass unless added as a follow-up.
+- Changing book/cancel Computer Use behavior.
+
+## Decision summary
+
+| Choice | Value |
+|---|---|
+| Surface | `POST /tee-times` on booking-agent |
+| Auth | Bearer `BOOKING_SERVICE_SECRET` (same as `/book`) |
+| Credentials | Body: `username`, `password`, `date` |
+| Fetch | httpx login + SSO + `Member_sheet` HTML scrape |
+| Identity | Per-user ForeTees session (not a shared service account) |
+| Consumers this pass | Direct API callers / future FastAPI proxy; SPA stays on FastAPI |
+
+## Architecture
+
+```
+Caller (API client / future proxy)
+        │  Authorization: Bearer BOOKING_SERVICE_SECRET
+        │  POST /tee-times { username, password, date }
+        ▼
+wgp-booking (Cloud Run)
+        │  httpx (no Chromium, no Gemini)
+        ├─ Wingpoint login (UserLOGIN / UserPWD)
+        ├─ Tee page → ftSSOKey / ftSSOIV
+        ├─ ForeTees Member_select SSO → JSESSIONID
+        └─ GET Member_sheet?calDate=MM/DD/YYYY
+                ▼
+        Parse data-ftjson Member_slot rows
+                ▼
+        { status, date, slots: [ time, players, open_slots, … ] }
+```
+
+Existing book/cancel path is unchanged and remains Computer Use + Playwright.
+
+## API contract
+
+### Request
+
+`POST /tee-times`
+
+Headers:
+
+- `Authorization: Bearer <BOOKING_SERVICE_SECRET>` (required when secret is configured)
+
+Body:
+
+```json
+{
+  "username": "member@example.com",
+  "password": "…",
+  "date": "2026-07-28"
+}
+```
+
+- `date` must be `YYYY-MM-DD`.
+- Empty username/password → `400`.
+
+### Success response
+
+HTTP `200`:
+
+```json
+{
+  "status": "ok",
+  "date": "2026-07-28",
+  "slots": [
+    {
+      "date": "2026-07-28",
+      "time": "11:00 AM",
+      "front_back": "F",
+      "players": [
+        { "name": "Jane D", "transport": "WLK" }
+      ],
+      "open_slots": 3,
+      "max_players": 4,
+      "ttdata": "…",
+      "jump": 0,
+      "p5_allowed": false
+    }
+  ]
+}
+```
+
+Slot field semantics match FastAPI’s `_parse_tee_sheet` output so a future FastAPI proxy can drop in without reshaping.
+
+### Error responses
+
+| Condition | HTTP | Body |
+|---|---|---|
+| Missing/invalid Bearer | `401` | `{ "detail": "Unauthorized" }` |
+| Invalid/missing date or creds | `400` | `{ "detail": "…" }` |
+| ForeTees login / SSO failure | `502` | `{ "status": "failed", "error": "foretees_auth_failed" }` |
+| Sheet fetch/parse failure after auth | `502` | `{ "status": "failed", "error": "foretees_sheet_failed" }` |
+
+Unlike FastAPI’s current list path (which often returns `[]` on auth failure), this endpoint **must not** disguise auth failure as an empty day. Empty `slots` is only valid when auth succeeded and the sheet truly has no `Member_slot` rows.
+
+## Components
+
+### `booking-agent/app/main.py`
+
+- Add `TeeTimesRequest` Pydantic model.
+- Add `POST /tee-times` handler: `_check_auth` → validate → call sheet fetcher → return contract above.
+
+### `booking-agent/app/tee_sheet.py` (new)
+
+Port the minimal ForeTees read path from `backend/app/services/foretees_service.py`:
+
+1. Session establish (Wingpoint login → SSO → JSESSIONID).
+2. `get_tee_times(date)` against `Member_sheet`.
+3. `_parse_tee_sheet` equivalent for `data-ftjson` / `Member_slot` / `wasP1…wasP5` / open-slot CSS.
+
+Use URLs from `Settings` (`wingpoint_base`, `login_page`, `tee_time_page`, `foretees_base`). Do **not** import backend packages into the booking-agent image.
+
+Session handling: short-lived per request (or request-scoped httpx client). No need to share state with Computer Use jobs; listing must not require session affinity.
+
+### Dependencies
+
+- Ensure `httpx` is in `booking-agent/requirements.txt` if not already present.
+
+## Testing
+
+1. **Unit — parser:** Fixture HTML with known `data-ftjson` rows → expected players / open_slots / times.
+2. **Unit — auth gate:** Missing Bearer → `401` when secret configured.
+3. **Unit — validation:** Bad date / empty creds → `400`.
+4. **Contract (optional, mocked httpx):** Login + sheet sequence returns shaped slots.
+5. **Live (optional, env-gated):** Against real ForeTees with test member creds — not part of default CI.
+
+## Rollout
+
+1. Implement + unit tests in `booking-agent/`.
+2. Auto-deploy via existing `booking-agent/**` → `deploy-booking` path.
+3. Smoke: `POST /tee-times` with Bearer + member creds → non-empty or intentional empty slots; bad secret → `401`.
+4. Document the endpoint in `booking-agent/README.md` and `docs/architecture/COMPUTER_USE_BOOKING.md` (amend non-goals: reads available via httpx on the agent; SPA still uses FastAPI).
+
+## Follow-ups (explicitly deferred)
+
+- FastAPI proxy option: `GET /api/foretees/tee-times` may call booking-agent `/tee-times` as primary or fallback.
+- SPA unchanged until that proxy lands.
+- Shared scrape package if both services should stay in sync without copy-paste drift.
+- `POST /bookings` for the member’s upcoming list.


### PR DESCRIPTION
## Summary
- Add `POST /tee-times` on the Computer Use booking agent so callers can list a day's ForeTees slots and who is playing, using the member's own credentials (same pattern as `/book`).
- Implement httpx login + SSO + `Member_sheet` scrape (no Chromium/Gemini for reads); slot shape matches FastAPI's existing parser.
- Auth/sheet failures return top-level `502` `{status, error}` instead of an empty list; SPA/FastAPI list path intentionally unchanged.

## Spec / plan
- [Design](docs/superpowers/specs/2026-07-28-booking-agent-tee-times-design.md)
- [Plan](docs/superpowers/plans/2026-07-28-booking-agent-tee-times.md)

## Test plan
- [x] `cd booking-agent && pytest tests/ -q` — 14 passed
- [ ] After merge auto-deploy: `POST /tee-times` with Bearer + member creds → `200` + slots (or intentional empty)
- [ ] Junk Bearer → `401`
- [ ] Bad ForeTees password → `502` `foretees_auth_failed` (not empty slots)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated `POST /tee-times` endpoint to retrieve available tee times, player details, and open-slot information for a selected date.
  * Added validation and clear error responses for invalid requests, authentication failures, and tee-sheet retrieval issues.

* **Documentation**
  * Documented the new endpoint, request format, authorization, and usage example.
  * Updated booking-agent architecture documentation.

* **Tests**
  * Added coverage for successful retrieval, validation, authentication, parsing, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->