### PR TITLE
fix(booking): use a model that actually serves Computer Use

### DIFF
--- a/booking-agent/app/agent.py
+++ b/booking-agent/app/agent.py
@@ -96,12 +96,8 @@ def _generate_config(settings: Settings) -> types.GenerateContentConfig:
         system_instruction=SYSTEM_INSTRUCTION,
         temperature=0.2,
         tools=[
-            # Do NOT set excluded_predefined_functions here. Vertex rejects a
-            # ComputerUse tool that both excludes predefined functions and is
-            # combined with custom function_declarations, failing the whole
-            # request with a misleading "computer use is not supported for this
-            # model in this region" 400. drag_and_drop is implemented in
-            # browser.execute_computer_action, so nothing needs excluding.
+            # Every predefined action stays enabled — browser.execute_computer_action
+            # implements the full Gemini 2.5 set, including drag_and_drop.
             types.Tool(
                 computer_use=types.ComputerUse(
                     environment=types.Environment.ENVIRONMENT_BROWSER,

--- a/booking-agent/app/config.py
+++ b/booking-agent/app/config.py
@@ -14,7 +14,12 @@ class Settings(BaseSettings):
     booking_service_secret: str = ""
     gcp_project_id: str = "seventh-country-232522"
     gcp_location: str = "global"
-    computer_use_model: str = "gemini-3.5-flash"
+    # Must be a model that actually serves the Computer Use tool. Vertex rejects
+    # `gemini-3.5-flash` here with "computer use is not supported for this model
+    # in this region" (8/8 calls on the global endpoint), and Gemini 3.x emits a
+    # different FunctionCall name set than browser.execute_computer_action
+    # implements. The dedicated 2.5 model answers reliably and speaks that set.
+    computer_use_model: str = "gemini-2.5-computer-use-preview-10-2025"
     max_agent_turns: int = 40
     job_ttl_seconds: int = 900
     screen_width: int = 1280

--- a/booking-agent/tests/test_agent_config.py
+++ b/booking-agent/tests/test_agent_config.py
@@ -6,8 +6,12 @@ def _tools():
     return _generate_config(Settings()).tools
 
 
-def test_computer_use_tool_excludes_nothing():
-    """Vertex 400s when ComputerUse excludes functions alongside custom declarations."""
+def test_model_serves_the_computer_use_tool():
+    """General-purpose models 400 with 'computer use is not supported ... in this region'."""
+    assert Settings().computer_use_model == "gemini-2.5-computer-use-preview-10-2025"
+
+
+def test_no_predefined_actions_are_excluded():
     computer_use_tools = [t for t in _tools() if t.computer_use is not None]
     assert len(computer_use_tools) == 1
     assert not computer_use_tools[0].computer_use.excluded_predefined_functions

--- a/deploy/gcp/cloudbuild-booking.yaml
+++ b/deploy/gcp/cloudbuild-booking.yaml
@@ -12,8 +12,11 @@ substitutions:
   _SERVICE: wgp-booking
   _RUNTIME_SA_NAME: wgp-run
   _SECRETS: "BOOKING_SERVICE_SECRET=BOOKING_SERVICE_SECRET:latest"
-  # Vertex model for Gemini Computer Use (global endpoint).
-  _COMPUTER_USE_MODEL: gemini-3.5-flash
+  # Vertex model for Gemini Computer Use (global endpoint). Keep in sync with
+  # booking-agent/app/config.py — general-purpose models such as
+  # `gemini-3.5-flash` are refused with "computer use is not supported for this
+  # model in this region".
+  _COMPUTER_USE_MODEL: gemini-2.5-computer-use-preview-10-2025
 
 images:
   - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/${_SERVICE}:${SHORT_SHA}"


### PR DESCRIPTION
## Summary
- Booking jobs still crashed on turn 1 after #338 with `400 INVALID_ARGUMENT: computer use is not supported for this model in this region`.
- Real root cause is the **model**. Measured on the `global` endpoint with a clean account:

| Model | Computer Use tool |
|---|---|
| `gemini-3.5-flash` | 8/8 → 400 not supported |
| `gemini-2.5-computer-use-preview-10-2025` | 8/8 → 200 |

- Gemini 3.x also emits a different `FunctionCall` name set than `browser.execute_computer_action` implements; the 2.5 Computer Use model speaks exactly the set already handled there.
- Updated the default in `config.py` and `_COMPUTER_USE_MODEL` in `cloudbuild-booking.yaml` so runtime and deploy agree.

### Correcting #338
That PR blamed `excluded_predefined_functions`. That was a false reading of intermittent quota (429) and auth (403) responses — the gcloud account had silently rotated mid-probe. Re-tested cleanly: the exclusion is accepted fine on a Computer Use model. The exclusion stays removed since `drag_and_drop` is implemented anyway, but it was never the bug.

## Test plan
- [x] `booking-agent` pytest: 17 passed
- [x] Replayed the real `_generate_config()` payload on the new model → 4/4 OK
- [ ] After deploy: book flow gets past login instead of failing on turn 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default computer-use model to a compatible Gemini 2.5 model.
  - Preserved support for predefined browser actions, including drag-and-drop interactions.

- **Tests**
  - Added coverage confirming the selected computer-use model and available browser actions.

- **Deployment**
  - Synchronized the cloud deployment configuration with the updated model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->