### PR TITLE
chore(sheets): cut over to 2026-27 season dashboard

### DIFF
--- a/.github/workflows/sheet-sync.yml
+++ b/.github/workflows/sheet-sync.yml
@@ -16,6 +16,6 @@ jobs:
     uses: ./.github/workflows/_cron-curl.yml
     with:
       label: Sheet → DB sync
-      url: https://wolf-goat-pig.onrender.com/admin/spreadsheet/sync-legacy-rounds
+      url: https://wolf-goat-pig-api-i5v2shrpoa-uc.a.run.app/admin/spreadsheet/sync-legacy-rounds
       headers: 'X-Admin-Email: stuagano@gmail.com'
       max-time: 120

--- a/backend/app/routers/unified_data.py
+++ b/backend/app/routers/unified_data.py
@@ -115,7 +115,7 @@ def get_leaderboard_config() -> Any:
     """Return the configured leaderboard spreadsheet URL.
 
     This is a public endpoint used by the frontend to build the 'View Spreadsheet' link.
-    The sheet ID can be changed via the LEADERBOARD_SHEET_ID env var on Render.
+    The sheet ID can be changed via the LEADERBOARD_SHEET_ID env var.
     """
     sheet_url = (
         f"https://docs.google.com/spreadsheets/d/{PRIMARY_SHEET_ID}"

--- a/backend/app/services/email_scheduler.py
+++ b/backend/app/services/email_scheduler.py
@@ -590,7 +590,7 @@ class EmailScheduler:
         #     import httpx
         #
         #     # Hardcoded sheet URL (same as in SheetSyncContext)
-        #     sheet_id = "1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM"
+        #     sheet_id = "141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ"
         #     gid = "0"
         #     csv_url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&gid={gid}"
         #

--- a/backend/app/services/spreadsheet_sync_service.py
+++ b/backend/app/services/spreadsheet_sync_service.py
@@ -2,7 +2,7 @@
 
 This service provides two-way sync between the Wolf Goat Pig app and the
 legacy Google Sheets dashboard at:
-- Primary (read-only): https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM
+- Primary (read-only): https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ
 - Writable copy: https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
 
 Sheet Structure:
@@ -40,7 +40,7 @@ from ..observability.report import report_exception
 logger = logging.getLogger(__name__)
 
 # Spreadsheet IDs — PRIMARY_SHEET_ID can be overridden via LEADERBOARD_SHEET_ID env var
-PRIMARY_SHEET_ID = os.environ.get("LEADERBOARD_SHEET_ID", "1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM")
+PRIMARY_SHEET_ID = os.environ.get("LEADERBOARD_SHEET_ID", "141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ")
 WRITABLE_SHEET_ID = "19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA"  # Stuart's writable copy for app sync
 
 # Tab GID for the leaderboard view (Details tab)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -211,7 +211,7 @@
       "Body_import_course_from_file_courses_import_file_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -225,7 +225,7 @@
       "Body_scan_scorecard_photo_scorecard_scan_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           },
@@ -250,7 +250,7 @@
       "Body_upload_gmail_credentials_admin_upload_credentials_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -264,7 +264,7 @@
       "Body_upload_my_avatar_players_me_avatar_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -3813,13 +3813,6 @@
       },
       "ValidationError": {
         "properties": {
-          "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "input": {
-            "title": "Input"
-          },
           "loc": {
             "items": {
               "anyOf": [
@@ -7423,7 +7416,7 @@
     },
     "/data/leaderboard-config": {
       "get": {
-        "description": "Return the configured leaderboard spreadsheet URL.\n\nThis is a public endpoint used by the frontend to build the 'View Spreadsheet' link.\nThe sheet ID can be changed via the LEADERBOARD_SHEET_ID env var on Render.",
+        "description": "Return the configured leaderboard spreadsheet URL.\n\nThis is a public endpoint used by the frontend to build the 'View Spreadsheet' link.\nThe sheet ID can be changed via the LEADERBOARD_SHEET_ID env var.",
         "operationId": "get_leaderboard_config_data_leaderboard_config_get",
         "responses": {
           "200": {

--- a/docs/backend/SHEET_SYNC_SCHEDULER.md
+++ b/docs/backend/SHEET_SYNC_SCHEDULER.md
@@ -69,7 +69,7 @@ To manually trigger a sync (bypassing the 1-hour rate limit):
 curl -X POST https://wolf-goat-pig.onrender.com/sheet-integration/sync-wgp-sheet \
   -H "Content-Type: application/json" \
   -H "X-Scheduled-Job: true" \
-  -d '{"csv_url": "https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/export?format=csv&gid=0"}'
+  -d '{"csv_url": "https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/export?format=csv&gid=0"}'
 ```
 
 ## Monitoring

--- a/docs/guides/google-sheets-sync.md
+++ b/docs/guides/google-sheets-sync.md
@@ -9,13 +9,12 @@ sync, how to verify it, and how to push data back to a sheet.
 - **Push** (app → sheet): an optional Apps Script writes the live leaderboard back
   into a sheet tab.
 
-**Default sheet:** `https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM`
+**Default sheet:** `https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ`
 
-> ⚠️ **Scheduling caveat.** The code references a daily 2 AM in-process sync
-> (`backend/app/services/email_scheduler.py`), but the in-process scheduler does
-> **not** run reliably on Render, and there is currently **no** GitHub Actions cron
-> replacement for sheet sync. Treat the **admin UI / API sync as the reliable path**
-> and trigger it manually when you need fresh data.
+> **Scheduling.** Sheet → DB sync runs every 2 hours via `.github/workflows/sheet-sync.yml`
+> against the Cloud Run API. In-process schedulers are disabled in production
+> (`RUN_INPROCESS_SCHEDULERS=false`). The admin UI / API sync remains available
+> for an immediate refresh.
 
 ## How it works
 
@@ -46,10 +45,10 @@ preview table and optional auto-sync interval.
 ### 2. API
 
 ```bash
-curl -X POST https://wolf-goat-pig.onrender.com/sheet-integration/sync-wgp-sheet \
+curl -X POST https://wolf-goat-pig-api-i5v2shrpoa-uc.a.run.app/sheet-integration/sync-wgp-sheet \
   -H "Content-Type: application/json" \
   -H "X-Scheduled-Job: true" \
-  -d '{"csv_url":"https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/export?format=csv&gid=0"}'
+  -d '{"csv_url":"https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/export?format=csv&gid=0"}'
 ```
 
 The `X-Scheduled-Job: true` header bypasses the one-sync-per-hour rate limit on
@@ -67,10 +66,10 @@ the public endpoint. The response includes `sync_results`
 
 ```bash
 # Backend up? (environment must read "production")
-curl https://wolf-goat-pig.onrender.com/health
+curl https://wolf-goat-pig-api-i5v2shrpoa-uc.a.run.app/health
 
 # Data present?
-curl https://wolf-goat-pig.onrender.com/leaderboard/total_earnings
+curl https://wolf-goat-pig-api-i5v2shrpoa-uc.a.run.app/leaderboard/total_earnings
 ```
 
 Expected leaderboard shape:
@@ -111,7 +110,7 @@ Direct API call (no context):
 
 ```javascript
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
-const csvUrl = "https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/export?format=csv&gid=0";
+const csvUrl = "https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/export?format=csv&gid=0";
 const res = await fetch(`${API_URL}/sheet-integration/sync-wgp-sheet`, {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
@@ -129,7 +128,7 @@ pulls from the API. In the sheet: **Extensions → Apps Script**, paste the scri
 below, save, and run `testAPIConnection` once to grant permissions.
 
 ```javascript
-const API_URL = 'https://wolf-goat-pig.onrender.com';
+const API_URL = 'https://wolf-goat-pig-api-i5v2shrpoa-uc.a.run.app';
 const LEADERBOARD_SHEET_NAME = 'Leaderboard';
 const LEADERBOARD_TYPE = 'total_earnings';
 // types: total_earnings | win_rate | games_played | average_score | partnerships_won

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1434,7 +1434,7 @@ export interface paths {
          * @description Return the configured leaderboard spreadsheet URL.
          *
          *     This is a public endpoint used by the frontend to build the 'View Spreadsheet' link.
-         *     The sheet ID can be changed via the LEADERBOARD_SHEET_ID env var on Render.
+         *     The sheet ID can be changed via the LEADERBOARD_SHEET_ID env var.
          */
         get: operations["get_leaderboard_config_data_leaderboard_config_get"];
         put?: never;
@@ -4874,24 +4874,36 @@ export interface components {
         };
         /** Body_import_course_from_file_courses_import_file_post */
         Body_import_course_from_file_courses_import_file_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_scan_scorecard_photo_scorecard_scan_post */
         Body_scan_scorecard_photo_scorecard_scan_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
             /** Players */
             players?: string | null;
         };
         /** Body_upload_gmail_credentials_admin_upload_credentials_post */
         Body_upload_gmail_credentials_admin_upload_credentials_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_upload_my_avatar_players_me_avatar_post */
         Body_upload_my_avatar_players_me_avatar_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** BookTeeTimeRequest */
@@ -6358,10 +6370,6 @@ export interface components {
         };
         /** ValidationError */
         ValidationError: {
-            /** Context */
-            ctx?: Record<string, never>;
-            /** Input */
-            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */

--- a/frontend/src/components/integration/SheetIntegrationDashboard.jsx
+++ b/frontend/src/components/integration/SheetIntegrationDashboard.jsx
@@ -464,7 +464,7 @@ const SheetIntegrationDashboard = () => {
                                 </div>
                             )}
                             <p className="text-xs text-gray-500">
-                                To change the spreadsheet, update <code>LEADERBOARD_SHEET_ID</code> in Render environment variables.
+                                To change the spreadsheet, update <code>LEADERBOARD_SHEET_ID</code> (or the default in spreadsheet_sync_service.py).
                                 The leaderboard cache syncs automatically every 2 hours.
                             </p>
                         </>

--- a/frontend/src/components/ui/Navigation.jsx
+++ b/frontend/src/components/ui/Navigation.jsx
@@ -68,7 +68,7 @@ const Navigation = () => {
     { path: '/ask', label: 'Ask Commissioner', icon: '⚖️' },
     { path: '/analytics', label: 'Analytics', icon: '📈' },
     { path: '/about', label: 'About', icon: 'ℹ️' },
-    { href: 'https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM', label: 'Legacy Standings', icon: '📊', external: true },
+    { href: 'https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ', label: 'Legacy Standings', icon: '📊', external: true },
     ...(showAdminLink ? [{ path: '/admin', label: 'Admin', icon: '🔧' }] : [])
   ];
 
@@ -93,7 +93,7 @@ const Navigation = () => {
     { path: '/analytics', label: '📈 Analytics', primary: false },
     { path: '/about', label: 'ℹ️ About', primary: false },
     { path: '/rules', label: '📋 Rules', primary: false },
-    { href: 'https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM', label: '📊 Legacy Standings', primary: false, external: true },
+    { href: 'https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ', label: '📊 Legacy Standings', primary: false, external: true },
     ...(showAdminLink ? [{ path: '/admin', label: '🔧 Admin', primary: true }] : [])
   ];
 

--- a/frontend/src/context/SheetSyncContext.jsx
+++ b/frontend/src/context/SheetSyncContext.jsx
@@ -15,7 +15,7 @@ export const useSheetSync = () => {
 
 export const SheetSyncProvider = ({ children }) => {
   const [sheetUrl, setSheetUrl] = useState(
-    "https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/edit?gid=474065919#gid=474065919",
+    "https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/edit?gid=474065919#gid=474065919",
   );
   const [syncStatus, setSyncStatus] = useState("idle"); // idle, connecting, syncing, error, success
   const [lastSync, setLastSync] = useState(null);

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -218,7 +218,7 @@ function HomePage() {
               </button>
             ))}
             <a
-              href="https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM"
+              href="https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/scripts/deployment/test-production-sync.sh
+++ b/scripts/deployment/test-production-sync.sh
@@ -5,7 +5,7 @@
 set -e
 
 PROD_URL="https://wolf-goat-pig.onrender.com"
-SHEET_CSV_URL="https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/export?format=csv&gid=0"
+SHEET_CSV_URL="https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/export?format=csv&gid=0"
 
 echo "🔍 Testing Production Google Sheets Sync"
 echo "========================================"

--- a/scripts/diagnostics/test_all_routes.py
+++ b/scripts/diagnostics/test_all_routes.py
@@ -24,7 +24,7 @@ API_BASE_URL = LOCAL_API if "--local" in sys.argv else PRODUCTION_API
 
 # Test data
 TEST_ADMIN_EMAIL = "stuagano@gmail.com"
-TEST_CSV_URL = "https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/export?format=csv&gid=0"
+TEST_CSV_URL = "https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/export?format=csv&gid=0"
 
 # Colors for output
 GREEN = '\033[92m'

--- a/scripts/diagnostics/test_sheet_parsing.py
+++ b/scripts/diagnostics/test_sheet_parsing.py
@@ -4,7 +4,7 @@
 import requests
 
 # Your sheet URL
-csv_url = "https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/export?format=csv&gid=474065919"
+csv_url = "https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/export?format=csv&gid=474065919"
 
 # Fetch the CSV data
 response = requests.get(csv_url, timeout=30)

--- a/scripts/diagnostics/test_sync_endpoints.py
+++ b/scripts/diagnostics/test_sync_endpoints.py
@@ -7,7 +7,7 @@ import httpx
 import json
 
 # Test the endpoints with a mock CSV URL
-TEST_CSV_URL = "https://docs.google.com/spreadsheets/d/1PWhi5rJ4ZGhTwySZh-D_9lo_GKJcHb1Q5MEkNasHLgM/export?format=csv&gid=0"
+TEST_CSV_URL = "https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ/export?format=csv&gid=0"
 API_BASE_URL = "http://localhost:8000"
 
 async def test_fetch_google_sheet():


### PR DESCRIPTION
## Summary
- Point `PRIMARY_SHEET_ID` (and all frontend Legacy Standings / Sheet Sync links) at the new **WGP Dashboard 2026-2027** sheet: `141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ`
- Retarget `.github/workflows/sheet-sync.yml` from dead `wolf-goat-pig.onrender.com` to Cloud Run so the every-2h Sheet → DB sync works again
- Leave `WRITABLE_SHEET_ID` on Stuart's existing writable copy for now (app → sheet writes)

Public CSV for the new sheet already exposes the expected `Details` columns (`Date,Group,Member,Score,Location,Duration`) and the Dashboard tab at the same `gid=474065919`.

## Test plan
- [x] Sheet-related unit tests pass
- [x] OpenAPI `--check` in sync
- [x] Frontend typecheck
- [ ] After merge: trigger Sheet → DB Sync workflow and confirm `rows_synced > 0`
- [ ] Confirm OAuth account (`GOOGLE_OAUTH_CREDENTIALS`) can read the new sheet (share Viewer with that Google account if sync returns empty / 403)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated spreadsheet integrations and legacy standings links to use the current Google Sheets sources.
  - Moved documented sync and verification examples to the current service endpoint.
  - Clarified spreadsheet configuration and scheduling guidance.
  - Improved API documentation for file uploads and validation errors.
  - Updated leaderboard configuration guidance to reflect environment-based sheet selection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->