### PR TITLE
fix(sheets): stop reading the retired writable copy

### DIFF
--- a/backend/app/routers/spreadsheet_sync.py
+++ b/backend/app/routers/spreadsheet_sync.py
@@ -341,6 +341,7 @@ def get_spreadsheet_config():
     return {
         "primary_sheet_id": PRIMARY_SHEET_ID,
         "writable_sheet_id": WRITABLE_SHEET_ID,
+        "writable_sheet_retired_for_reads": True,
         "primary_url": f"https://docs.google.com/spreadsheets/d/{PRIMARY_SHEET_ID}",
         "writable_url": f"https://docs.google.com/spreadsheets/d/{WRITABLE_SHEET_ID}",
         "sheets": ["Dashboard", "Details"],

--- a/backend/app/services/spreadsheet_sync_service.py
+++ b/backend/app/services/spreadsheet_sync_service.py
@@ -1,9 +1,8 @@
 """Service for syncing game data with the WGP Dashboard Google Sheet.
 
-This service provides two-way sync between the Wolf Goat Pig app and the
-legacy Google Sheets dashboard at:
-- Primary (read-only): https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ
-- Writable copy: https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
+This service syncs the Wolf Goat Pig app with the season Google Sheet:
+- Primary (season of record, reads): https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ
+- Writable copy (app→sheet writes only; no longer read): https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
 
 Sheet Structure:
 - Dashboard: Leaderboard summary (auto-calculated from Details)
@@ -41,7 +40,10 @@ logger = logging.getLogger(__name__)
 
 # Spreadsheet IDs — PRIMARY_SHEET_ID can be overridden via LEADERBOARD_SHEET_ID env var
 PRIMARY_SHEET_ID = os.environ.get("LEADERBOARD_SHEET_ID", "141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ")
-WRITABLE_SHEET_ID = "19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA"  # Stuart's writable copy for app sync
+# Retired for reads after the 2026-27 cutover (prior-season rows polluted the
+# leaderboard). Still used as the default target for app→sheet *writes* until
+# those are pointed at the season sheet.
+WRITABLE_SHEET_ID = "19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA"
 
 # Tab GID for the leaderboard view (Details tab)
 PRIMARY_SHEET_TAB_GID = os.environ.get("LEADERBOARD_SHEET_TAB_GID", "474065919")

--- a/backend/app/services/unified_data_service.py
+++ b/backend/app/services/unified_data_service.py
@@ -1,11 +1,11 @@
 """Unified data service that merges data from all sources.
 
 This service provides a single view of all game data by merging:
-1. Primary spreadsheet (read-only legacy data)
-2. Writable spreadsheet (app-entered data during transition)
-3. Render database (games recorded directly in the app)
+1. Primary spreadsheet (season-of-record Google Sheet)
+2. Database (games recorded directly in the app)
 
-The service deduplicates data and provides a unified leaderboard and round history.
+The old transition-era writable sheet copy is no longer read — it held prior-
+season rounds and was polluting the 2026-27 leaderboard after the sheet cutover.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 from ..database import get_db
 from ..models import GamePlayerResult, GameRecord, LegacyRound
 from ..utils.time import utc_now
-from .spreadsheet_sync_service import PRIMARY_SHEET_ID, WRITABLE_SHEET_ID, RoundResult, SpreadsheetSyncService
+from .spreadsheet_sync_service import PRIMARY_SHEET_ID, RoundResult, SpreadsheetSyncService
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,6 @@ class UnifiedDataService:
 
     def __init__(self, db: Session | None = None):
         self.primary_sheet = SpreadsheetSyncService(PRIMARY_SHEET_ID)
-        self.writable_sheet = SpreadsheetSyncService(WRITABLE_SHEET_ID)
         self._db = db
 
     def _get_db(self) -> Session:
@@ -191,7 +190,12 @@ class UnifiedDataService:
                 # Exclude pending member-posted rounds — they are not
                 # authoritative until a foursome member attests them. Sheet/db
                 # rows default to status='attested' so they are unaffected.
-                for r in db.query(LegacyRound).filter(LegacyRound.status != "pending").all():
+                # Also skip retired writable_sheet rows from the prior season.
+                for r in (
+                    db.query(LegacyRound)
+                    .filter(LegacyRound.status != "pending", LegacyRound.source != "writable_sheet")
+                    .all()
+                ):
                     unified = self._legacy_round_to_unified(r)
                     key = (unified.date_sortable, unified.group, unified.member, unified.score)
                     if key not in all_rounds:
@@ -199,7 +203,8 @@ class UnifiedDataService:
             except Exception as e:
                 logger.warning(f"Failed to read legacy_rounds cache: {e}")
         else:
-            # Slow path: live Sheets API — used only by the sync job itself
+            # Slow path: live Sheets API — used only by the sync job itself.
+            # Primary season sheet only; the old writable copy is retired.
             try:
                 for r in self.primary_sheet.get_all_rounds():
                     unified = self._sheet_round_to_unified(r, "primary_sheet")
@@ -208,15 +213,6 @@ class UnifiedDataService:
                         all_rounds[key] = unified
             except Exception as e:
                 logger.warning(f"Failed to fetch primary sheet: {e}")
-
-            try:
-                for r in self.writable_sheet.get_all_rounds():
-                    unified = self._sheet_round_to_unified(r, "writable_sheet")
-                    key = (unified.date_sortable, unified.group, unified.member, unified.score)
-                    if key not in all_rounds:
-                        all_rounds[key] = unified
-            except Exception as e:
-                logger.warning(f"Failed to fetch writable sheet: {e}")
 
         # Merge in-app GameRecord results
         if include_database:
@@ -302,7 +298,7 @@ class UnifiedDataService:
         Returns:
             Status info for each source including record counts
         """
-        status = {
+        status: dict[str, Any] = {
             "primary_sheet": {
                 "available": False,
                 "record_count": 0,
@@ -311,7 +307,9 @@ class UnifiedDataService:
             "writable_sheet": {
                 "available": False,
                 "record_count": 0,
-                "id": WRITABLE_SHEET_ID,
+                "id": None,
+                "retired": True,
+                "error": "Prior-season writable copy is no longer read",
             },
             "database": {"available": False, "record_count": 0},
             "unified_total": 0,
@@ -321,14 +319,10 @@ class UnifiedDataService:
         try:
             db = self._get_db()
             primary_count = db.query(LegacyRound).filter(LegacyRound.source == "primary_sheet").count()
-            writable_count = db.query(LegacyRound).filter(LegacyRound.source == "writable_sheet").count()
-            status["primary_sheet"]["available"] = primary_count > 0  # type: ignore[index]
-            status["primary_sheet"]["record_count"] = primary_count  # type: ignore[index]
-            status["writable_sheet"]["available"] = writable_count > 0  # type: ignore[index]
-            status["writable_sheet"]["record_count"] = writable_count  # type: ignore[index]
+            status["primary_sheet"]["available"] = primary_count > 0
+            status["primary_sheet"]["record_count"] = primary_count
         except Exception as e:
-            status["primary_sheet"]["error"] = str(e)  # type: ignore[index]
-            status["writable_sheet"]["error"] = str(e)  # type: ignore[index]
+            status["primary_sheet"]["error"] = str(e)
 
         try:
             db = self._get_db()
@@ -338,21 +332,16 @@ class UnifiedDataService:
                 .filter(GameRecord.completed_at.isnot(None))
                 .count()
             )
-            status["database"]["available"] = True  # type: ignore[index]
-            status["database"]["record_count"] = db_count  # type: ignore[index]
+            status["database"]["available"] = True
+            status["database"]["record_count"] = db_count
         except Exception as e:
-            status["database"]["error"] = str(e)  # type: ignore[index]
+            status["database"]["error"] = str(e)
 
-        # Calculate totals
-        status["unified_total"] = (
-            status["primary_sheet"]["record_count"]  # type: ignore[index]
-            + status["writable_sheet"]["record_count"]  # type: ignore[index]
-            + status["database"]["record_count"]  # type: ignore[index]
-        )
+        status["unified_total"] = status["primary_sheet"]["record_count"] + status["database"]["record_count"]
 
         try:
             db = self._get_db()
-            status["deduplicated_total"] = db.query(LegacyRound).count()
+            status["deduplicated_total"] = db.query(LegacyRound).filter(LegacyRound.source != "writable_sheet").count()
         except Exception:
             pass
 

--- a/backend/tests/unit/services/test_unified_data_service.py
+++ b/backend/tests/unit/services/test_unified_data_service.py
@@ -180,9 +180,7 @@ class TestGetUnifiedLeaderboard:
     def test_returns_list(self):
         svc = make_service()
         svc.primary_sheet = MagicMock()
-        svc.writable_sheet = MagicMock()
         svc.primary_sheet.get_all_rounds.return_value = []
-        svc.writable_sheet.get_all_rounds.return_value = []
 
         db = MagicMock()
         svc._db = db
@@ -198,7 +196,6 @@ class TestGetUnifiedLeaderboard:
         """Two rounds for same member should sum quarters."""
         svc = make_service()
         svc.primary_sheet = MagicMock()
-        svc.writable_sheet = MagicMock()
 
         from app.services.spreadsheet_sync_service import RoundResult
 
@@ -208,7 +205,6 @@ class TestGetUnifiedLeaderboard:
             RoundResult(date="06-Apr", group="A", member="Jeff", score=-4, location="Wing Point"),
         ]
         svc.primary_sheet.get_all_rounds.return_value = rounds
-        svc.writable_sheet.get_all_rounds.return_value = []
         svc._db = MagicMock()
         svc._db.query.return_value.all.return_value = []
 
@@ -220,3 +216,15 @@ class TestGetUnifiedLeaderboard:
                 assert stuart.rounds == 2
         except Exception:
             pass  # External deps; focus on pure logic elsewhere
+
+    def test_live_fetch_skips_writable_sheet(self):
+        """Prior-season writable copy must not be merged into season-of-record data."""
+        svc = make_service()
+        svc.primary_sheet = MagicMock()
+        svc.primary_sheet.get_all_rounds.return_value = []
+        svc._db = MagicMock()
+        # Would fail AttributeError if code still called writable_sheet
+        assert not hasattr(svc, "writable_sheet")
+        rounds = svc.get_all_rounds(include_database=False, use_sheet_cache=False)
+        assert rounds == []
+        svc.primary_sheet.get_all_rounds.assert_called_once()


### PR DESCRIPTION
## Summary
- Stop merging the prior-season writable Google Sheet into `get_all_rounds`
- Skip cached `writable_sheet` rows so the leaderboard is clean before the next sync
- Mark writable as retired in data-source status / spreadsheet config
- Next Sheet → DB sync will rewrite `legacy_rounds` from primary only (~28 season rows)

## Test plan
- [x] Unit tests for unified data + spreadsheet routers
- [ ] After merge: POST `/admin/spreadsheet/sync-legacy-rounds` and confirm `rows_synced` ≈ season Details count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spreadsheet configuration status indicating that the writable sheet is retired for data reads.

* **Updates**
  * Data synchronization now reads from the primary spreadsheet and app database only.
  * Retired writable-sheet records are excluded from unified data and leaderboard results.
  * Data source status now identifies the writable sheet as retired and updates availability totals accordingly.

* **Bug Fixes**
  * Prevented data retrieval from querying the retired writable-sheet source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->