### PR TITLE
fix(auth): pin every token request to the API audience so club linking ties into OAuth users

### DIFF
--- a/frontend/src/components/chat/GroupMeChat.jsx
+++ b/frontend/src/components/chat/GroupMeChat.jsx
@@ -6,15 +6,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../config/api.config';
-import { acquireAccessToken } from '../../services/authToken';
+import { acquireAccessToken, apiTokenOptions } from '../../services/authToken';
 import { Message } from './MessageParts';
 
 const API_URL = apiConfig.baseUrl;
 const POLL_MS = 30000;
-const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
-const tokenOptions = AUTH0_AUDIENCE
-  ? { authorizationParams: { audience: AUTH0_AUDIENCE } }
-  : undefined;
 
 const GroupMeChat = () => {
   const { isAuthenticated, getAccessTokenSilently, loginWithRedirect } = useAuth0();
@@ -62,7 +58,7 @@ const GroupMeChat = () => {
     setSending(true);
     setSendError(null);
     try {
-      const token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
+      const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
       const res = await fetch(`${API_URL}/groupme/messages`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },

--- a/frontend/src/components/game/livsow/LivSowTeamPage.jsx
+++ b/frontend/src/components/game/livsow/LivSowTeamPage.jsx
@@ -6,15 +6,10 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../../config/api.config';
-import { acquireAccessToken } from '../../../services/authToken';
+import { acquireAccessToken, apiTokenOptions } from '../../../services/authToken';
 import { teamColor, RoleTag, WeekCell } from './shared';
 import LivSowTransactions from './LivSowTransactions';
 import TeamEditModal from './TeamEditModal';
-
-const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
-const tokenOptions = AUTH0_AUDIENCE
-  ? { authorizationParams: { audience: AUTH0_AUDIENCE } }
-  : undefined;
 
 const ROLE_ORDER = { Captain: 0, Starter: 1, Alternate: 2 };
 
@@ -51,7 +46,7 @@ const LivSowTeamPage = () => {
     let cancelled = false;
     (async () => {
       try {
-        const token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
+        const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
         const res = await fetch(`${apiConfig.baseUrl}/data/livsow/teams/${teamSlug}/can-edit`, {
           headers: { Authorization: `Bearer ${token}` },
         });

--- a/frontend/src/components/game/livsow/TeamEditModal.jsx
+++ b/frontend/src/components/game/livsow/TeamEditModal.jsx
@@ -7,12 +7,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useAuth0 } from '@auth0/auth0-react';
 import { apiConfig } from '../../../config/api.config';
-import { acquireAccessToken } from '../../../services/authToken';
-
-const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
-const tokenOptions = AUTH0_AUDIENCE
-  ? { authorizationParams: { audience: AUTH0_AUDIENCE } }
-  : undefined;
+import { acquireAccessToken, apiTokenOptions } from '../../../services/authToken';
 
 const fieldLabel = { fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 4, display: 'block' };
 const fieldBox = {
@@ -33,7 +28,7 @@ const TeamEditModal = ({ slug, teamName, accent, initial, onClose, onSaved }) =>
     setSaving(true);
     setError(null);
     try {
-      const token = await acquireAccessToken(getAccessTokenSilently, tokenOptions);
+      const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
       const res = await fetch(`${apiConfig.baseUrl}/data/livsow/teams/${slug}/content`, {
         method: 'PUT',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },

--- a/frontend/src/components/signup/DailySignupView.jsx
+++ b/frontend/src/components/signup/DailySignupView.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import '../../styles/mobile-touch.css';
 import { calculateCourseHandicap } from '../../utils';
 import { usePlayerProfile } from '../../hooks/usePlayerProfile';
-import { acquireAccessToken } from '../../services/authToken';
+import { acquireAccessToken, apiTokenOptions } from '../../services/authToken';
 import { api } from '../../api/client';
 import { errorDetail } from '../../api/http';
 
@@ -208,7 +208,7 @@ const DailySignupView = ({ selectedDate: initialDate, onBack }) => {
     }
     try {
       setSigningUp(true);
-      const token = await acquireAccessToken(getAccessTokenSilently);
+      const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
       const { data, error: apiError } = await api.POST('/signups', {
         headers: { Authorization: `Bearer ${token}` },
         body: {

--- a/frontend/src/components/signup/PlayerAvailability.jsx
+++ b/frontend/src/components/signup/PlayerAvailability.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { acquireAccessToken } from '../../services/authToken';
+import { acquireAccessToken, apiTokenOptions } from '../../services/authToken';
 import { api } from '../../api/client';
 import { errorDetail } from '../../api/http';
 
@@ -8,11 +8,7 @@ const dayNamesFull = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'S
 
 const PlayerAvailability = () => {
   const { getAccessTokenSilently, isAuthenticated } = useAuth0();
-  const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
-  const tokenOptions = useMemo(
-    () => (AUTH0_AUDIENCE ? { authorizationParams: { audience: AUTH0_AUDIENCE } } : undefined),
-    [AUTH0_AUDIENCE],
-  );
+  const tokenOptions = apiTokenOptions;
   const [availability, setAvailability] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/frontend/src/components/signup/WgpSignupSheet.jsx
+++ b/frontend/src/components/signup/WgpSignupSheet.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTheme } from '../../theme/Provider';
 import { useAuth0 } from '@auth0/auth0-react';
-import { acquireAccessToken } from '../../services/authToken';
+import { acquireAccessToken, apiTokenOptions } from '../../services/authToken';
 import { api } from '../../api/client';
 import { errorDetail } from '../../api/http';
 import { apiConfig } from '../../config/api.config';
@@ -93,7 +93,7 @@ export default function WgpSignupSheet() {
     if (!isAuthenticated) return;
     (async () => {
       try {
-        const token = await acquireAccessToken(getAccessTokenSilently);
+        const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
         const { data, response } = await api.GET('/players/me', {
           headers: { Authorization: `Bearer ${token}` },
         });

--- a/frontend/src/hooks/useAuthenticatedFetch.js
+++ b/frontend/src/hooks/useAuthenticatedFetch.js
@@ -1,14 +1,14 @@
 import { useCallback } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 
-import { acquireAccessToken } from "../services/authToken";
+import { acquireAccessToken, apiTokenOptions } from "../services/authToken";
 
 export const useAuthenticatedFetch = () => {
   const { getAccessTokenSilently } = useAuth0();
 
   return useCallback(
     async (url, options = {}) => {
-      const token = await acquireAccessToken(getAccessTokenSilently);
+      const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
       return fetch(url, {
         ...options,
         headers: {

--- a/frontend/src/hooks/useMatchmaking.js
+++ b/frontend/src/hooks/useMatchmaking.js
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { acquireAccessToken } from '../services/authToken';
+import { acquireAccessToken, apiTokenOptions } from '../services/authToken';
 import { api } from '../api/client';
 
 // How often to refresh matches in the background. Matchmaking is not
@@ -33,7 +33,7 @@ const useMatchmaking = (playerProfileId) => {
   // Per-request auth header — token acquired via Auth0, with transparent
   // recovery from a missing/expired refresh token (see acquireAccessToken).
   const authHeaders = useCallback(async () => {
-    const token = await acquireAccessToken(getAccessTokenSilently);
+    const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
     return { Authorization: `Bearer ${token}` };
   }, [getAccessTokenSilently]);
 

--- a/frontend/src/hooks/usePlayerProfile.js
+++ b/frontend/src/hooks/usePlayerProfile.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { apiConfig } from "../config/api.config";
-import { acquireAccessToken } from "../services/authToken";
+import { acquireAccessToken, apiTokenOptions } from "../services/authToken";
 
 const API_URL = apiConfig.baseUrl;
 
@@ -26,7 +26,7 @@ export const usePlayerProfile = () => {
 
     try {
       setLoading(true);
-      const token = await acquireAccessToken(getAccessTokenSilently);
+      const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
 
       const response = await fetch(`${API_URL}/players/me`, {
         headers: {
@@ -67,7 +67,7 @@ export const usePlayerProfile = () => {
       }
 
       try {
-        const token = await acquireAccessToken(getAccessTokenSilently);
+        const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
 
         const response = await fetch(`${API_URL}/players/me/legacy-name`, {
           method: "PUT",

--- a/frontend/src/hooks/useTeeTimes.js
+++ b/frontend/src/hooks/useTeeTimes.js
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { acquireAccessToken } from '../services/authToken';
+import { acquireAccessToken, apiTokenOptions } from '../services/authToken';
 import { apiConfig } from '../config/api.config';
 
 const API_URL = apiConfig.baseUrl;
@@ -21,7 +21,7 @@ const useTeeTimes = () => {
   const clearBookingError = useCallback(() => setBookingError(null), []);
 
   const authFetch = useCallback(async (url, options = {}) => {
-    const token = await acquireAccessToken(getAccessTokenSilently);
+    const token = await acquireAccessToken(getAccessTokenSilently, apiTokenOptions);
     const fullUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
     return fetch(fullUrl, {
       ...options,

--- a/frontend/src/services/__tests__/authToken.test.js
+++ b/frontend/src/services/__tests__/authToken.test.js
@@ -1,5 +1,32 @@
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi, afterEach } from "vitest";
 import { acquireAccessToken, isRecoverableAuthError } from "../authToken";
+
+describe("apiTokenOptions", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  // Pins the fix for club-player linking not tying into OAuth users: every token
+  // acquisition must request our backend API audience, not just rely on the
+  // Auth0Provider default (a silent refresh can otherwise mint an /userinfo-only
+  // token the backend rejects). Evaluated at import, so stub the env then re-import.
+  test("requests the API audience when VITE_AUTH0_AUDIENCE is set", async () => {
+    vi.stubEnv("VITE_AUTH0_AUDIENCE", "https://api.example.com");
+    vi.resetModules();
+    const { apiTokenOptions } = await import("../authToken");
+    expect(apiTokenOptions).toEqual({
+      authorizationParams: { audience: "https://api.example.com" },
+    });
+  });
+
+  test("is undefined when no audience is configured", async () => {
+    vi.stubEnv("VITE_AUTH0_AUDIENCE", "");
+    vi.resetModules();
+    const { apiTokenOptions } = await import("../authToken");
+    expect(apiTokenOptions).toBeUndefined();
+  });
+});
 
 describe("isRecoverableAuthError", () => {
   test("returns false for nullish input", () => {

--- a/frontend/src/services/authToken.js
+++ b/frontend/src/services/authToken.js
@@ -13,6 +13,22 @@
  * the provider). If that still fails the caller can prompt a full re-login.
  */
 
+/**
+ * Token options that pin every acquisition to our backend API audience.
+ *
+ * The backend verifies the JWT with `audience=AUTH0_API_AUDIENCE` and rejects
+ * anything else. Relying on the `Auth0Provider` default audience is not enough:
+ * once `offline_access`/`useRefreshTokens` is on, a silent refresh can mint a
+ * token for the default OIDC (`/userinfo`) audience instead of our API. The
+ * backend then rejects it as an invalid token (401), which silently breaks
+ * `/players/me` and the club-player → OAuth link. Passing the audience on every
+ * call keeps each request pinned to the API regardless of how the token is
+ * minted. `undefined` when unset so tests and audience-less setups are unchanged.
+ */
+export const apiTokenOptions = import.meta.env.VITE_AUTH0_AUDIENCE
+  ? { authorizationParams: { audience: import.meta.env.VITE_AUTH0_AUDIENCE } }
+  : undefined;
+
 // Auth0 error codes that mean "the cached credential is gone/stale — get a fresh
 // one" rather than a genuine failure we should surface as-is.
 const RECOVERABLE_AUTH_ERROR_CODES = new Set([


### PR DESCRIPTION
## Problem

Linking a club (legacy tee-sheet) player profile wasn't tying into OAuth users — the link would silently fail, surfacing as an Auth0/OIDC token error in the client.

**Root cause (client-side):** The Auth0 API `audience` was requested *inconsistently*. The club-linking path — `usePlayerProfile` (`GET /players/me` and `PUT /players/me/legacy-name`) plus the signup calls — acquired tokens **without** `authorizationParams.audience`, relying on the `Auth0Provider` default. The backend verifies the JWT with `audience=AUTH0_API_AUDIENCE` and rejects anything else.

Once `offline_access` / `useRefreshTokens` is enabled, a **silent refresh can mint a token for the default OIDC (`/userinfo`) audience** instead of our API. The backend then rejects that token as invalid (`aud` mismatch → 401), so `/players/me` and the legacy-name write fail and the club player never links to the OAuth account.

The LivSow / chat / availability features already passed the audience explicitly and kept working — which is exactly why linking looked broken while other authenticated features didn't.

## Fix

- Add a single shared `apiTokenOptions` in `services/authToken.js` that pins the API audience (`VITE_AUTH0_AUDIENCE`), or `undefined` when unset so audience-less/dev setups are unchanged.
- Thread it through **every** authenticated token acquisition — most importantly the club-linking path (`usePlayerProfile`) and the signup flows — so no request depends on how the token happened to be minted.
- Replace the four duplicated per-component `tokenOptions` definitions (`GroupMeChat`, `LivSowTeamPage`, `TeamEditModal`, `PlayerAvailability`) with the shared constant so there's one source of truth.

## Testing

- `apiTokenOptions` shape pinned with new tests (audience set → options; unset → `undefined`).
- Full frontend gate green: `npm run typecheck` ✓, `npx vitest run` (646 tests) ✓, `npm run build` ✓.

No backend changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkiMiLYE5Yayvff31yV3FH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication consistency across chat, signup, matchmaking, profile, scheduling, and team-management workflows.
  * Authenticated requests now reliably target the configured backend API, reducing potential authorization issues.
  * Behavior remains unchanged when no API audience is configured.

* **Tests**
  * Added coverage to verify authentication settings are applied correctly in configured and unconfigured environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->