### PR TITLE
fix(api): resync OpenAPI contract and prevent drift

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -72,6 +72,15 @@ jobs:
         pip install -r requirements-testing.txt
         ruff check app/ tests/
         ruff format --check app/ tests/
+
+    # Keep the committed OpenAPI contract honest on every backend change — do not
+    # wait for the separate openapi-contract workflow. Fail here if routes/schemas
+    # drifted without regenerating backend/openapi.json.
+    - name: Check OpenAPI contract is in sync
+      if: matrix.python-version == '3.12'
+      run: |
+        cd backend
+        python scripts/export_openapi.py --check
     
     - name: Run type checking
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,9 @@ cd frontend && npm run typecheck && npx vitest run && npm run build
 
 # Backend changes (mirrors .github/workflows/backend-ci.yml):
 cd backend && ruff check app/ tests/ && ruff format --check app/ tests/ \
+  && python scripts/export_openapi.py --check \
   && pytest tests/ --ignore=tests/manual --ignore=tests/_diagnostic
+# If OpenAPI --check fails: ./scripts/sync_openapi.sh then commit both artifacts.
 ```
 
 Editing rules that prevent past deploy failures:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -211,7 +211,7 @@
       "Body_import_course_from_file_courses_import_file_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -225,7 +225,7 @@
       "Body_scan_scorecard_photo_scorecard_scan_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           },
@@ -250,7 +250,7 @@
       "Body_upload_gmail_credentials_admin_upload_credentials_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -264,7 +264,7 @@
       "Body_upload_my_avatar_players_me_avatar_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -3813,6 +3813,13 @@
       },
       "ValidationError": {
         "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
           "loc": {
             "items": {
               "anyOf": [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,10 @@
 # contract and fail the openapi-contract CI check. Bump deliberately and run
 # `python scripts/export_openapi.py` + `npm run gen:api` in the same change.
 fastapi==0.140.0
+# starlette is PINNED for the same reason as fastapi — upload fields flip between
+# `format: binary` and `contentMediaType` across starlette minors, which drifts
+# backend/openapi.json even when fastapi itself is unchanged.
+starlette==1.3.1
 uvicorn[standard]>=0.29.0
 python-multipart>=0.0.9
 

--- a/docs/development/API_CONTRACT.md
+++ b/docs/development/API_CONTRACT.md
@@ -21,18 +21,23 @@ artifact fails the build.
 Any change to routes, params, or Pydantic response models changes the contract:
 
 ```bash
+# One-shot: regenerate both artifacts and verify --check
+./scripts/sync_openapi.sh
+
+# Or manually:
 # 1. Regenerate the committed spec from the app
 cd backend && python scripts/export_openapi.py
-
 # 2. Regenerate the frontend types from that spec
 cd ../frontend && npm run gen:api
-
 # 3. Commit both regenerated files with your change
 ```
 
-If you forget, the `OpenAPI Contract` CI job fails with a diff showing what's
-stale. `python scripts/export_openapi.py --check` reproduces the backend check
-locally.
+If you forget, **Backend CI** and the `OpenAPI Contract` workflow both fail.
+`python scripts/export_openapi.py --check` reproduces the backend check locally.
+
+FastAPI, Pydantic, and Starlette are exact-pinned in `backend/requirements.txt`
+because they control schema serialization. Bumping any of them requires running
+`./scripts/sync_openapi.sh` in the same change.
 
 ## Using the typed client in the frontend
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1067,6 +1067,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/foretees/book/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm Booking Step
+         * @description Resume a paused Computer Use book/cancel job after user confirmation.
+         */
+        post: operations["confirm_booking_step_api_foretees_book_confirm_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/foretees/bookings": {
         parameters: {
             query?: never;
@@ -4918,6 +4938,16 @@ export interface components {
                 [key: string]: unknown;
             }[];
         };
+        /** ConfirmBookingJobRequest */
+        ConfirmBookingJobRequest: {
+            /**
+             * Confirm
+             * @default true
+             */
+            confirm: boolean;
+            /** Job Id */
+            job_id: string;
+        };
         /** CourseCreate */
         CourseCreate: {
             /** Description */
@@ -8068,6 +8098,41 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["BookTeeTimeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_booking_step_api_foretees_book_confirm_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmBookingJobRequest"];
             };
         };
         responses: {

--- a/scripts/sync_openapi.sh
+++ b/scripts/sync_openapi.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Regenerate the committed API contract + frontend types.
+# Run whenever backend routes/schemas change, or after bumping fastapi /
+# pydantic / starlette. Mirrors what OpenAPI Contract CI expects.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+cd "$ROOT/backend"
+python scripts/export_openapi.py
+python scripts/export_openapi.py --check
+
+cd "$ROOT/frontend"
+npm run gen:api
+
+echo "✅ OpenAPI contract + frontend types are in sync."
+echo "   Commit: backend/openapi.json frontend/src/api/schema.d.ts"


### PR DESCRIPTION
## Summary
- Regenerates `backend/openapi.json` and `frontend/src/api/schema.d.ts` to match current FastAPI/Starlette schema output (upload `contentMediaType`, ValidationError `ctx`/`input`, plus missing booking confirm types).
- Pins `starlette==1.3.1` alongside fastapi/pydantic so floating starlette minors cannot silently drift the committed contract.
- Adds OpenAPI `--check` to Backend CI (3.12) and the local backend DoD; adds `./scripts/sync_openapi.sh` for one-shot regeneration.

## Test plan
- [x] `frontend` typecheck passes
- [ ] Backend CI OpenAPI check green
- [ ] OpenAPI Contract workflow green