### PR TITLE
fix(booking): ask for submit confirmation once per booking

### DIFF
--- a/booking-agent/app/agent.py
+++ b/booking-agent/app/agent.py
@@ -24,9 +24,10 @@ RULES:
    - Call enter_foretees_credentials() directly. Do NOT ask the user to
      confirm logging in — the credentials are filled server-side and are
      never exposed to you.
-2. Before clicking Submit Request, Submit Changes, or Cancel Reservation:
-   - Call request_confirmation(kind="submit", explanation=...).
-   - Only click the button after the user confirms.
+2. Call request_confirmation(kind="submit", explanation=...) exactly ONCE per
+   booking, immediately before the first Submit Request / Submit Changes /
+   Cancel Reservation click. That one approval covers the rest of this job —
+   do not ask again for later steps or confirmation dialogs.
 3. Stay on wingpointgolf.com and ftapp.wingpointgolf.com only.
 4. When the booking/cancel outcome is clear from the page (success or ForeTees
    error messages), call report_booking_result(...).
@@ -38,6 +39,7 @@ REQUEST_CONFIRMATION_DECL = types.FunctionDeclaration(
     name="request_confirmation",
     description=(
         "Pause and ask the end user to confirm before the final submit or cancel. "
+        "Call at most once per booking; the approval covers every remaining step. "
         "Do not use this for logging in."
     ),
     parameters_json_schema={
@@ -308,17 +310,26 @@ async def run_job(job: BookingJob) -> dict[str, Any]:
                 if name == "request_confirmation":
                     kind = str(args.get("kind") or "safety")
                     explanation = str(args.get("explanation") or "Confirmation required")
-                    approved = await _pause_for_confirm(job, kind, explanation, page)
-                    if not approved:
-                        job.status = JobStatus.FAILED
-                        job.error = "User denied confirmation"
-                        await job.close_browser()
-                        return job.to_response()
+                    if job.action_confirmed:
+                        # ForeTees has several submit-ish steps and the model asks at
+                        # each one; re-prompting made a single booking cost the user
+                        # three taps. The first approval covers this job's action.
+                        logger.info("job %s reusing existing confirmation kind=%s", job.id, kind)
+                        result = "confirmed"
+                    else:
+                        approved = await _pause_for_confirm(job, kind, explanation, page)
+                        if not approved:
+                            job.status = JobStatus.FAILED
+                            job.error = "User denied confirmation"
+                            await job.close_browser()
+                            return job.to_response()
+                        job.action_confirmed = True
+                        result = "confirmed"
                     fr_parts.append(
                         await _function_response_part(
                             name,
                             page,
-                            {"result": "confirmed"},
+                            {"result": result},
                             extra_fr,
                         )
                     )

--- a/booking-agent/app/jobs.py
+++ b/booking-agent/app/jobs.py
@@ -46,6 +46,9 @@ class BookingJob:
     pending_function_calls: list[Any] = field(default_factory=list)
     confirm_event: asyncio.Event = field(default_factory=asyncio.Event)
     confirm_decision: bool | None = None
+    # A job is a single book-or-cancel, so our own policy gate is asked once.
+    # Google's safety gates are separate and always surfaced.
+    action_confirmed: bool = False
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     def touch(self) -> None:

--- a/booking-agent/tests/test_confirm_lifecycle.py
+++ b/booking-agent/tests/test_confirm_lifecycle.py
@@ -1,9 +1,10 @@
-"""Confirmation-pause behaviour: no login gate, and expiry says so out loud."""
+"""Confirmation-pause behaviour: no login gate, asked once, and expiry says so."""
 
 import pytest
 
 from app.agent import REQUEST_CONFIRMATION_DECL, SYSTEM_INSTRUCTION, confirm_job
 from app.config import Settings
+from app.jobs import BookingJob, JobKind
 
 
 def test_login_is_not_a_confirmation_kind():
@@ -16,6 +17,17 @@ def test_login_is_not_a_confirmation_kind():
 def test_system_instruction_logs_in_without_asking():
     assert "enter_foretees_credentials() directly" in SYSTEM_INSTRUCTION
     assert 'request_confirmation(kind="login")' not in SYSTEM_INSTRUCTION
+
+
+def test_confirmation_is_requested_at_most_once():
+    """Asking at every submit-ish step cost the user three taps for one booking."""
+    assert "ONCE per" in SYSTEM_INSTRUCTION
+    assert "at most once per booking" in REQUEST_CONFIRMATION_DECL.description
+
+
+def test_a_fresh_job_has_not_been_confirmed():
+    job = BookingJob(id="j1", kind=JobKind.BOOK, args={})
+    assert job.action_confirmed is False
 
 
 def test_confirm_window_stays_under_cloud_run_idle_reap():


### PR DESCRIPTION
## Summary
Booking now works end to end, but a single tee time still prompted three times. ForeTees has several submit-ish steps (slot, players, submit, dialog) and nothing deduped our own gate, so the model asked at each one.

- Track `action_confirmed` on the job; the first approval covers the rest of that book/cancel
- Tell the model to call `request_confirmation` exactly once, immediately before the first submit click
- Google's `require_confirmation` safety gates are deliberately unchanged — Computer Use ToS requires the end user answer each one

## Test plan
- [x] `booking-agent`: 23 passed, `ruff check` clean
- [ ] After deploy: book a slot and confirm exactly one prompt (barring a Google safety gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Booking and cancellation actions now require confirmation only once per session.
  * The initial approval automatically covers the remaining related steps.

* **Bug Fixes**
  * Prevented repeated confirmation prompts after approval.
  * New booking sessions correctly begin without prior confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->