### PR TITLE
fix(sheets): use the 2026-27 sheet for writes too

### DIFF
--- a/backend/app/routers/spreadsheet_sync.py
+++ b/backend/app/routers/spreadsheet_sync.py
@@ -341,7 +341,6 @@ def get_spreadsheet_config():
     return {
         "primary_sheet_id": PRIMARY_SHEET_ID,
         "writable_sheet_id": WRITABLE_SHEET_ID,
-        "writable_sheet_retired_for_reads": True,
         "primary_url": f"https://docs.google.com/spreadsheets/d/{PRIMARY_SHEET_ID}",
         "writable_url": f"https://docs.google.com/spreadsheets/d/{WRITABLE_SHEET_ID}",
         "sheets": ["Dashboard", "Details"],

--- a/backend/app/services/spreadsheet_sync_service.py
+++ b/backend/app/services/spreadsheet_sync_service.py
@@ -1,8 +1,7 @@
 """Service for syncing game data with the WGP Dashboard Google Sheet.
 
 This service syncs the Wolf Goat Pig app with the season Google Sheet:
-- Primary (season of record, reads): https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ
-- Writable copy (app→sheet writes only; no longer read): https://docs.google.com/spreadsheets/d/19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA
+- Season of record (reads + writes): https://docs.google.com/spreadsheets/d/141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ
 
 Sheet Structure:
 - Dashboard: Leaderboard summary (auto-calculated from Details)
@@ -17,7 +16,7 @@ Sheet Structure:
 The service uses Google Sheets API v4 with OAuth credentials.
 
 To enable write access:
-1. Share the writable spreadsheet with stuagano@gmail.com as Editor
+1. Share the season spreadsheet with stuagano@gmail.com as Editor
 2. Ensure gcloud is authenticated with that account:
    gcloud auth application-default login --scopes="openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive"
 """
@@ -40,10 +39,8 @@ logger = logging.getLogger(__name__)
 
 # Spreadsheet IDs — PRIMARY_SHEET_ID can be overridden via LEADERBOARD_SHEET_ID env var
 PRIMARY_SHEET_ID = os.environ.get("LEADERBOARD_SHEET_ID", "141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ")
-# Retired for reads after the 2026-27 cutover (prior-season rows polluted the
-# leaderboard). Still used as the default target for app→sheet *writes* until
-# those are pointed at the season sheet.
-WRITABLE_SHEET_ID = "19AabC4vx0jRXHIAmz8QJfqTIBxxvMfFUplB0abg8mdA"
+# Season of record only — app→sheet writes go to the same workbook as reads.
+WRITABLE_SHEET_ID = PRIMARY_SHEET_ID
 
 # Tab GID for the leaderboard view (Details tab)
 PRIMARY_SHEET_TAB_GID = os.environ.get("LEADERBOARD_SHEET_TAB_GID", "474065919")
@@ -218,7 +215,7 @@ def _sheets_api_append(sheet_id: str, range_spec: str, values: list[list[Any]]) 
 class SpreadsheetSyncService:
     """Service for syncing game data with Google Sheets."""
 
-    def __init__(self, sheet_id: str = WRITABLE_SHEET_ID):
+    def __init__(self, sheet_id: str = PRIMARY_SHEET_ID):
         self.sheet_id = sheet_id
 
     def get_all_rounds(self) -> list[RoundResult]:

--- a/backend/app/services/unified_data_service.py
+++ b/backend/app/services/unified_data_service.py
@@ -307,9 +307,8 @@ class UnifiedDataService:
             "writable_sheet": {
                 "available": False,
                 "record_count": 0,
-                "id": None,
-                "retired": True,
-                "error": "Prior-season writable copy is no longer read",
+                "id": PRIMARY_SHEET_ID,
+                "note": "Same workbook as primary_sheet (season of record)",
             },
             "database": {"available": False, "record_count": 0},
             "unified_total": 0,

--- a/backend/tests/unit/services/test_unified_data_service.py
+++ b/backend/tests/unit/services/test_unified_data_service.py
@@ -228,3 +228,11 @@ class TestGetUnifiedLeaderboard:
         rounds = svc.get_all_rounds(include_database=False, use_sheet_cache=False)
         assert rounds == []
         svc.primary_sheet.get_all_rounds.assert_called_once()
+
+def test_writable_sheet_is_season_primary():
+    """App→sheet writes must target the same 2026-27 workbook as reads."""
+    from app.services.spreadsheet_sync_service import PRIMARY_SHEET_ID, WRITABLE_SHEET_ID
+
+    assert WRITABLE_SHEET_ID == PRIMARY_SHEET_ID
+    assert PRIMARY_SHEET_ID == "141s8V_UACdBc8Xg17W0UhWxd08BMbEImkXOSPa66RfQ"
+


### PR DESCRIPTION
## Summary
Point `WRITABLE_SHEET_ID` at the same 2026-27 season workbook as `PRIMARY_SHEET_ID`. Reads already ignore the old copy; writes now go to the new sheet only.

**Note:** the OAuth account behind `GOOGLE_OAUTH_CREDENTIALS` needs **Editor** on the new sheet for appends to succeed.

## Test plan
- [x] Unit tests
- [ ] After merge: `/admin/spreadsheet/config` shows identical primary/writable IDs