### PR TITLE
fix(booking): don't strand jobs waiting on a login confirmation

### DIFF
--- a/booking-agent/app/agent.py
+++ b/booking-agent/app/agent.py
@@ -21,8 +21,9 @@ You are automating Wingpoint Golf Club / ForeTees tee-time booking in a browser.
 RULES:
 1. Never type usernames or passwords. For login:
    - Navigate to the Wingpoint member login page if needed.
-   - Call request_confirmation(kind="login", explanation=...).
-   - After the user confirms, call enter_foretees_credentials().
+   - Call enter_foretees_credentials() directly. Do NOT ask the user to
+     confirm logging in — the credentials are filled server-side and are
+     never exposed to you.
 2. Before clicking Submit Request, Submit Changes, or Cancel Reservation:
    - Call request_confirmation(kind="submit", explanation=...).
    - Only click the button after the user confirms.
@@ -36,15 +37,15 @@ RULES:
 REQUEST_CONFIRMATION_DECL = types.FunctionDeclaration(
     name="request_confirmation",
     description=(
-        "Pause and ask the end user to confirm before a sensitive step "
-        "(login or final submit/cancel)."
+        "Pause and ask the end user to confirm before the final submit or cancel. "
+        "Do not use this for logging in."
     ),
     parameters_json_schema={
         "type": "object",
         "properties": {
             "kind": {
                 "type": "string",
-                "enum": ["login", "submit", "safety"],
+                "enum": ["submit", "safety"],
                 "description": "Which sensitive step needs confirmation",
             },
             "explanation": {
@@ -60,7 +61,7 @@ ENTER_CREDENTIALS_DECL = types.FunctionDeclaration(
     name="enter_foretees_credentials",
     description=(
         "Fill and submit the Wingpoint login form using server-side credentials. "
-        "Call only after request_confirmation(kind='login') was approved."
+        "Call this as soon as the login form is visible; no confirmation needed."
     ),
     parameters_json_schema={"type": "object", "properties": {}},
 )
@@ -170,6 +171,10 @@ def _safety_decision(fc: Any) -> dict[str, Any] | None:
     return None
 
 
+class ConfirmationExpired(Exception):
+    """Raised when the user never answered a confirmation prompt in time."""
+
+
 async def _pause_for_confirm(
     job: BookingJob,
     kind: str,
@@ -185,7 +190,14 @@ async def _pause_for_confirm(
     job.confirm_decision = None
     job.touch()
     logger.info("job %s waiting for confirm kind=%s", job.id, kind)
-    await job.confirm_event.wait()
+    try:
+        await asyncio.wait_for(job.confirm_event.wait(), timeout=get_settings().job_ttl_seconds)
+    except TimeoutError as exc:
+        logger.info("job %s confirm kind=%s expired", job.id, kind)
+        raise ConfirmationExpired(
+            "This booking session expired because it sat unconfirmed too long. "
+            "Please start the booking again."
+        ) from exc
     approved = bool(job.confirm_decision)
     job.status = JobStatus.RUNNING
     job.confirm_kind = None
@@ -353,10 +365,7 @@ async def run_job(job: BookingJob) -> dict[str, Any]:
                             name,
                             page,
                             {
-                                "result": (
-                                    "blocked: use enter_foretees_credentials after "
-                                    "request_confirmation(kind=login)"
-                                )
+                                "result": "blocked: call enter_foretees_credentials instead"
                             },
                             extra_fr,
                         )
@@ -390,6 +399,12 @@ async def run_job(job: BookingJob) -> dict[str, Any]:
 
         job.status = JobStatus.FAILED
         job.error = f"Exceeded max agent turns ({settings.max_agent_turns})"
+        await job.close_browser()
+        return job.to_response()
+    except ConfirmationExpired as exc:
+        logger.info("job %s abandoned: %s", job.id, exc)
+        job.status = JobStatus.FAILED
+        job.error = str(exc)
         await job.close_browser()
         return job.to_response()
     except Exception as exc:
@@ -427,7 +442,18 @@ async def start_job(kind: JobKind, args: dict[str, Any]) -> dict[str, Any]:
 async def confirm_job(job_id: str, confirm: bool) -> dict[str, Any]:
     job = await job_store.get(job_id)
     if not job:
-        return {"status": "failed", "success": False, "error": "Unknown job_id"}
+        # The job and its live browser only exist in this instance's memory, so a
+        # scaled-away or recycled instance loses them. Say so instead of
+        # reporting a generic failure the user cannot act on.
+        return {
+            "status": "expired",
+            "success": False,
+            "error": (
+                "This booking session expired because it sat unconfirmed too long. "
+                "Please start the booking again."
+            ),
+            "job_id": job_id,
+        }
 
     if job.status != JobStatus.NEEDS_CONFIRMATION:
         # Idempotent: if already terminal, return that.

--- a/booking-agent/app/config.py
+++ b/booking-agent/app/config.py
@@ -21,7 +21,11 @@ class Settings(BaseSettings):
     # implements. The dedicated 2.5 model answers reliably and speaks that set.
     computer_use_model: str = "gemini-2.5-computer-use-preview-10-2025"
     max_agent_turns: int = 40
-    job_ttl_seconds: int = 900
+    # Must stay under Cloud Run's ~15min idle reap. A job paused for confirmation
+    # sends no requests, so the instance (and the job's live browser) can be
+    # scaled away; expiring first turns that into an actionable message instead
+    # of a confirm landing on a cold instance that never saw the job.
+    job_ttl_seconds: int = 600
     screen_width: int = 1280
     screen_height: int = 720
     headless: bool = True

--- a/booking-agent/tests/test_confirm_lifecycle.py
+++ b/booking-agent/tests/test_confirm_lifecycle.py
@@ -1,0 +1,31 @@
+"""Confirmation-pause behaviour: no login gate, and expiry says so out loud."""
+
+import pytest
+
+from app.agent import REQUEST_CONFIRMATION_DECL, SYSTEM_INSTRUCTION, confirm_job
+from app.config import Settings
+
+
+def test_login_is_not_a_confirmation_kind():
+    """A login pause stranded jobs: the instance scaled away while the user read the prompt."""
+    kinds = REQUEST_CONFIRMATION_DECL.parameters_json_schema["properties"]["kind"]["enum"]
+    assert "login" not in kinds
+    assert "submit" in kinds
+
+
+def test_system_instruction_logs_in_without_asking():
+    assert "enter_foretees_credentials() directly" in SYSTEM_INSTRUCTION
+    assert 'request_confirmation(kind="login")' not in SYSTEM_INSTRUCTION
+
+
+def test_confirm_window_stays_under_cloud_run_idle_reap():
+    """Cloud Run reclaims an idle instance at ~15min, taking the job's live browser."""
+    assert Settings().job_ttl_seconds < 900
+
+
+@pytest.mark.asyncio
+async def test_confirming_an_unknown_job_reports_expired():
+    result = await confirm_job("does-not-exist", True)
+    assert result["status"] == "expired"
+    assert result["success"] is False
+    assert "start the booking again" in result["error"]

--- a/docs/architecture/COMPUTER_USE_BOOKING.md
+++ b/docs/architecture/COMPUTER_USE_BOOKING.md
@@ -10,12 +10,22 @@ Replaces the Node/Playwright microservice on Render
 |---|---|
 | Approach | Full Computer Use rewrite (not lift-and-shift of scripted Playwright) |
 | Speed | Not a hard requirement — multi-turn agent loop is OK |
-| Safety | Hybrid: auto-run low-risk nav; **SPA must confirm login + final submit/cancel** |
+| Safety | Hybrid: auto-run low-risk nav and login; **SPA must confirm final submit/cancel** |
 | Credentials | Never sent through the model — custom tool `enter_foretees_credentials` |
 
 Google’s Computer Use ToS: when the model returns `require_confirmation`, the
 end user must confirm. We never auto-ack those. Separately, our policy always
-pauses before credential entry and before irreversible ForeTees submit/cancel.
+pauses before irreversible ForeTees submit/cancel.
+
+Login is deliberately **not** gated. The model never sees the credentials, so a
+prompt there bought no safety — and it cost reliability: the job and its live
+Playwright browser exist only in one instance's memory, so while the user read
+the login prompt Cloud Run scaled the instance away and the confirm landed on a
+cold instance that had never seen the job. Confirmations now happen seconds
+before the submit the user just asked for. Two guards back that up:
+`job_ttl_seconds` (600) expires a stalled job *before* Cloud Run's ~15min idle
+reap, and an unknown `job_id` returns `status: "expired"` with a
+"start the booking again" message rather than a bare failure.
 
 ## Architecture
 
@@ -50,8 +60,8 @@ Playwright executes `click_at` / `type_text_at` / etc. from model function calls
 {
   "status": "needs_confirmation",
   "job_id": "…",
-  "kind": "login" | "submit" | "safety",
-  "explanation": "About to log in to Wingpoint…",
+  "kind": "submit" | "safety",
+  "explanation": "About to submit the 8:40 AM request…",
   "screenshot_b64": "…",   // optional PNG
   "success": false
 }
@@ -75,7 +85,7 @@ SPA → FastAPI `GET /api/foretees/tee-times` → booking-agent `POST /tee-times
 Built-in Computer Use (`ENVIRONMENT_BROWSER`) plus:
 
 1. **`request_confirmation(kind, explanation)`** — pauses the job for the SPA.
-   Required before login and before Submit Request / Cancel Reservation.
+   Required before Submit Request / Cancel Reservation. Not used for login.
 2. **`enter_foretees_credentials()`** — fills Wingpoint login from job-scoped
    secrets (never included in model prompts or `type_text_at`).
 3. **`report_booking_result(success, title, messages)`** — terminal structured

--- a/frontend/src/components/foretees/AgentConfirmDialog.jsx
+++ b/frontend/src/components/foretees/AgentConfirmDialog.jsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { useTheme } from '../../theme/Provider';
 
 const KIND_LABELS = {
-  login: 'Allow ForeTees login',
   submit: 'Confirm final submit',
   safety: 'Safety confirmation required',
 };
 
 /**
  * Mid-flow confirmation for the Computer Use booking agent.
- * Shown for login, final submit/cancel, and Google safety gates.
+ * Shown for the final submit/cancel and Google safety gates. Login is not
+ * gated — the agent fills credentials server-side, and a pause there let
+ * Cloud Run scale the instance (and the job's browser) away mid-flow.
  */
 const AgentConfirmDialog = ({ pendingConfirm, onResolve }) => {
   const theme = useTheme();


### PR DESCRIPTION
## Summary

Booking failed with a bare `Unknown job_id` after the agent correctly reached the login page and paused. Root cause from the logs for job `3f99987e`:

```text
19:00:47  POST /book              job created
19:01:27  waiting for confirm     kind=login     <- agent healthy
19:16:31  instance SHUT DOWN      (idle scale-to-zero)
19:29:51  new cold instance starts
19:29:59  POST .../confirm        job=None -> status=failed
```

A job paused for confirmation issues no requests, so Cloud Run reclaimed the instance — taking the in-memory job and its live Playwright browser with it. Session affinity was already on, but it can't route to an instance that no longer exists.

- **Drop the login confirmation.** The model never sees the credentials (`enter_foretees_credentials` fills them server-side), so the prompt bought no safety while costing the entire booking. Confirmation now happens only before the irreversible submit/cancel, seconds after the user asked for it.
- **Expire before Cloud Run reaps.** `job_ttl_seconds` 900 -> 600, so a stalled job fails with our own message instead of racing the ~15min idle reap.
- **Say "expired", not "failed."** An unknown `job_id` returns `status: "expired"` with "start the booking again"; a confirmation that goes unanswered raises `ConfirmationExpired` and closes the browser rather than holding it forever.

## Test plan

- [x] `booking-agent`: 21 passed (4 new tests covering the login gate, TTL headroom, and expired-job reporting)
- [x] `ruff check app/ tests/` clean
- [x] Frontend: `npm run typecheck`, `npx vitest run` (583 passed), `npm run build`
- [ ] Post-deploy: book a slot and confirm the agent logs in without prompting, then prompts only at submit