### PR TITLE
feat: manage club-player link from the Account page

### DIFF
--- a/frontend/src/components/auth/LegacyNameSelector.jsx
+++ b/frontend/src/components/auth/LegacyNameSelector.jsx
@@ -5,13 +5,21 @@ const API_URL = apiConfig.baseUrl;
 
 /**
  * Component for selecting a legacy player name from the thousand-cranes.com tee sheet
- * Shows a searchable dropdown of all known legacy players
+ * Shows a searchable dropdown of all known legacy players.
+ *
+ * Reused in two places: the first-login onboarding modal and the Account page's
+ * "Club Player" section. The header copy and the secondary (skip/cancel) button
+ * are configurable so it reads correctly in both contexts. The skip button is
+ * only rendered when ``onSkip`` is provided.
  */
 const LegacyNameSelector = ({
   currentName,
   onSelect,
   onSkip,
-  suggestedName = null
+  suggestedName = null,
+  title = 'Link Your Account',
+  description = 'Select your name from the Wing Point Golf tee sheet to sync your signups with the existing system.',
+  skipLabel = "I'm not in the list (new player)"
 }) => {
   const [players, setPlayers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -78,7 +86,7 @@ const LegacyNameSelector = ({
     return (
       <div className="legacy-name-selector error">
         <p>Error loading players: {error}</p>
-        <button onClick={onSkip}>Skip for now</button>
+        {onSkip && <button onClick={onSkip}>Skip for now</button>}
       </div>
     );
   }
@@ -86,11 +94,8 @@ const LegacyNameSelector = ({
   return (
     <div className="legacy-name-selector">
       <div className="selector-header">
-        <h3>Link Your Account</h3>
-        <p>
-          Select your name from the Wing Point Golf tee sheet to sync your signups
-          with the existing system.
-        </p>
+        <h3>{title}</h3>
+        <p>{description}</p>
         {currentName && (
           <p className="current-name">
             Signed in as: <strong>{currentName}</strong>
@@ -163,12 +168,14 @@ const LegacyNameSelector = ({
           Confirm: {selectedName || 'Select a name'}
         </button>
 
-        <button
-          className="skip-button"
-          onClick={onSkip}
-        >
-          I'm not in the list (new player)
-        </button>
+        {onSkip && (
+          <button
+            className="skip-button"
+            onClick={onSkip}
+          >
+            {skipLabel}
+          </button>
+        )}
       </div>
 
       <style jsx>{`

--- a/frontend/src/pages/AccountPage.jsx
+++ b/frontend/src/pages/AccountPage.jsx
@@ -7,6 +7,8 @@ import useTeeTimes from '../hooks/useTeeTimes';
 import PlayerAvailability from '../components/signup/PlayerAvailability';
 import EmailPreferences from '../components/signup/EmailPreferences';
 import MyMatches from '../components/signup/MyMatches';
+import LegacyNameSelector from '../components/auth/LegacyNameSelector';
+import usePlayerProfile from '../hooks/usePlayerProfile';
 
 const STORAGE_KEY = 'wgp_account_settings';
 
@@ -685,6 +687,11 @@ function AccountPage() {
         )}
       </div>
 
+      {/* Club Player Link */}
+      {isAuthenticated && (
+        <ClubPlayerLinkSection cardStyle={cardStyle} sectionTitle={sectionTitle} theme={theme} />
+      )}
+
       {/* My Availability */}
       {isAuthenticated && (
         <div style={cardStyle}>
@@ -761,6 +768,207 @@ function AccountPage() {
         >
           Log Out
         </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Manage the link between this account and a Wing Point tee-sheet ("club")
+ * player. Onboarding covers the very first link via a one-shot modal; this
+ * section lets a user link, change, or unlink at any time afterwards — the
+ * modal alone left no way to revisit that decision.
+ */
+export function ClubPlayerLinkSection({ cardStyle, sectionTitle, theme }) {
+  const { profile, loading, updateLegacyName } = usePlayerProfile();
+  const [mode, setMode] = useState('view'); // 'view' | 'edit'
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [status, setStatus] = useState(null);
+  const [confirmingUnlink, setConfirmingUnlink] = useState(false);
+
+  const linkedName = profile?.legacy_name || null;
+  const suggestion = profile?.legacy_name_suggestion || null;
+
+  const flashStatus = (msg) => {
+    setStatus(msg);
+    setTimeout(() => setStatus(null), 2500);
+  };
+
+  const handleSelect = async (name) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateLegacyName(name);
+      setMode('view');
+      flashStatus(`Linked to ${name}`);
+    } catch (err) {
+      setError(err.message || 'Could not link — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleUnlink = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateLegacyName(null);
+      setConfirmingUnlink(false);
+      flashStatus('Unlinked from the club roster');
+    } catch (err) {
+      setError(err.message || 'Could not unlink — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const primaryButton = {
+    ...theme.buttonStyle,
+    padding: '10px 20px',
+    fontSize: '14px',
+    opacity: busy ? 0.6 : 1,
+  };
+
+  const outlineButton = {
+    ...theme.buttonStyle,
+    padding: '10px 20px',
+    fontSize: '14px',
+    background: 'transparent',
+    color: theme.colors.primary,
+    border: `1px solid ${theme.colors.primary}`,
+    opacity: busy ? 0.6 : 1,
+  };
+
+  const dangerButton = {
+    ...theme.buttonStyle,
+    padding: '10px 20px',
+    fontSize: '14px',
+    background: 'transparent',
+    color: theme.colors.error,
+    border: `1px solid ${theme.colors.error}`,
+    opacity: busy ? 0.6 : 1,
+  };
+
+  return (
+    <div style={cardStyle}>
+      <h3 style={{ ...sectionTitle, marginBottom: '4px' }}>Club Player</h3>
+      <p style={{ fontSize: '14px', color: theme.colors.textSecondary, margin: '0 0 16px 0' }}>
+        Link your account to your name on the Wing Point tee sheet so your signups and
+        round history stay in sync with the club system.
+      </p>
+
+      {status && (
+        <div style={{
+          padding: '10px 16px',
+          background: theme.isDark ? 'rgba(16, 185, 129, 0.15)' : '#ecfdf5',
+          color: theme.colors.success,
+          borderRadius: '8px',
+          fontSize: '14px',
+          fontWeight: 500,
+          marginBottom: '16px',
+        }}>
+          {status}
+        </div>
+      )}
+
+      {error && (
+        <div style={{
+          padding: '10px 16px',
+          background: theme.isDark ? 'rgba(239, 68, 68, 0.15)' : '#fef2f2',
+          color: theme.colors.error,
+          borderRadius: '8px',
+          fontSize: '14px',
+          fontWeight: 500,
+          marginBottom: '16px',
+        }}>
+          {error}
+        </div>
+      )}
+
+      {loading && !profile ? (
+        <div style={{ fontSize: '14px', color: theme.colors.textSecondary }}>Loading…</div>
+      ) : busy ? (
+        <div style={{ fontSize: '14px', color: theme.colors.textSecondary }}>Saving…</div>
+      ) : mode === 'edit' ? (
+        <LegacyNameSelector
+          currentName={profile?.name}
+          suggestedName={suggestion}
+          title={linkedName ? 'Change club player' : 'Link your club player'}
+          description="Pick your name from the Wing Point tee sheet."
+          skipLabel="Cancel"
+          onSelect={handleSelect}
+          onSkip={() => { setMode('view'); setError(null); }}
+        />
+      ) : linkedName ? (
+        <div>
+          <div style={{
+            padding: '10px 16px',
+            background: theme.isDark ? 'rgba(16, 185, 129, 0.15)' : '#ecfdf5',
+            color: theme.colors.success,
+            borderRadius: '8px',
+            fontSize: '14px',
+            fontWeight: 500,
+            marginBottom: '16px',
+          }}>
+            Linked to <strong>{linkedName}</strong>
+          </div>
+
+          {confirmingUnlink ? (
+            <div>
+              <p style={{ fontSize: '14px', color: theme.colors.textSecondary, margin: '0 0 12px 0' }}>
+                Unlink from <strong>{linkedName}</strong>? Your signups will no longer sync
+                with the club tee sheet until you link again.
+              </p>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <button onClick={handleUnlink} disabled={busy} style={dangerButton}>
+                  Yes, unlink
+                </button>
+                <button onClick={() => setConfirmingUnlink(false)} disabled={busy} style={outlineButton}>
+                  Keep linked
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <button
+                onClick={() => { setMode('edit'); setError(null); }}
+                disabled={busy}
+                style={outlineButton}
+              >
+                Change
+              </button>
+              <button
+                onClick={() => { setConfirmingUnlink(true); setError(null); }}
+                disabled={busy}
+                style={dangerButton}
+              >
+                Unlink
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div>
+          <div style={{
+            padding: '10px 16px',
+            background: theme.isDark ? theme.colors.gray200 : '#f9fafb',
+            color: theme.colors.textSecondary,
+            borderRadius: '8px',
+            fontSize: '14px',
+            fontWeight: 500,
+            marginBottom: '16px',
+          }}>
+            Not linked yet.{suggestion ? ` We think you may be ${suggestion}.` : ''}
+          </div>
+          <button
+            onClick={() => { setMode('edit'); setError(null); }}
+            disabled={busy}
+            style={primaryButton}
+          >
+            Link my club player
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/__tests__/ClubPlayerLinkSection.test.jsx
+++ b/frontend/src/pages/__tests__/ClubPlayerLinkSection.test.jsx
@@ -1,0 +1,134 @@
+// Tests for the Account page "Club Player" section, which lets a user link,
+// change, or unlink their Wing Point tee-sheet name any time after onboarding.
+//
+// Mocks only Auth0 and fetch (same pattern as OnboardingWrapper.test.jsx),
+// exercising the real usePlayerProfile hook + LegacyNameSelector underneath.
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ClubPlayerLinkSection } from "../AccountPage";
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: vi.fn(),
+}));
+
+import { useAuth0 as mockUseAuth0 } from "@auth0/auth0-react";
+
+const LEGACY_PLAYERS = ["Alice Adams", "Bob Brown", "Stuart Gano", "Jane Smith"];
+
+const theme = {
+  isDark: false,
+  buttonStyle: {},
+  colors: {
+    primary: "#047857",
+    success: "#10b981",
+    error: "#ef4444",
+    textPrimary: "#111",
+    textSecondary: "#666",
+    gray200: "#e5e7eb",
+    border: "#ddd",
+  },
+};
+
+const okJson = (body) =>
+  Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+
+function installFetch({ legacyName = null, suggestion = null, onPut } = {}) {
+  global.fetch.mockImplementation((url, opts = {}) => {
+    if (url.endsWith("/players/me/legacy-name") && opts.method === "PUT") {
+      const body = JSON.parse(opts.body);
+      if (onPut) onPut(body);
+      return okJson({
+        id: 7,
+        name: "Auth0 Name",
+        legacy_name: body.legacy_name,
+        legacy_name_suggestion: null,
+      });
+    }
+    if (url.endsWith("/players/me")) {
+      return okJson({
+        id: 7,
+        name: "Auth0 Name",
+        legacy_name: legacyName,
+        legacy_name_suggestion: suggestion,
+      });
+    }
+    if (url.endsWith("/legacy-players")) {
+      return okJson({ players: LEGACY_PLAYERS });
+    }
+    return okJson({});
+  });
+}
+
+const renderSection = () =>
+  render(<ClubPlayerLinkSection cardStyle={{}} sectionTitle={{}} theme={theme} />);
+
+beforeEach(() => {
+  mockUseAuth0.mockReturnValue({
+    isAuthenticated: true,
+    getAccessTokenSilently: vi.fn().mockResolvedValue("token-123"),
+  });
+  localStorage.clear();
+});
+
+describe("ClubPlayerLinkSection", () => {
+  test("shows the linked name with Change / Unlink when already linked", async () => {
+    installFetch({ legacyName: "Stuart Gano" });
+    renderSection();
+
+    expect(await screen.findByText("Stuart Gano")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Change/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Unlink$/i })).toBeInTheDocument();
+  });
+
+  test("unlinked state links a chosen name via PUT", async () => {
+    const putBodies = [];
+    installFetch({ legacyName: null, onPut: (b) => putBodies.push(b) });
+    renderSection();
+
+    // Unlinked prompt → open the selector.
+    fireEvent.click(await screen.findByRole("button", { name: /Link my club player/i }));
+
+    const search = await screen.findByPlaceholderText(/Search for your name/i);
+    fireEvent.change(search, { target: { value: "Jane" } });
+    fireEvent.click(await screen.findByText("Jane Smith"));
+    fireEvent.click(screen.getByRole("button", { name: /Confirm: Jane Smith/i }));
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([{ legacy_name: "Jane Smith" }]);
+    });
+    // Returns to the linked view (Change/Unlink controls appear).
+    expect(await screen.findByRole("button", { name: /Change/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Unlink$/i })).toBeInTheDocument();
+  });
+
+  test("unlink asks for confirmation then PUTs a null legacy_name", async () => {
+    const putBodies = [];
+    installFetch({ legacyName: "Stuart Gano", onPut: (b) => putBodies.push(b) });
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /^Unlink$/i }));
+    // Confirmation step.
+    fireEvent.click(await screen.findByRole("button", { name: /Yes, unlink/i }));
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([{ legacy_name: null }]);
+    });
+    expect(await screen.findByText(/Not linked yet/i)).toBeInTheDocument();
+  });
+
+  test("Cancel from the selector returns to the linked view without a PUT", async () => {
+    installFetch({ legacyName: "Stuart Gano" });
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Change/i }));
+    // Selector is open; back out.
+    fireEvent.click(await screen.findByRole("button", { name: /^Cancel$/i }));
+
+    expect(await screen.findByText("Stuart Gano")).toBeInTheDocument();
+    const putCall = global.fetch.mock.calls.find(
+      ([url, opts]) => url.endsWith("/players/me/legacy-name") && opts?.method === "PUT",
+    );
+    expect(putCall).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

Linking an account to a Wing Point tee-sheet ("club") player only happened through the one-shot first-login onboarding modal. Once that modal was dismissed — or skipped with "I'm not in the list" — there was no way to link, change, or unlink afterward (short of clearing `localStorage`). That's the clunkiness: a one-time, irreversible decision with no home in the app.

## What changed

- **New "Club Player" section on the Account page** (`AccountPage.jsx`). It shows the current link state and lets the user:
  - **Link** their club player when unlinked (surfaces the fuzzy suggestion when the backend provides one).
  - **Change** the linked name.
  - **Unlink**, with an inline confirmation before clearing the tee-sheet association.
  - Success/error feedback matches the existing section styling (ForeTees, Account Settings).
- **`LegacyNameSelector` is now reusable** outside onboarding: `title`, `description`, and `skipLabel` are configurable, and the skip/cancel button only renders when an `onSkip` handler is provided. Defaults preserve the exact onboarding copy, so the first-login flow is unchanged.
- Reuses the existing `usePlayerProfile` hook and `PUT /players/me/legacy-name` endpoint (passing `null` to unlink) — no backend changes.

## Tests

- New `ClubPlayerLinkSection.test.jsx` covers the linked/unlinked states and the link, unlink (with confirm), and cancel flows, mocking only Auth0 + fetch (same pattern as the onboarding tests).
- Full frontend gate green locally: `npm run typecheck`, `npx vitest run` (587 passed), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw9VAQ7c2t24hj765mmYoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw9VAQ7c2t24hj765mmYoL)_