### PR TITLE
fix(booking): stop Vertex 400 that killed the booking agent at login

### DIFF
--- a/booking-agent/app/agent.py
+++ b/booking-agent/app/agent.py
@@ -96,10 +96,15 @@ def _generate_config(settings: Settings) -> types.GenerateContentConfig:
         system_instruction=SYSTEM_INSTRUCTION,
         temperature=0.2,
         tools=[
+            # Do NOT set excluded_predefined_functions here. Vertex rejects a
+            # ComputerUse tool that both excludes predefined functions and is
+            # combined with custom function_declarations, failing the whole
+            # request with a misleading "computer use is not supported for this
+            # model in this region" 400. drag_and_drop is implemented in
+            # browser.execute_computer_action, so nothing needs excluding.
             types.Tool(
                 computer_use=types.ComputerUse(
                     environment=types.Environment.ENVIRONMENT_BROWSER,
-                    excluded_predefined_functions=["drag_and_drop"],
                 )
             ),
             types.Tool(

--- a/booking-agent/tests/test_agent_config.py
+++ b/booking-agent/tests/test_agent_config.py
@@ -1,0 +1,24 @@
+from app.agent import _generate_config
+from app.config import Settings
+
+
+def _tools():
+    return _generate_config(Settings()).tools
+
+
+def test_computer_use_tool_excludes_nothing():
+    """Vertex 400s when ComputerUse excludes functions alongside custom declarations."""
+    computer_use_tools = [t for t in _tools() if t.computer_use is not None]
+    assert len(computer_use_tools) == 1
+    assert not computer_use_tools[0].computer_use.excluded_predefined_functions
+
+
+def test_custom_function_declarations_are_registered():
+    declared = {
+        decl.name for tool in _tools() if tool.function_declarations for decl in tool.function_declarations
+    }
+    assert declared == {
+        "request_confirmation",
+        "enter_foretees_credentials",
+        "report_booking_result",
+    }


### PR DESCRIPTION
## Summary
- The Computer Use agent crashed on its very first turn — right after the browser reached the Wingpoint login page — with `400 INVALID_ARGUMENT: computer use is not supported for this model in this region`.
- Root cause is not the model or region. Vertex rejects a `ComputerUse` tool that sets `excluded_predefined_functions` **while** custom `function_declarations` are also registered. Verified by isolating the tool config against `global` + `gemini-3.5-flash`:
  - `computerUse` only → 200
  - `computerUse` + `excludedPredefinedFunctions` → 200
  - `computerUse` + `functionDeclarations` → 200
  - `computerUse` + `excludedPredefinedFunctions` + `functionDeclarations` → **400**
- Removed the exclusion. `drag_and_drop` is already implemented in `browser.execute_computer_action`, so nothing needed excluding.
- Added a regression test asserting the ComputerUse tool excludes nothing while the three custom declarations stay registered.

Note: the tee-time **list** path is unaffected and already working (`Parsed 24 tee time slots`).

## Test plan
- [x] `booking-agent` pytest: 16 passed
- [x] Replayed the real `_generate_config()` tool payload against Vertex → 200
- [ ] After deploy: book flow gets past login instead of failing on turn 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-based booking interactions in regions where ComputerUse previously reported misleading unsupported-tool errors.
  * Preserved support for custom booking actions alongside built-in browser controls.

* **Tests**
  * Added coverage to verify browser tools and custom booking actions are configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->